### PR TITLE
Implement /recent command with persistent project history

### DIFF
--- a/src/unifocl/Models/CommandModels.cs
+++ b/src/unifocl/Models/CommandModels.cs
@@ -10,6 +10,7 @@ internal sealed record DaemonInstance(
     string? ProjectPath,
     DateTime LastHeartbeatUtc);
 internal sealed record DaemonSessionInfo(int Port, DateTimeOffset StartedAtUtc, bool Created);
+internal sealed record RecentProjectEntry(string ProjectPath, DateTimeOffset LastOpenedUtc);
 internal sealed record ProcessResult(int ExitCode, string Stdout, string Stderr);
 internal sealed record OperationResult(bool Ok, string Error)
 {

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -7,6 +7,7 @@ internal sealed class ProjectLifecycleService
 {
     private readonly EditorDependencyInitializerService _editorDependencyInitializerService = new();
     private readonly ProjectViewService _projectViewService = new();
+    private readonly RecentProjectHistoryService _recentProjectHistoryService = new();
 
     public async Task<bool> TryHandleLifecycleCommandAsync(
         string input,
@@ -21,6 +22,7 @@ internal sealed class ProjectLifecycleService
             "/open" => await HandleOpenAsync(input, matched, session, daemonControlService, daemonRuntime, log),
             "/new" => await HandleNewAsync(input, matched, session, daemonControlService, daemonRuntime, log),
             "/clone" => await HandleCloneAsync(input, matched, session, daemonControlService, daemonRuntime, log),
+            "/recent" => await HandleRecentAsync(input, matched, log),
             "/close" => await HandleCloseAsync(session, daemonControlService, daemonRuntime, log),
             "/init" => await HandleInitAsync(input, matched, session, log),
             _ => false
@@ -298,6 +300,48 @@ internal sealed class ProjectLifecycleService
         return Task.FromResult(true);
     }
 
+    private Task<bool> HandleRecentAsync(
+        string input,
+        CommandSpec matched,
+        Action<string> log)
+    {
+        var args = ParseCommandArgs(input, matched.Trigger);
+        if (args.Count > 1)
+        {
+            log("[red]error[/]: usage /recent [n]");
+            return Task.FromResult(true);
+        }
+
+        var count = 10;
+        if (args.Count == 1 && (!int.TryParse(args[0], out count) || count <= 0))
+        {
+            log("[red]error[/]: n must be a positive integer");
+            return Task.FromResult(true);
+        }
+
+        if (!_recentProjectHistoryService.TryGetRecentProjects(count, out var entries, out var historyError))
+        {
+            log($"[red]error[/]: {Markup.Escape(historyError ?? "failed to load recent projects")}");
+            return Task.FromResult(true);
+        }
+
+        if (entries.Count == 0)
+        {
+            log("[grey]recent[/]: no recent projects found");
+            return Task.FromResult(true);
+        }
+
+        log("[grey]recent[/]: most recently opened projects");
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var entry = entries[i];
+            var opened = entry.LastOpenedUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz");
+            log($"[grey]recent[/]: [white]{i + 1}[/]. [white]{Markup.Escape(entry.ProjectPath)}[/] [dim]({opened})[/]");
+        }
+
+        return Task.FromResult(true);
+    }
+
     private async Task<bool> HandleCloseAsync(
         CliSessionState session,
         DaemonControlService daemonControlService,
@@ -422,6 +466,11 @@ internal sealed class ProjectLifecycleService
         session.CurrentProjectPath = projectPath;
         session.Mode = CliMode.Project;
         session.LastOpenedUtc = DateTimeOffset.UtcNow;
+        if (!_recentProjectHistoryService.TryRecordProjectOpen(projectPath, session.LastOpenedUtc.Value, out var historyError))
+        {
+            log($"[yellow]recent[/]: unable to update history ({Markup.Escape(historyError ?? "unknown error")})");
+        }
+
         log("[grey]open[/]: step 4/4 load project context");
         _projectViewService.OpenInitialView(session);
         return true;

--- a/src/unifocl/Services/RecentProjectHistoryService.cs
+++ b/src/unifocl/Services/RecentProjectHistoryService.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+
+internal sealed class RecentProjectHistoryService
+{
+    private const int MaxStoredEntries = 100;
+    private readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+
+    public bool TryRecordProjectOpen(string projectPath, DateTimeOffset openedAtUtc, out string? error)
+    {
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(projectPath))
+        {
+            error = "project path is empty";
+            return false;
+        }
+
+        if (!TryLoadEntries(out var entries, out error))
+        {
+            return false;
+        }
+
+        entries.RemoveAll(entry => string.Equals(entry.ProjectPath, projectPath, StringComparison.Ordinal));
+        entries.Insert(0, new RecentProjectEntry(projectPath, openedAtUtc));
+
+        if (entries.Count > MaxStoredEntries)
+        {
+            entries = entries.Take(MaxStoredEntries).ToList();
+        }
+
+        return TrySaveEntries(entries, out error);
+    }
+
+    public bool TryGetRecentProjects(int maxCount, out List<RecentProjectEntry> entries, out string? error)
+    {
+        entries = [];
+        error = null;
+
+        if (maxCount <= 0)
+        {
+            error = "max count must be greater than zero";
+            return false;
+        }
+
+        if (!TryLoadEntries(out var loadedEntries, out error))
+        {
+            return false;
+        }
+
+        entries = loadedEntries
+            .OrderByDescending(entry => entry.LastOpenedUtc)
+            .Take(maxCount)
+            .ToList();
+        return true;
+    }
+
+    private bool TryLoadEntries(out List<RecentProjectEntry> entries, out string? error)
+    {
+        entries = [];
+        error = null;
+        var historyPath = GetHistoryPath();
+
+        if (!File.Exists(historyPath))
+        {
+            return true;
+        }
+
+        try
+        {
+            var raw = File.ReadAllText(historyPath);
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return true;
+            }
+
+            var parsed = JsonSerializer.Deserialize<List<RecentProjectEntry>>(raw);
+            if (parsed is null)
+            {
+                return true;
+            }
+
+            entries = parsed
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.ProjectPath))
+                .ToList();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"failed to read recent project history ({ex.Message})";
+            return false;
+        }
+    }
+
+    private bool TrySaveEntries(List<RecentProjectEntry> entries, out string? error)
+    {
+        error = null;
+        var historyPath = GetHistoryPath();
+        var directory = Path.GetDirectoryName(historyPath);
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            error = "failed to resolve recent project history directory";
+            return false;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(historyPath, JsonSerializer.Serialize(entries, _jsonOptions) + Environment.NewLine);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"failed to write recent project history ({ex.Message})";
+            return false;
+        }
+    }
+
+    private static string GetHistoryPath()
+    {
+        var overridePath = Environment.GetEnvironmentVariable("UNIFOCL_RECENT_PROJECTS_PATH");
+        if (!string.IsNullOrWhiteSpace(overridePath))
+        {
+            return Path.GetFullPath(overridePath);
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".unifocl", "recent-projects.json");
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `/recent [n]` command behavior in lifecycle routing.
- Add persistent recent-project history storage and retrieval.
- Record successful project opens so `/recent` works across CLI sessions.
- Add validation and user-facing errors for invalid `/recent` arguments.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
- `src/unifocl/Services/ProjectLifecycleService.cs`
- `src/unifocl/Services/RecentProjectHistoryService.cs` (new)
- `src/unifocl/Models/CommandModels.cs`
- Out-of-scope / intentionally not addressed:
- `/switch` behavior is unchanged.
- Existing command palette/help registration text is unchanged.

## How to Test
1. Build: `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Run CLI and open one or more Unity projects with `/open <path>`.
3. Run `/recent` and `/recent 1`.
4. Run `/recent 0` and `/recent abc` to validate error handling.

Expected results:
- `/recent` lists projects in most-recent-first order with timestamps.
- `/recent n` limits output count.
- Non-positive or non-numeric `n` returns a clear usage error.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- 

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Stores local recent project metadata in `~/.unifocl/recent-projects.json` (or `UNIFOCL_RECENT_PROJECTS_PATH` override).

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
