### PR TITLE
Fix /exit teardown and restore project command transcript

### DIFF
--- a/src/unifocl/Models/ProjectViewModels.cs
+++ b/src/unifocl/Models/ProjectViewModels.cs
@@ -10,6 +10,7 @@ internal sealed class ProjectViewState
     public string RelativeCwd { get; set; } = string.Empty;
     public List<ProjectTreeEntry> VisibleEntries { get; } = [];
     public HashSet<string> ExpandedDirectories { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public List<string> CommandTranscript { get; } = [];
     public ProjectDbState DbState { get; set; } = ProjectDbState.IdleSafe;
 }
 

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -34,6 +34,37 @@ internal sealed class ProjectLifecycleService
         Action<string> log)
     {
         await HandleCloseAsync(session, daemonControlService, daemonRuntime, log);
+
+        daemonRuntime.CleanStaleEntries();
+        var remainingPorts = daemonRuntime.GetAll()
+            .Select(instance => instance.Port)
+            .Distinct()
+            .OrderBy(port => port)
+            .ToList();
+
+        if (remainingPorts.Count == 0)
+        {
+            log("[grey]exit[/]: teardown complete");
+            return;
+        }
+
+        var stoppedCount = 0;
+        foreach (var port in remainingPorts)
+        {
+            if (await daemonControlService.StopDaemonByPortAsync(port, daemonRuntime, session, log))
+            {
+                stoppedCount++;
+            }
+        }
+
+        if (stoppedCount == remainingPorts.Count)
+        {
+            log($"[green]exit[/]: teardown complete; stopped {stoppedCount} daemon(s)");
+        }
+        else
+        {
+            log($"[yellow]exit[/]: teardown partial; stopped {stoppedCount}/{remainingPorts.Count} daemon(s)");
+        }
     }
 
     private async Task<bool> HandleOpenAsync(

--- a/src/unifocl/Services/ProjectViewRenderer.cs
+++ b/src/unifocl/Services/ProjectViewRenderer.cs
@@ -3,7 +3,7 @@ using Spectre.Console;
 internal sealed class ProjectViewRenderer
 {
     private const int FrameWidth = 78;
-    private const int BottomPaddingRows = 2;
+    private const int CommandRows = 8;
 
     public IReadOnlyList<string> Render(ProjectViewState state)
     {
@@ -21,9 +21,16 @@ internal sealed class ProjectViewRenderer
             lines.Add(BorderBody(treeLine));
         }
 
-        for (var i = 0; i < BottomPaddingRows; i++)
+        lines.Add(BorderSeparator());
+        var recent = state.CommandTranscript
+            .Skip(Math.Max(0, state.CommandTranscript.Count - CommandRows))
+            .ToList();
+        for (var i = 0; i < CommandRows; i++)
         {
-            lines.Add(BorderBody(string.Empty));
+            var line = i < recent.Count
+                ? recent[i]
+                : (i == recent.Count ? $"UnityCLI:{cwd} > _" : string.Empty);
+            lines.Add(BorderBody($" {line}"));
         }
 
         lines.Add(BorderBottom());

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -4,6 +4,7 @@ using Spectre.Console;
 
 internal sealed class ProjectViewService
 {
+    private const int MaxTranscriptEntries = 80;
     private readonly ProjectViewRenderer _renderer = new();
 
     public void OpenInitialView(CliSessionState session)
@@ -78,6 +79,7 @@ internal sealed class ProjectViewService
             return false;
         }
 
+        AppendTranscript(session.ProjectView, outputs);
         RenderFrame(session.ProjectView);
         return true;
     }
@@ -105,6 +107,8 @@ internal sealed class ProjectViewService
         state.RelativeCwd = defaultCwd;
         state.ExpandedDirectories.Clear();
         state.VisibleEntries.Clear();
+        state.CommandTranscript.Clear();
+        state.CommandTranscript.Add("[i] project view ready");
         state.DbState = ProjectDbState.IdleSafe;
         state.Initialized = true;
         RefreshTree(projectPath, state);
@@ -302,6 +306,23 @@ internal sealed class ProjectViewService
         {
             AnsiConsole.MarkupLine(line);
         }
+    }
+
+    private static void AppendTranscript(ProjectViewState state, IReadOnlyList<string> outputs)
+    {
+        if (outputs.Count == 0)
+        {
+            return;
+        }
+
+        state.CommandTranscript.AddRange(outputs);
+        if (state.CommandTranscript.Count <= MaxTranscriptEntries)
+        {
+            return;
+        }
+
+        var overflow = state.CommandTranscript.Count - MaxTranscriptEntries;
+        state.CommandTranscript.RemoveRange(0, overflow);
     }
 
     private static async Task EnsureUnityContextAsync(


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Fixes `/exit` teardown to stop any remaining registered daemons after session detach/close cleanup.
  - Restores and wires `ProjectViewState.CommandTranscript` so project-mode command outputs are persisted and rendered in the TUI.
- Why is this change needed?
  - Ensures shutdown behavior is robust even when daemons are not the current attached target.
  - Resolves build failure (`CS1061`) and closes a functional gap where generated project command outputs were never displayed.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `ProjectLifecycleService` safe-exit teardown
  - `ProjectViewState` model
  - `ProjectViewService` transcript management
  - `ProjectViewRenderer` project-mode transcript panel
- Out-of-scope / intentionally not addressed:
  - No changes to daemon protocol or Unity-side editor scripts
  - No additions to command surface area

## How to Test
1. Run `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`.
2. Start CLI, open a project, run project view commands (e.g., `ls`, `cd <idx> -long`, `mk script Foo`) and verify command log appears in PROJECT frame.
3. Start/attach multiple daemons, then run `/exit` and verify teardown logs indicate stop attempts for remaining daemons.

Expected results:
- Build succeeds with 0 errors.
- Project-mode command transcript is visible and bounded.
- `/exit` performs close + full teardown and reports completion/partial status.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->
- `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal` -> Build succeeded, 0 warnings, 0 errors.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No secrets, credentials, or external data handling changes.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
