### PR TITLE
Implement /open, /new, and /clone lifecycle commands

### DIFF
--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -1,5 +1,7 @@
 using Spectre.Console;
+using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 
 var commands = new List<CommandSpec>
 {
@@ -51,6 +53,7 @@ var commands = new List<CommandSpec>
 };
 
 var streamLog = new List<string>();
+var session = new SessionState();
 SeedBootLog(streamLog);
 RenderInitialLog(streamLog);
 
@@ -103,6 +106,11 @@ while (true)
     }
 
     AppendLog(streamLog, $"[bold deepskyblue1]unifocl[/] [grey]>[/] [white]{Markup.Escape(input)}[/]");
+    if (TryHandleLifecycleCommand(input, matched, session, streamLog))
+    {
+        continue;
+    }
+
     AppendLog(streamLog, $"[deepskyblue1]stub[/]: {Markup.Escape(matched.Signature)}");
     WriteMockCommandStream(input, streamLog);
 }
@@ -303,4 +311,462 @@ static void AppendLog(List<string> streamLog, string line)
     AnsiConsole.MarkupLine(line);
 }
 
+static bool TryHandleLifecycleCommand(string input, CommandSpec matched, SessionState session, List<string> streamLog)
+{
+    return matched.Trigger switch
+    {
+        "/open" => HandleOpen(input, matched, session, streamLog),
+        "/new" => HandleNew(input, matched, session, streamLog),
+        "/clone" => HandleClone(input, matched, session, streamLog),
+        _ => false
+    };
+}
+
+static bool HandleOpen(string input, CommandSpec matched, SessionState session, List<string> streamLog)
+{
+    var args = ParseCommandArgs(input, matched.Trigger);
+    if (args.Count < 1)
+    {
+        AppendLog(streamLog, "[red]error[/]: usage /open <path>");
+        return true;
+    }
+
+    var projectPath = ResolveAbsolutePath(args[0], Directory.GetCurrentDirectory());
+    TryOpenProject(projectPath, session, streamLog);
+    return true;
+}
+
+static bool HandleNew(string input, CommandSpec matched, SessionState session, List<string> streamLog)
+{
+    var args = ParseCommandArgs(input, matched.Trigger);
+    if (args.Count < 1)
+    {
+        AppendLog(streamLog, "[red]error[/]: usage /new <project-name> [unity-version]");
+        return true;
+    }
+
+    var projectName = args[0].Trim();
+    var unityVersion = args.Count > 1 ? args[1].Trim() : "6000.0.0f1";
+    if (string.IsNullOrWhiteSpace(projectName))
+    {
+        AppendLog(streamLog, "[red]error[/]: project name cannot be empty");
+        return true;
+    }
+
+    var projectPath = ResolveAbsolutePath(projectName, Directory.GetCurrentDirectory());
+    AppendLog(streamLog, $"[grey]new[/]: step 1/5 create project directory -> [white]{Markup.Escape(projectPath)}[/]");
+
+    if (Directory.Exists(projectPath) && Directory.EnumerateFileSystemEntries(projectPath).Any())
+    {
+        AppendLog(streamLog, "[red]error[/]: target directory already exists and is not empty");
+        return true;
+    }
+
+    try
+    {
+        Directory.CreateDirectory(projectPath);
+        Directory.CreateDirectory(Path.Combine(projectPath, "Assets"));
+        Directory.CreateDirectory(Path.Combine(projectPath, "Packages"));
+        Directory.CreateDirectory(Path.Combine(projectPath, "ProjectSettings"));
+    }
+    catch (Exception ex)
+    {
+        AppendLog(streamLog, $"[red]error[/]: failed to create Unity folder structure ({Markup.Escape(ex.Message)})");
+        return true;
+    }
+
+    AppendLog(streamLog, "[grey]new[/]: step 2/5 write Unity package manifest");
+    var manifestResult = WriteDefaultUnityManifest(projectPath);
+    if (!manifestResult.Ok)
+    {
+        AppendLog(streamLog, $"[red]error[/]: {Markup.Escape(manifestResult.Error)}");
+        return true;
+    }
+
+    AppendLog(streamLog, $"[grey]new[/]: step 3/5 set Unity editor version [white]{Markup.Escape(unityVersion)}[/]");
+    var versionResult = WriteProjectVersion(projectPath, unityVersion);
+    if (!versionResult.Ok)
+    {
+        AppendLog(streamLog, $"[red]error[/]: {Markup.Escape(versionResult.Error)}");
+        return true;
+    }
+
+    AppendLog(streamLog, "[grey]new[/]: step 4/5 generate local templates and bridge config");
+    var configResult = EnsureProjectLocalConfig(projectPath);
+    if (!configResult.Ok)
+    {
+        AppendLog(streamLog, $"[red]error[/]: {Markup.Escape(configResult.Error)}");
+        return true;
+    }
+
+    AppendLog(streamLog, "[grey]new[/]: step 5/5 open bootstrapped project");
+    if (TryOpenProject(projectPath, session, streamLog))
+    {
+        AppendLog(streamLog, "[green]new[/]: Unity project scaffold ready");
+    }
+    else
+    {
+        AppendLog(streamLog, "[yellow]new[/]: project scaffolded, but auto-open failed");
+    }
+    return true;
+}
+
+static bool HandleClone(string input, CommandSpec matched, SessionState session, List<string> streamLog)
+{
+    var args = ParseCommandArgs(input, matched.Trigger);
+    if (args.Count < 1)
+    {
+        AppendLog(streamLog, "[red]error[/]: usage /clone <git-url>");
+        return true;
+    }
+
+    var gitUrl = args[0].Trim();
+    if (string.IsNullOrWhiteSpace(gitUrl))
+    {
+        AppendLog(streamLog, "[red]error[/]: git url cannot be empty");
+        return true;
+    }
+
+    AppendLog(streamLog, "[grey]clone[/]: step 1/4 validate git binary");
+    var gitVersion = RunProcess("git", "--version", Directory.GetCurrentDirectory());
+    if (gitVersion.ExitCode != 0)
+    {
+        AppendLog(streamLog, "[red]error[/]: git is not available on PATH");
+        return true;
+    }
+
+    var targetFolderName = GuessRepoFolderName(gitUrl);
+    var targetPath = Path.Combine(Directory.GetCurrentDirectory(), targetFolderName);
+    AppendLog(streamLog, $"[grey]clone[/]: step 2/4 clone [white]{Markup.Escape(gitUrl)}[/] -> [white]{Markup.Escape(targetPath)}[/]");
+
+    if (Directory.Exists(targetPath))
+    {
+        AppendLog(streamLog, "[red]error[/]: clone target already exists");
+        return true;
+    }
+
+    var cloneResult = RunProcess("git", $"clone \"{gitUrl}\" \"{targetPath}\"", Directory.GetCurrentDirectory());
+    if (cloneResult.ExitCode != 0)
+    {
+        AppendLog(streamLog, $"[red]error[/]: git clone failed ({Markup.Escape(SummarizeProcessError(cloneResult))})");
+        return true;
+    }
+
+    AppendLog(streamLog, "[grey]clone[/]: step 3/4 write local templates and bridge config");
+    var configResult = EnsureProjectLocalConfig(targetPath);
+    if (!configResult.Ok)
+    {
+        AppendLog(streamLog, $"[red]error[/]: {Markup.Escape(configResult.Error)}");
+        return true;
+    }
+
+    AppendLog(streamLog, "[grey]clone[/]: step 4/4 open cloned project");
+    if (TryOpenProject(targetPath, session, streamLog))
+    {
+        AppendLog(streamLog, "[green]clone[/]: repository cloned and prepared");
+    }
+    else
+    {
+        AppendLog(streamLog, "[yellow]clone[/]: repository cloned; open skipped (not a Unity project yet)");
+    }
+    return true;
+}
+
+static bool TryOpenProject(string projectPath, SessionState session, List<string> streamLog)
+{
+    AppendLog(streamLog, $"[grey]open[/]: step 1/4 resolve project path -> [white]{Markup.Escape(projectPath)}[/]");
+
+    if (!Directory.Exists(projectPath))
+    {
+        AppendLog(streamLog, "[red]error[/]: project directory does not exist");
+        return false;
+    }
+
+    if (!LooksLikeUnityProject(projectPath))
+    {
+        AppendLog(streamLog, "[red]error[/]: path is not a Unity project (missing Assets/ or ProjectSettings/)");
+        return false;
+    }
+
+    AppendLog(streamLog, "[grey]open[/]: step 2/4 validate Unity project layout");
+    var bridgeResult = EnsureProjectLocalConfig(projectPath);
+    if (!bridgeResult.Ok)
+    {
+        AppendLog(streamLog, $"[red]error[/]: {Markup.Escape(bridgeResult.Error)}");
+        return false;
+    }
+
+    AppendLog(streamLog, "[grey]open[/]: step 3/4 attach or start daemon session");
+    var daemonSession = EnsureDaemonSession(projectPath);
+    var daemonVerb = daemonSession.Created ? "started" : "attached";
+    AppendLog(streamLog, $"[grey]daemon[/]: {daemonVerb} project daemon on [white]127.0.0.1:{daemonSession.Port}[/]");
+
+    session.CurrentProjectPath = projectPath;
+    session.LastOpenedUtc = DateTimeOffset.UtcNow;
+    AppendLog(streamLog, "[grey]open[/]: step 4/4 load project context");
+    AppendLog(streamLog, $"[green]open[/]: attached [white]{Markup.Escape(Path.GetFileName(projectPath))}[/]");
+    return true;
+}
+
+static List<string> ParseCommandArgs(string input, string trigger)
+{
+    var raw = input.Length > trigger.Length ? input[trigger.Length..].Trim() : string.Empty;
+    if (string.IsNullOrWhiteSpace(raw))
+    {
+        return new List<string>();
+    }
+
+    var tokens = new List<string>();
+    var current = new StringBuilder();
+    var inQuotes = false;
+
+    for (var i = 0; i < raw.Length; i++)
+    {
+        var c = raw[i];
+
+        if (c == '\\' && i + 1 < raw.Length && raw[i + 1] == '"')
+        {
+            current.Append('"');
+            i++;
+            continue;
+        }
+
+        if (c == '"')
+        {
+            inQuotes = !inQuotes;
+            continue;
+        }
+
+        if (!inQuotes && char.IsWhiteSpace(c))
+        {
+            if (current.Length > 0)
+            {
+                tokens.Add(current.ToString());
+                current.Clear();
+            }
+
+            continue;
+        }
+
+        current.Append(c);
+    }
+
+    if (current.Length > 0)
+    {
+        tokens.Add(current.ToString());
+    }
+
+    return tokens;
+}
+
+static string ResolveAbsolutePath(string path, string baseDirectory)
+{
+    if (string.IsNullOrWhiteSpace(path))
+    {
+        return baseDirectory;
+    }
+
+    if (path.StartsWith("~"))
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var suffix = path[1..].TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return Path.GetFullPath(Path.Combine(home, suffix));
+    }
+
+    return Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(baseDirectory, path));
+}
+
+static bool LooksLikeUnityProject(string projectPath)
+{
+    return Directory.Exists(Path.Combine(projectPath, "Assets"))
+           && Directory.Exists(Path.Combine(projectPath, "ProjectSettings"));
+}
+
+static OperationResult EnsureProjectLocalConfig(string projectPath)
+{
+    try
+    {
+        var templatesPath = Path.Combine(projectPath, "templates.json");
+        if (!File.Exists(templatesPath))
+        {
+            var templates = JsonSerializer.Serialize(new
+            {
+                templates = new Dictionary<string, string>
+                {
+                    ["script"] = "Assets/Scripts/NewScript.cs",
+                    ["shader"] = "Assets/Shaders/NewShader.shader",
+                    ["material"] = "Assets/Materials/NewMaterial.mat"
+                }
+            }, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(templatesPath, templates + Environment.NewLine);
+        }
+
+        var bridgeDir = Path.Combine(projectPath, ".unifocl");
+        Directory.CreateDirectory(bridgeDir);
+
+        var bridgePath = Path.Combine(bridgeDir, "bridge.json");
+        if (!File.Exists(bridgePath))
+        {
+            var bridge = JsonSerializer.Serialize(new
+            {
+                projectPath,
+                daemon = new { host = "127.0.0.1", port = 18080 },
+                protocol = "v1",
+                updatedAtUtc = DateTimeOffset.UtcNow
+            }, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(bridgePath, bridge + Environment.NewLine);
+        }
+
+        return OperationResult.Success();
+    }
+    catch (Exception ex)
+    {
+        return OperationResult.Fail($"failed to write local config ({ex.Message})");
+    }
+}
+
+static OperationResult WriteDefaultUnityManifest(string projectPath)
+{
+    try
+    {
+        var manifestPath = Path.Combine(projectPath, "Packages", "manifest.json");
+        if (!File.Exists(manifestPath))
+        {
+            var manifest = JsonSerializer.Serialize(new
+            {
+                dependencies = new Dictionary<string, string>
+                {
+                    ["com.unity.collab-proxy"] = "2.7.2",
+                    ["com.unity.ide.rider"] = "3.0.35",
+                    ["com.unity.ide.visualstudio"] = "2.0.24",
+                    ["com.unity.test-framework"] = "1.4.5",
+                    ["com.unity.timeline"] = "1.8.9",
+                    ["com.unity.ugui"] = "1.0.0"
+                }
+            }, new JsonSerializerOptions { WriteIndented = true });
+
+            File.WriteAllText(manifestPath, manifest + Environment.NewLine);
+        }
+
+        return OperationResult.Success();
+    }
+    catch (Exception ex)
+    {
+        return OperationResult.Fail($"failed to write Packages/manifest.json ({ex.Message})");
+    }
+}
+
+static OperationResult WriteProjectVersion(string projectPath, string unityVersion)
+{
+    try
+    {
+        var projectVersionPath = Path.Combine(projectPath, "ProjectSettings", "ProjectVersion.txt");
+        var content = $"m_EditorVersion: {unityVersion}{Environment.NewLine}m_EditorVersionWithRevision: {unityVersion} (placeholder){Environment.NewLine}";
+        File.WriteAllText(projectVersionPath, content);
+        return OperationResult.Success();
+    }
+    catch (Exception ex)
+    {
+        return OperationResult.Fail($"failed to write ProjectVersion.txt ({ex.Message})");
+    }
+}
+
+static DaemonSessionInfo EnsureDaemonSession(string projectPath)
+{
+    var daemonDir = Path.Combine(projectPath, ".unifocl");
+    Directory.CreateDirectory(daemonDir);
+    var daemonPath = Path.Combine(daemonDir, "daemon.session.json");
+
+    try
+    {
+        if (File.Exists(daemonPath))
+        {
+            var existing = JsonSerializer.Deserialize<DaemonSessionInfo>(File.ReadAllText(daemonPath));
+            if (existing is not null && existing.Port > 0)
+            {
+                return existing with { Created = false };
+            }
+        }
+    }
+    catch
+    {
+        // If file is corrupt we overwrite it below.
+    }
+
+    var port = 18080 + Math.Abs(projectPath.GetHashCode()) % 2000;
+    var session = new DaemonSessionInfo(port, DateTimeOffset.UtcNow, true);
+    File.WriteAllText(daemonPath, JsonSerializer.Serialize(session, new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine);
+    return session;
+}
+
+static ProcessResult RunProcess(string fileName, string arguments, string workingDirectory)
+{
+    try
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(startInfo);
+        if (process is null)
+        {
+            return new ProcessResult(-1, string.Empty, "failed to start process");
+        }
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return new ProcessResult(process.ExitCode, stdout, stderr);
+    }
+    catch (Exception ex)
+    {
+        return new ProcessResult(-1, string.Empty, ex.Message);
+    }
+}
+
+static string GuessRepoFolderName(string gitUrl)
+{
+    var trimmed = gitUrl.TrimEnd('/');
+    var lastSegment = trimmed[(trimmed.LastIndexOf('/') + 1)..];
+    if (lastSegment.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+    {
+        lastSegment = lastSegment[..^4];
+    }
+
+    return string.IsNullOrWhiteSpace(lastSegment) ? "cloned-project" : lastSegment;
+}
+
+static string SummarizeProcessError(ProcessResult result)
+{
+    var text = string.IsNullOrWhiteSpace(result.Stderr) ? result.Stdout : result.Stderr;
+    if (string.IsNullOrWhiteSpace(text))
+    {
+        return $"exit code {result.ExitCode}";
+    }
+
+    var firstLine = text.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
+    return firstLine is null ? $"exit code {result.ExitCode}" : firstLine;
+}
+
 internal sealed record CommandSpec(string Signature, string Description, string Trigger);
+internal sealed record SessionState
+{
+    public string? CurrentProjectPath { get; set; }
+    public DateTimeOffset? LastOpenedUtc { get; set; }
+}
+
+internal sealed record OperationResult(bool Ok, string Error)
+{
+    public static OperationResult Success() => new(true, string.Empty);
+    public static OperationResult Fail(string error) => new(false, error);
+}
+
+internal sealed record DaemonSessionInfo(int Port, DateTimeOffset StartedAtUtc, bool Created);
+internal sealed record ProcessResult(int ExitCode, string Stdout, string Stderr);


### PR DESCRIPTION
## Summary
- Implemented real command handlers for `/open <path>`, `/new <project-name> [unity-version]`, and `/clone <git-url>` in the CLI runtime instead of stub stream output.
- Added actionable step-by-step execution in each command to keep large lifecycle flows decomposed and observable (path resolution/validation, config generation, daemon session attach/start, project context load).
- Added shared lifecycle utilities for argument parsing, Unity project detection, local config bootstrapping, lightweight daemon session persistence, process execution (`git`), and clone target inference.
- Fixed clone behavior so success messaging reflects whether auto-open actually succeeded (non-Unity repos now report cloned-but-not-opened).

- Why is this change needed?
- These commands were listed as core project/session lifecycle features but were non-functional stubs.
- Implementing them unblocks real project creation/open/clone workflows and establishes reusable lifecycle primitives for later daemon/bridge integration.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
- `src/unifocl/Program.cs`
- Project lifecycle command execution path (`/open`, `/new`, `/clone`)
- Out-of-scope / intentionally not addressed:
- Real Unity Hub CLI invocation for project generation (current implementation scaffolds folder structure directly).
- Real daemon process management and health checks (current implementation persists a local session descriptor per project).
- Additional lifecycle commands (`/recent`, `/switch`, `/close`, etc.) which remain stubbed.

## How to Test
1. Build the solution: `dotnet build unifocl.sln`
2. Smoke-test project creation and open:
   - `printf '/new SampleGame 2022.3.20f1\n/exit\n' | dotnet run --project src/unifocl/unifocl.csproj`
   - `printf '/open SampleGame\n/exit\n' | dotnet run --project src/unifocl/unifocl.csproj`
3. Smoke-test clone behavior:
   - `printf '/clone <git-url>\n/exit\n' | dotnet run --project src/unifocl/unifocl.csproj`

Expected results:
- `/new` creates Unity skeleton folders/files (`Assets`, `Packages/manifest.json`, `ProjectSettings/ProjectVersion.txt`) plus local `templates.json` and `.unifocl/bridge.json`, then attaches project context.
- `/open` validates Unity project structure, ensures local config, and reuses/creates `.unifocl/daemon.session.json`.
- `/clone` clones repo, writes local config, and either opens Unity projects or reports cloned-but-not-opened for non-Unity repos.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->
- Local smoke tests were run for `/new`, `/open`, and `/clone` with expected step logs and error handling.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Changes are local CLI runtime behavior and file generation under the target project directory.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
