### PR TITLE
Implement daemon memory-aware routing and file-bypass command path

### DIFF
--- a/src/unifocl/Models/CommandModels.cs
+++ b/src/unifocl/Models/CommandModels.cs
@@ -1,6 +1,6 @@
 internal sealed record CommandSpec(string Signature, string Description, string Trigger);
-internal sealed record DaemonStartOptions(int Port, string? UnityPath, bool Headless);
-internal sealed record DaemonServiceOptions(int Port, string? UnityPath, bool Headless);
+internal sealed record DaemonStartOptions(int Port, string? UnityPath, string? ProjectPath, bool Headless);
+internal sealed record DaemonServiceOptions(int Port, string? UnityPath, string? ProjectPath, bool Headless, int InactivityTimeoutSeconds);
 internal sealed record DaemonInstance(
     int Port,
     int Pid,

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -29,7 +29,7 @@ var commands = new List<CommandSpec>
     new("/logs [daemon|unity] [-f]", "Tail or follow daemon/unity logs", "/logs"),
 
     // Daemon control
-    new("/daemon start [--port 8080] [--unity <path>] [--headless]", "Start always-warm daemon", "/daemon start"),
+    new("/daemon start [--port 8080] [--unity <path>] [--project <path>] [--headless]", "Start always-warm daemon", "/daemon start"),
     new("/daemon stop", "Stop daemon", "/daemon stop"),
     new("/daemon restart", "Restart daemon", "/daemon restart"),
     new("/daemon ps", "Show instances, ports, uptime, project", "/daemon ps"),
@@ -70,6 +70,7 @@ var daemonRuntime = new DaemonRuntime(runtimePath);
 var session = new CliSessionState();
 var daemonControlService = new DaemonControlService();
 var projectLifecycleService = new ProjectLifecycleService();
+var projectCommandRouterService = new ProjectCommandRouterService();
 SeedBootLog(streamLog);
 RenderInitialLog(streamLog);
 
@@ -90,7 +91,16 @@ while (true)
 
     if (!input.StartsWith('/'))
     {
-        AppendLog(streamLog, "[grey]system[/]: boot mode is slash-first; type / to see available commands");
+        var handledProjectCommand = await projectCommandRouterService.TryHandleProjectCommandAsync(
+            input,
+            session,
+            daemonControlService,
+            daemonRuntime,
+            line => AppendLog(streamLog, line));
+        if (!handledProjectCommand)
+        {
+            AppendLog(streamLog, "[grey]system[/]: unknown project command; use / for command palette");
+        }
         continue;
     }
 
@@ -133,10 +143,12 @@ while (true)
             streamLog);
         continue;
     }
-    if (projectLifecycleService.TryHandleLifecycleCommand(
+    if (await projectLifecycleService.TryHandleLifecycleCommandAsync(
             input,
             matched,
             session,
+            daemonControlService,
+            daemonRuntime,
             line => AppendLog(streamLog, line)))
     {
         continue;

--- a/src/unifocl/Services/DaemonControlService.cs
+++ b/src/unifocl/Services/DaemonControlService.cs
@@ -7,6 +7,8 @@ using System.Text;
 
 internal sealed class DaemonControlService
 {
+    private const int DefaultInactivityTimeoutSeconds = 600;
+
     public async Task HandleDaemonCommandAsync(
         string input,
         string trigger,
@@ -53,7 +55,9 @@ internal sealed class DaemonControlService
 
         var port = 8080;
         string? unityPath = null;
+        string? projectPath = null;
         var headless = false;
+        var ttlSeconds = DefaultInactivityTimeoutSeconds;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -78,13 +82,32 @@ internal sealed class DaemonControlService
                     unityPath = args[i + 1];
                     i++;
                     break;
+                case "--project":
+                    if (i + 1 >= args.Length)
+                    {
+                        error = "Missing --project value for daemon service.";
+                        return true;
+                    }
+
+                    projectPath = args[i + 1];
+                    i++;
+                    break;
+                case "--ttl-seconds":
+                    if (i + 1 >= args.Length || !int.TryParse(args[i + 1], out ttlSeconds) || ttlSeconds < 1)
+                    {
+                        error = "Invalid --ttl-seconds value for daemon service.";
+                        return true;
+                    }
+
+                    i++;
+                    break;
                 case "--headless":
                     headless = true;
                     break;
             }
         }
 
-        options = new DaemonServiceOptions(port, unityPath, headless);
+        options = new DaemonServiceOptions(port, unityPath, projectPath, headless, ttlSeconds);
         return true;
     }
 
@@ -94,16 +117,24 @@ internal sealed class DaemonControlService
         var runtime = new DaemonRuntime(runtimePath);
         var pid = Environment.ProcessId;
         var startedAtUtc = DateTime.UtcNow;
-        var state = new DaemonInstance(options.Port, pid, startedAtUtc, options.UnityPath, options.Headless, null, DateTime.UtcNow);
+        var state = new DaemonInstance(options.Port, pid, startedAtUtc, options.UnityPath, options.Headless, options.ProjectPath, DateTime.UtcNow);
 
         runtime.Upsert(state);
         using var cts = new CancellationTokenSource();
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+        var lastActivityUtc = DateTime.UtcNow;
+
         var heartbeatTask = Task.Run(async () =>
         {
             while (await timer.WaitForNextTickAsync(cts.Token))
             {
                 runtime.Upsert(state with { LastHeartbeatUtc = DateTime.UtcNow });
+
+                if (DateTime.UtcNow - lastActivityUtc >= TimeSpan.FromSeconds(options.InactivityTimeoutSeconds))
+                {
+                    cts.Cancel();
+                    break;
+                }
             }
         }, cts.Token);
 
@@ -129,11 +160,16 @@ internal sealed class DaemonControlService
                         case "PING":
                             await writer.WriteLineAsync("PONG");
                             break;
+                        case "TOUCH":
+                            lastActivityUtc = DateTime.UtcNow;
+                            await writer.WriteLineAsync("OK");
+                            break;
                         case "STOP":
                             await writer.WriteLineAsync("STOPPING");
                             cts.Cancel();
                             break;
                         default:
+                            lastActivityUtc = DateTime.UtcNow;
                             await writer.WriteLineAsync("ERR");
                             break;
                     }
@@ -164,6 +200,77 @@ internal sealed class DaemonControlService
         }
     }
 
+    public async Task<bool> EnsureProjectDaemonAsync(
+        string projectPath,
+        DaemonRuntime runtime,
+        CliSessionState session,
+        Action<string> log)
+    {
+        var port = ComputeProjectDaemonPort(projectPath);
+        var existing = runtime.GetByPort(port);
+
+        if (existing is not null && await TrySendControlAsync(port, "PING", "PONG"))
+        {
+            session.AttachedPort = port;
+            await TrySendControlAsync(port, "TOUCH", "OK");
+            return true;
+        }
+
+        if (existing is not null)
+        {
+            runtime.Remove(port);
+        }
+
+        var startOptions = new DaemonStartOptions(
+            port,
+            ResolveDefaultUnityPath(),
+            projectPath,
+            Headless: true);
+
+        var started = await StartDaemonAsync(startOptions, runtime, log);
+        if (!started)
+        {
+            return false;
+        }
+
+        session.AttachedPort = port;
+        await TrySendControlAsync(port, "TOUCH", "OK");
+        return true;
+    }
+
+    public async Task<bool> TouchAttachedDaemonAsync(CliSessionState session)
+    {
+        if (session.AttachedPort is null)
+        {
+            return false;
+        }
+
+        return await TrySendControlAsync(session.AttachedPort.Value, "TOUCH", "OK");
+    }
+
+    public static bool IsUnityClientActiveForProject(string projectPath)
+    {
+        var lockFile = Path.Combine(projectPath, "Temp", "UnityLockfile");
+        if (!File.Exists(lockFile))
+        {
+            return false;
+        }
+
+        try
+        {
+            return Process.GetProcessesByName("Unity").Any() || Process.GetProcessesByName("Unity Editor").Any();
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    public static int ComputeProjectDaemonPort(string projectPath)
+    {
+        return 18080 + Math.Abs(projectPath.GetHashCode()) % 2000;
+    }
+
     private async Task HandleDaemonStartAsync(string input, DaemonRuntime runtime, Action<string> log)
     {
         if (!TryParseDaemonStartArgs(input, out var startOptions, out var parseError))
@@ -172,11 +279,16 @@ internal sealed class DaemonControlService
             return;
         }
 
+        await StartDaemonAsync(startOptions, runtime, log);
+    }
+
+    private async Task<bool> StartDaemonAsync(DaemonStartOptions startOptions, DaemonRuntime runtime, Action<string> log)
+    {
         var existing = runtime.GetByPort(startOptions.Port);
         if (existing is not null && ProcessUtil.IsAlive(existing.Pid) && await TrySendControlAsync(existing.Port, "PING", "PONG"))
         {
             log($"[yellow]daemon[/]: port {startOptions.Port} already has a running daemon (pid {existing.Pid})");
-            return;
+            return true;
         }
 
         if (existing is not null)
@@ -189,17 +301,18 @@ internal sealed class DaemonControlService
         if (process is null)
         {
             log("[red]daemon[/]: failed to start daemon process");
-            return;
+            return false;
         }
 
-        var ready = await WaitForDaemonReadyAsync(startOptions.Port, TimeSpan.FromSeconds(6));
+        var ready = await WaitForDaemonReadyAsync(startOptions.Port, TimeSpan.FromSeconds(25));
         if (!ready)
         {
             log($"[red]daemon[/]: process launched (pid {process.Id}) but not responding on port {startOptions.Port}");
-            return;
+            return false;
         }
 
         log($"[green]daemon[/]: started [white]pid={process.Id}[/] [white]port={startOptions.Port}[/] [white]headless={startOptions.Headless}[/]");
+        return true;
     }
 
     private async Task HandleDaemonStopAsync(DaemonRuntime runtime, CliSessionState session, Action<string> log)
@@ -239,6 +352,7 @@ internal sealed class DaemonControlService
         var restartPort = target?.Port ?? 8080;
         var restartHeadless = target?.Headless ?? false;
         var restartUnity = target?.UnityPath;
+        var restartProject = target?.ProjectPath;
 
         if (target is not null)
         {
@@ -258,6 +372,7 @@ internal sealed class DaemonControlService
 
         var synthesized = $"/daemon start --port {restartPort}" +
                           (restartUnity is null ? string.Empty : $" --unity \"{restartUnity}\"") +
+                          (restartProject is null ? string.Empty : $" --project \"{restartProject}\"") +
                           (restartHeadless ? " --headless" : string.Empty);
         await HandleDaemonStartAsync(synthesized, runtime, log);
     }
@@ -359,7 +474,7 @@ internal sealed class DaemonControlService
     private static bool TryParseDaemonStartArgs(string input, out DaemonStartOptions options, out string error)
     {
         var tokens = TokenizeArgs(input);
-        options = new DaemonStartOptions(8080, null, false);
+        options = new DaemonStartOptions(8080, null, null, false);
         error = string.Empty;
 
         for (var i = 2; i < tokens.Count; i++)
@@ -387,6 +502,16 @@ internal sealed class DaemonControlService
                     options = options with { UnityPath = tokens[i + 1] };
                     i++;
                     break;
+                case "--project":
+                    if (i + 1 >= tokens.Count)
+                    {
+                        error = "missing value for --project";
+                        return false;
+                    }
+
+                    options = options with { ProjectPath = tokens[i + 1] };
+                    i++;
+                    break;
                 case "--headless":
                     options = options with { Headless = true };
                     break;
@@ -401,6 +526,36 @@ internal sealed class DaemonControlService
 
     private static ProcessStartInfo ResolveDaemonLaunch(DaemonStartOptions options)
     {
+        if (options.Headless && !string.IsNullOrWhiteSpace(options.UnityPath) && !string.IsNullOrWhiteSpace(options.ProjectPath))
+        {
+            var unityPsi = new ProcessStartInfo(options.UnityPath)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = false,
+                RedirectStandardError = false,
+                CreateNoWindow = true
+            };
+
+            unityPsi.ArgumentList.Add("-projectPath");
+            unityPsi.ArgumentList.Add(options.ProjectPath);
+            unityPsi.ArgumentList.Add("-batchmode");
+            unityPsi.ArgumentList.Add("-nographics");
+            unityPsi.ArgumentList.Add("-noUpm");
+            unityPsi.ArgumentList.Add("-vcsMode");
+            unityPsi.ArgumentList.Add("None");
+            unityPsi.ArgumentList.Add("-executeMethod");
+            unityPsi.ArgumentList.Add("CLIDaemon.StartServer");
+            unityPsi.ArgumentList.Add("--daemon-service");
+            unityPsi.ArgumentList.Add("--port");
+            unityPsi.ArgumentList.Add(options.Port.ToString());
+            unityPsi.ArgumentList.Add("--project");
+            unityPsi.ArgumentList.Add(options.ProjectPath);
+            unityPsi.ArgumentList.Add("--headless");
+            unityPsi.ArgumentList.Add("--ttl-seconds");
+            unityPsi.ArgumentList.Add(DefaultInactivityTimeoutSeconds.ToString());
+            return unityPsi;
+        }
+
         var processPath = Environment.ProcessPath;
         if (string.IsNullOrWhiteSpace(processPath))
         {
@@ -410,13 +565,20 @@ internal sealed class DaemonControlService
         var daemonArgs = new List<string>
         {
             "--daemon-service",
-            "--port", options.Port.ToString()
+            "--port", options.Port.ToString(),
+            "--ttl-seconds", DefaultInactivityTimeoutSeconds.ToString()
         };
 
         if (options.UnityPath is not null)
         {
             daemonArgs.Add("--unity");
             daemonArgs.Add(options.UnityPath);
+        }
+
+        if (options.ProjectPath is not null)
+        {
+            daemonArgs.Add("--project");
+            daemonArgs.Add(options.ProjectPath);
         }
 
         if (options.Headless)
@@ -469,7 +631,7 @@ internal sealed class DaemonControlService
                 return true;
             }
 
-            await Task.Delay(120);
+            await Task.Delay(180);
         }
 
         return false;
@@ -493,6 +655,17 @@ internal sealed class DaemonControlService
         {
             return false;
         }
+    }
+
+    private static string? ResolveDefaultUnityPath()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable("UNITY_PATH");
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+        {
+            return fromEnv;
+        }
+
+        return null;
     }
 
     private static string FormatUptime(DateTime startedAtUtc)

--- a/src/unifocl/Services/ProjectCommandRouterService.cs
+++ b/src/unifocl/Services/ProjectCommandRouterService.cs
@@ -1,0 +1,211 @@
+using Spectre.Console;
+using System.Text;
+
+internal sealed class ProjectCommandRouterService
+{
+    public async Task<bool> TryHandleProjectCommandAsync(
+        string input,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        if (string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+        {
+            log("[grey]system[/]: boot mode is slash-first; type / to see available commands");
+            return true;
+        }
+
+        var tokens = Tokenize(input);
+        if (tokens.Count == 0)
+        {
+            return true;
+        }
+
+        if (IsFileBypassCommand(tokens))
+        {
+            return HandleFileBypassCommand(tokens, session.CurrentProjectPath, log);
+        }
+
+        if (IsDaemonCommand(tokens))
+        {
+            var touched = await daemonControlService.TouchAttachedDaemonAsync(session);
+            if (!touched)
+            {
+                await AnsiConsole.Status()
+                    .Spinner(Spinner.Known.Dots)
+                    .StartAsync("Headless daemon sleeping. Cold starting...", async _ =>
+                    {
+                        await daemonControlService.EnsureProjectDaemonAsync(session.CurrentProjectPath, daemonRuntime, session, log);
+                    });
+            }
+
+            if (!await daemonControlService.TouchAttachedDaemonAsync(session))
+            {
+                log("[red]daemon[/]: unavailable after cold start attempt");
+                return true;
+            }
+
+            log("[grey]daemon[/]: routed command to headless daemon (stub bridge)");
+            log($"[deepskyblue1]stub[/]: daemon command [white]{Markup.Escape(input)}[/]");
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsFileBypassCommand(IReadOnlyList<string> tokens)
+    {
+        if (tokens.Count >= 3 && tokens[0].Equals("mk", StringComparison.OrdinalIgnoreCase) && tokens[1].Equals("script", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (tokens.Count >= 2 && tokens[0].Equals("mkdir", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsDaemonCommand(IReadOnlyList<string> tokens)
+    {
+        if (tokens.Count == 0)
+        {
+            return false;
+        }
+
+        if (tokens[0].Equals("mv", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (tokens[0].Equals("set", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (tokens.Count >= 2
+            && tokens[0].Equals("mk", StringComparison.OrdinalIgnoreCase)
+            && tokens[1].Equals("cube", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool HandleFileBypassCommand(IReadOnlyList<string> tokens, string projectPath, Action<string> log)
+    {
+        if (tokens[0].Equals("mkdir", StringComparison.OrdinalIgnoreCase))
+        {
+            var relative = tokens[1];
+            var target = ResolveProjectPath(projectPath, relative);
+            Directory.CreateDirectory(target);
+            log($"[green]fs[/]: created directory [white]{Markup.Escape(target)}[/] (daemon bypass)");
+            return true;
+        }
+
+        var scriptName = tokens[2];
+        var sanitized = SanitizeTypeName(scriptName);
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            log("[red]fs[/]: invalid script name");
+            return true;
+        }
+
+        var scriptsDir = Path.Combine(projectPath, "Assets", "Scripts");
+        Directory.CreateDirectory(scriptsDir);
+        var targetPath = Path.Combine(scriptsDir, sanitized + ".cs");
+
+        if (File.Exists(targetPath))
+        {
+            log($"[yellow]fs[/]: script already exists [white]{Markup.Escape(targetPath)}[/]");
+            return true;
+        }
+
+        var content = BuildScriptTemplate(sanitized);
+        File.WriteAllText(targetPath, content);
+        log($"[green]fs[/]: created script [white]{Markup.Escape(targetPath)}[/] (daemon bypass)");
+        log("[grey]fs[/]: Unity will import and generate .meta when editor/daemon runs");
+        return true;
+    }
+
+    private static string ResolveProjectPath(string projectPath, string relativeOrAbsolute)
+    {
+        if (Path.IsPathRooted(relativeOrAbsolute))
+        {
+            return relativeOrAbsolute;
+        }
+
+        return Path.GetFullPath(Path.Combine(projectPath, relativeOrAbsolute));
+    }
+
+    private static string SanitizeTypeName(string raw)
+    {
+        var builder = new StringBuilder();
+        foreach (var ch in raw)
+        {
+            if (char.IsLetterOrDigit(ch) || ch == '_')
+            {
+                builder.Append(ch);
+            }
+        }
+
+        var value = builder.ToString();
+        if (value.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        if (!char.IsLetter(value[0]) && value[0] != '_')
+        {
+            value = "_" + value;
+        }
+
+        return value;
+    }
+
+    private static string BuildScriptTemplate(string typeName)
+    {
+        return
+$"using UnityEngine;{Environment.NewLine}{Environment.NewLine}public class {typeName} : MonoBehaviour{Environment.NewLine}{{{Environment.NewLine}    private void Start(){{ }}{Environment.NewLine}{Environment.NewLine}    private void Update(){{ }}{Environment.NewLine}}}{Environment.NewLine}";
+    }
+
+    private static List<string> Tokenize(string input)
+    {
+        var tokens = new List<string>();
+        var current = new StringBuilder();
+        var inQuotes = false;
+
+        foreach (var ch in input)
+        {
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (!inQuotes && char.IsWhiteSpace(ch))
+            {
+                if (current.Length > 0)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                }
+
+                continue;
+            }
+
+            current.Append(ch);
+        }
+
+        if (current.Length > 0)
+        {
+            tokens.Add(current.ToString());
+        }
+
+        return tokens;
+    }
+}

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -5,22 +5,30 @@ using System.Text.Json;
 
 internal sealed class ProjectLifecycleService
 {
-    public bool TryHandleLifecycleCommand(
+    public async Task<bool> TryHandleLifecycleCommandAsync(
         string input,
         CommandSpec matched,
         CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
         Action<string> log)
     {
         return matched.Trigger switch
         {
-            "/open" => HandleOpen(input, matched, session, log),
-            "/new" => HandleNew(input, matched, session, log),
-            "/clone" => HandleClone(input, matched, session, log),
+            "/open" => await HandleOpenAsync(input, matched, session, daemonControlService, daemonRuntime, log),
+            "/new" => await HandleNewAsync(input, matched, session, daemonControlService, daemonRuntime, log),
+            "/clone" => await HandleCloneAsync(input, matched, session, daemonControlService, daemonRuntime, log),
             _ => false
         };
     }
 
-    private bool HandleOpen(string input, CommandSpec matched, CliSessionState session, Action<string> log)
+    private async Task<bool> HandleOpenAsync(
+        string input,
+        CommandSpec matched,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
     {
         var args = ParseCommandArgs(input, matched.Trigger);
         if (args.Count < 1)
@@ -30,11 +38,17 @@ internal sealed class ProjectLifecycleService
         }
 
         var projectPath = ResolveAbsolutePath(args[0], Directory.GetCurrentDirectory());
-        TryOpenProject(projectPath, session, log);
+        await TryOpenProjectAsync(projectPath, session, daemonControlService, daemonRuntime, log);
         return true;
     }
 
-    private bool HandleNew(string input, CommandSpec matched, CliSessionState session, Action<string> log)
+    private async Task<bool> HandleNewAsync(
+        string input,
+        CommandSpec matched,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
     {
         var args = ParseCommandArgs(input, matched.Trigger);
         if (args.Count < 1)
@@ -98,7 +112,7 @@ internal sealed class ProjectLifecycleService
         }
 
         log("[grey]new[/]: step 5/5 open bootstrapped project");
-        if (TryOpenProject(projectPath, session, log))
+        if (await TryOpenProjectAsync(projectPath, session, daemonControlService, daemonRuntime, log))
         {
             log("[green]new[/]: Unity project scaffold ready");
         }
@@ -110,7 +124,13 @@ internal sealed class ProjectLifecycleService
         return true;
     }
 
-    private bool HandleClone(string input, CommandSpec matched, CliSessionState session, Action<string> log)
+    private async Task<bool> HandleCloneAsync(
+        string input,
+        CommandSpec matched,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
     {
         var args = ParseCommandArgs(input, matched.Trigger);
         if (args.Count < 1)
@@ -160,7 +180,7 @@ internal sealed class ProjectLifecycleService
         }
 
         log("[grey]clone[/]: step 4/4 open cloned project");
-        if (TryOpenProject(targetPath, session, log))
+        if (await TryOpenProjectAsync(targetPath, session, daemonControlService, daemonRuntime, log))
         {
             log("[green]clone[/]: repository cloned and prepared");
         }
@@ -172,7 +192,12 @@ internal sealed class ProjectLifecycleService
         return true;
     }
 
-    private bool TryOpenProject(string projectPath, CliSessionState session, Action<string> log)
+    private static async Task<bool> TryOpenProjectAsync(
+        string projectPath,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
     {
         log($"[grey]open[/]: step 1/4 resolve project path -> [white]{Markup.Escape(projectPath)}[/]");
 
@@ -196,16 +221,42 @@ internal sealed class ProjectLifecycleService
             return false;
         }
 
-        log("[grey]open[/]: step 3/4 attach or start daemon session");
-        var daemonSession = EnsureDaemonSession(projectPath);
-        var daemonVerb = daemonSession.Created ? "started" : "attached";
-        log($"[grey]daemon[/]: {daemonVerb} project daemon on [white]127.0.0.1:{daemonSession.Port}[/]");
+        log("[grey]open[/]: step 3/4 route runtime by active Unity client lock");
+        var daemonPort = DaemonControlService.ComputeProjectDaemonPort(projectPath);
+        if (DaemonControlService.IsUnityClientActiveForProject(projectPath))
+        {
+            session.AttachedPort = null;
+            SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, false));
+            log("[grey]daemon[/]: Unity editor lock detected; routing operations via InitializeOnLoad bridge");
+        }
+        else
+        {
+            var started = await daemonControlService.EnsureProjectDaemonAsync(projectPath, daemonRuntime, session, log);
+            if (!started)
+            {
+                log("[red]daemon[/]: failed to start or attach headless daemon");
+                return false;
+            }
+
+            SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, true));
+            log($"[grey]daemon[/]: started headless daemon on [white]127.0.0.1:{daemonPort}[/]");
+        }
 
         session.CurrentProjectPath = projectPath;
         session.LastOpenedUtc = DateTimeOffset.UtcNow;
         log("[grey]open[/]: step 4/4 load project context");
         log($"[green]open[/]: attached [white]{Markup.Escape(Path.GetFileName(projectPath))}[/]");
         return true;
+    }
+
+    private static void SaveDaemonSession(string projectPath, DaemonSessionInfo session)
+    {
+        var daemonDir = Path.Combine(projectPath, ".unifocl");
+        Directory.CreateDirectory(daemonDir);
+        var daemonPath = Path.Combine(daemonDir, "daemon.session.json");
+        File.WriteAllText(
+            daemonPath,
+            JsonSerializer.Serialize(session, new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine);
     }
 
     private static List<string> ParseCommandArgs(string input, string trigger)
@@ -370,36 +421,6 @@ internal sealed class ProjectLifecycleService
         {
             return OperationResult.Fail($"failed to write ProjectVersion.txt ({ex.Message})");
         }
-    }
-
-    private static DaemonSessionInfo EnsureDaemonSession(string projectPath)
-    {
-        var daemonDir = Path.Combine(projectPath, ".unifocl");
-        Directory.CreateDirectory(daemonDir);
-        var daemonPath = Path.Combine(daemonDir, "daemon.session.json");
-
-        try
-        {
-            if (File.Exists(daemonPath))
-            {
-                var existing = JsonSerializer.Deserialize<DaemonSessionInfo>(File.ReadAllText(daemonPath));
-                if (existing is not null && existing.Port > 0)
-                {
-                    return existing with { Created = false };
-                }
-            }
-        }
-        catch
-        {
-            // If file is corrupt we overwrite it below.
-        }
-
-        var port = 18080 + Math.Abs(projectPath.GetHashCode()) % 2000;
-        var session = new DaemonSessionInfo(port, DateTimeOffset.UtcNow, true);
-        File.WriteAllText(
-            daemonPath,
-            JsonSerializer.Serialize(session, new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine);
-        return session;
     }
 
     private static ProcessResult RunProcess(string fileName, string arguments, string workingDirectory)


### PR DESCRIPTION
## Summary
- route `/open` by active Unity client lock: use InitializeOnLoad path if locked, otherwise ensure/start headless daemon
- launch headless Unity with memory-reduction args (`-batchmode -nographics -noUpm -vcsMode None -executeMethod CLIDaemon.StartServer`)
- add daemon inactivity TTL handling (10 minutes) and `TOUCH` heartbeat semantics
- add OS-first bypass routing for file-only commands (`mk script`, `mkdir`)
- add daemon wake/retry with cold-start spinner for daemon-routed commands

## Validation
- `dotnet build`

## TODO (Unity-side implementation)
- [ ] Implement `CLIDaemon.StartServer` inside Unity Editor code to parse the daemon args passed from CLI (`--daemon-service`, `--port`, `--ttl-seconds`, `--project`)
- [ ] In Unity daemon loop, track inactivity and call `EditorApplication.Exit(0)` after 10 minutes with no CLI commands
- [ ] Ensure active editor path uses `[InitializeOnLoad]` bridge startup when `Temp/UnityLockfile` indicates an active Unity client
- [ ] Confirm Unity-side command classification remains consistent with CLI routing rules (scene/inspector commands wake daemon; `mk script`/`mkdir` bypass daemon)
