### PR TITLE
Render project mode TUI immediately after project lifecycle commands

### DIFF
--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -163,6 +163,18 @@ while (true)
             daemonRuntime,
             line => AppendLog(streamLog, line)))
     {
+        if ((matched.Trigger == "/open" || matched.Trigger == "/new" || matched.Trigger == "/clone")
+            && session.Mode == CliMode.Project
+            && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+        {
+            await projectCommandRouterService.TryHandleProjectCommandAsync(
+                string.Empty,
+                session,
+                daemonControlService,
+                daemonRuntime,
+                line => AppendLog(streamLog, line));
+        }
+
         continue;
     }
 


### PR DESCRIPTION
## Summary
- render the project-mode TUI frame immediately after successful /open, /new, and /clone
- trigger the existing project view renderer by dispatching an empty project command after mode switch
- preserve existing behavior for non-project modes and failed lifecycle commands

## Validation
- dotnet build unifocl.sln