### PR TITLE
Align Inspector/Hierarchy TUI with Project-mode window behavior

### DIFF
--- a/src/unifocl/Models/InspectorModels.cs
+++ b/src/unifocl/Models/InspectorModels.cs
@@ -13,6 +13,9 @@ internal sealed class InspectorContext
     public int? SelectedComponentIndex { get; set; }
     public string? SelectedComponentName { get; set; }
     public List<string> CommandStream { get; } = [];
+    public int BodyScrollOffset { get; set; }
+    public int StreamScrollOffset { get; set; } = int.MaxValue;
+    public bool FollowStreamScroll { get; set; } = true;
 
     public string PromptPath =>
         Depth == InspectorDepth.ComponentFields && !string.IsNullOrWhiteSpace(SelectedComponentName)

--- a/src/unifocl/Models/ProjectViewModels.cs
+++ b/src/unifocl/Models/ProjectViewModels.cs
@@ -10,6 +10,7 @@ internal sealed class ProjectViewState
     public string RelativeCwd { get; set; } = string.Empty;
     public List<ProjectTreeEntry> VisibleEntries { get; } = [];
     public HashSet<string> ExpandedDirectories { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public List<string> CommandTranscript { get; } = [];
     public ProjectDbState DbState { get; set; } = ProjectDbState.IdleSafe;
 }
 

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -254,7 +254,7 @@ static int RenderComposerFrame(string input, List<CommandSpec> commands, CliSess
     }
     else if (session.Inspector is not null)
     {
-        lines.Add("[dim]Inspector commands: inspect [idx], ls, set <field> <value>, toggle <field|idx>, :i[/]");
+        lines.Add("[dim]Inspector commands: inspect [idx], ls, set <field> <value>, toggle <field|idx>, scroll [body|stream] <up|down> [n], :i[/]");
     }
     else
     {

--- a/src/unifocl/Services/HierarchyTui.cs
+++ b/src/unifocl/Services/HierarchyTui.cs
@@ -3,10 +3,15 @@ using System.Text;
 internal sealed class HierarchyTui
 {
     private const int FrameWidth = 78;
-    private const int TreeRows = 12;
-    private const int CommandRows = 10;
+    private const int MinTreeRows = 6;
+    private const int MinCommandRows = 4;
+    private const int ReservedPromptRows = 4;
+    private const int FrameOverheadRows = 5;
 
     private readonly HierarchyDaemonClient _daemonClient = new();
+    private int _treeScrollOffset;
+    private int _commandScrollOffset = int.MaxValue;
+    private bool _followCommandScroll = true;
 
     public async Task RunAsync(
         CliSessionState session,
@@ -42,6 +47,9 @@ internal sealed class HierarchyTui
 
         var cwdId = snapshot.Root.Id;
         var commandLog = new List<string>();
+        _treeScrollOffset = 0;
+        _commandScrollOffset = int.MaxValue;
+        _followCommandScroll = true;
 
         while (true)
         {
@@ -54,8 +62,6 @@ internal sealed class HierarchyTui
             {
                 continue;
             }
-
-            commandLog.Add($"UnityCLI:{cwdPath} > {input}");
 
             if (input.Equals("q", StringComparison.OrdinalIgnoreCase)
                 || input.Equals("quit", StringComparison.OrdinalIgnoreCase)
@@ -97,7 +103,7 @@ internal sealed class HierarchyTui
 
             if (!handled)
             {
-                commandLog.Add("[!] unknown command (supported: cd, up, mk, toggle, ref, quit)");
+                commandLog.Add("[!] unknown command (supported: cd, up, mk, toggle, ref, scroll, quit)");
             }
 
             var nextSnapshot = await _daemonClient.GetSnapshotAsync(port);
@@ -136,7 +142,13 @@ internal sealed class HierarchyTui
         {
             var parentId = FindParentId(snapshot.Root, cwdId);
             setCwd(parentId ?? snapshot.Root.Id);
+            _treeScrollOffset = 0;
             commandLog.Add("[*] ok: moved to parent");
+            return true;
+        }
+
+        if (TryHandleScrollCommand(tokens, commandLog))
+        {
             return true;
         }
 
@@ -149,6 +161,7 @@ internal sealed class HierarchyTui
             }
 
             setCwd(targetId);
+            _treeScrollOffset = 0;
             commandLog.Add("[*] ok: changed current object");
             return true;
         }
@@ -198,30 +211,105 @@ internal sealed class HierarchyTui
         return false;
     }
 
-    private static void RenderFrame(int daemonPort, string scene, List<string> treeLines, List<string> commandLog, string cwdPath)
+    private bool TryHandleScrollCommand(IReadOnlyList<string> tokens, List<string> commandLog)
+    {
+        if (tokens.Count < 2 || !tokens[0].Equals("scroll", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var section = "tree";
+        var directionIndex = 1;
+        if (tokens[1].Equals("tree", StringComparison.OrdinalIgnoreCase)
+            || tokens[1].Equals("log", StringComparison.OrdinalIgnoreCase))
+        {
+            section = tokens[1].ToLowerInvariant();
+            directionIndex = 2;
+        }
+
+        if (tokens.Count <= directionIndex)
+        {
+            commandLog.Add("[!] usage: scroll [tree|log] <up|down> [count]");
+            return true;
+        }
+
+        var direction = tokens[directionIndex].ToLowerInvariant();
+        if (direction is not ("up" or "down"))
+        {
+            commandLog.Add("[!] direction must be up or down");
+            return true;
+        }
+
+        var amount = 1;
+        if (tokens.Count > directionIndex + 1 && (!int.TryParse(tokens[directionIndex + 1], out amount) || amount <= 0))
+        {
+            commandLog.Add("[!] count must be a positive integer");
+            return true;
+        }
+
+        var delta = direction == "up" ? -amount : amount;
+        if (section == "log")
+        {
+            if (_followCommandScroll)
+            {
+                _commandScrollOffset = Math.Max(0, commandLog.Count - 1);
+            }
+
+            _followCommandScroll = false;
+            _commandScrollOffset += delta;
+            if (_commandScrollOffset >= commandLog.Count)
+            {
+                _followCommandScroll = true;
+                _commandScrollOffset = int.MaxValue;
+            }
+
+            commandLog.Add($"[*] log scrolled {direction} by {amount}");
+            return true;
+        }
+
+        _treeScrollOffset += delta;
+        commandLog.Add($"[*] tree scrolled {direction} by {amount}");
+        return true;
+    }
+
+    private void RenderFrame(int daemonPort, string scene, List<string> treeLines, List<string> commandLog, string cwdPath)
     {
         Console.Clear();
 
         var borderTop = $"┌{new string('─', FrameWidth)}┐";
         var borderMid = $"├{new string('─', FrameWidth)}┤";
         var borderBottom = $"└{new string('─', FrameWidth)}┘";
+        var availableRows = Math.Max(MinTreeRows + MinCommandRows, Console.WindowHeight - ReservedPromptRows);
+        var dynamicRows = Math.Max(MinTreeRows + MinCommandRows, availableRows - FrameOverheadRows);
+        var streamRows = commandLog
+            .Where(line => !line.StartsWith("UnityCLI:", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var hasStreamPane = streamRows.Count > 0;
+        var (treeRows, commandRows) = hasStreamPane
+            ? AllocateViewportRows(dynamicRows, treeLines.Count, streamRows.Count)
+            : (Math.Max(1, dynamicRows), 0);
+        var visibleTree = SliceRows(treeLines, treeRows, ref _treeScrollOffset, followTail: false);
+        var visibleCommandLog = hasStreamPane
+            ? SliceRows(streamRows, commandRows, ref _commandScrollOffset, _followCommandScroll)
+            : [];
 
         Console.WriteLine(borderTop);
         Console.WriteLine(ToFrameLine($" UnityCLI v0.1 | MODE: HIERARCHY | Daemon: 127.0.0.1:{daemonPort} | Scene: {scene}"));
         Console.WriteLine(borderMid);
 
-        for (var i = 0; i < TreeRows; i++)
+        foreach (var line in visibleTree)
         {
-            var line = i < treeLines.Count ? treeLines[i] : string.Empty;
             Console.WriteLine(ToFrameLine($" {line}"));
         }
 
-        Console.WriteLine(borderMid);
-        var recent = commandLog.Skip(Math.Max(0, commandLog.Count - CommandRows)).ToList();
-        for (var i = 0; i < CommandRows; i++)
+        if (hasStreamPane)
         {
-            var line = i < recent.Count ? recent[i] : (i == recent.Count ? $"UnityCLI:{cwdPath} > _" : string.Empty);
-            Console.WriteLine(ToFrameLine($" {line}"));
+            Console.WriteLine(borderMid);
+            for (var i = 0; i < visibleCommandLog.Count; i++)
+            {
+                var line = visibleCommandLog[i];
+                Console.WriteLine(ToFrameLine($" {line}"));
+            }
         }
 
         Console.WriteLine(borderBottom);
@@ -393,5 +481,58 @@ internal sealed class HierarchyTui
         var sanitized = raw.Replace('\t', ' ');
         var content = sanitized.Length > FrameWidth ? sanitized[..FrameWidth] : sanitized.PadRight(FrameWidth, ' ');
         return $"│{content}│";
+    }
+
+    private static (int TreeRows, int CommandRows) AllocateViewportRows(int dynamicRows, int treeCount, int commandCount)
+    {
+        var preferredTree = Math.Max(MinTreeRows, treeCount);
+        var preferredCommand = Math.Max(MinCommandRows, commandCount);
+        var preferredTotal = preferredTree + preferredCommand;
+        if (preferredTotal <= dynamicRows)
+        {
+            return (preferredTree, preferredCommand);
+        }
+
+        var commandRows = Math.Min(preferredCommand, Math.Max(MinCommandRows, dynamicRows / 3));
+        var treeRows = dynamicRows - commandRows;
+        if (treeRows < MinTreeRows)
+        {
+            treeRows = MinTreeRows;
+            commandRows = Math.Max(MinCommandRows, dynamicRows - treeRows);
+        }
+
+        return (Math.Max(1, treeRows), Math.Max(1, commandRows));
+    }
+
+    private static List<string> SliceRows(IReadOnlyList<string> source, int viewportRows, ref int offset, bool followTail)
+    {
+        viewportRows = Math.Max(1, viewportRows);
+        var rows = source.Count == 0 ? new List<string> { string.Empty } : source.ToList();
+        var maxOffset = Math.Max(0, rows.Count - viewportRows);
+        if (followTail)
+        {
+            offset = maxOffset;
+        }
+
+        offset = Math.Clamp(offset, 0, maxOffset);
+        var visible = rows.Skip(offset).Take(viewportRows).ToList();
+        while (visible.Count < viewportRows)
+        {
+            visible.Add(string.Empty);
+        }
+
+        var hiddenAbove = offset;
+        var hiddenBelow = Math.Max(0, rows.Count - (offset + visible.Count));
+        if (hiddenAbove > 0 && visible.Count > 0)
+        {
+            visible[0] = $"... {hiddenAbove} line(s) above ...";
+        }
+
+        if (hiddenBelow > 0 && visible.Count > 1)
+        {
+            visible[^1] = $"... {hiddenBelow} line(s) below ...";
+        }
+
+        return visible;
     }
 }

--- a/src/unifocl/Services/InspectorModeService.cs
+++ b/src/unifocl/Services/InspectorModeService.cs
@@ -21,7 +21,7 @@ internal sealed class InspectorModeService
 
         var command = tokens[0].ToLowerInvariant();
         var inInspector = session.Inspector is not null;
-        var isInspectorCommand = command is "inspect" or "set" or "toggle" or "ls" or ":i";
+        var isInspectorCommand = command is "inspect" or "set" or "toggle" or "ls" or "scroll" or ":i";
 
         if (!inInspector && !isInspectorCommand)
         {
@@ -46,6 +46,9 @@ internal sealed class InspectorModeService
                 return true;
             case "set":
                 await HandleSetAsync(input, tokens, session, log);
+                return true;
+            case "scroll":
+                HandleScroll(input, tokens, session, log);
                 return true;
             case ":i":
                 HandleStepUp(session, log);
@@ -281,6 +284,88 @@ internal sealed class InspectorModeService
         _renderer.Render(context);
     }
 
+    private void HandleScroll(
+        string input,
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        Action<string> log)
+    {
+        var context = session.Inspector;
+        if (context is null)
+        {
+            log("[grey]system[/]: scroll requires inspect mode");
+            return;
+        }
+
+        if (tokens.Count < 2)
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, "[!] usage: scroll [body|stream] <up|down> [count]");
+            _renderer.Render(context);
+            return;
+        }
+
+        var section = "body";
+        var directionTokenIndex = 1;
+        if (tokens[1].Equals("body", StringComparison.OrdinalIgnoreCase)
+            || tokens[1].Equals("stream", StringComparison.OrdinalIgnoreCase))
+        {
+            section = tokens[1].ToLowerInvariant();
+            directionTokenIndex = 2;
+        }
+
+        if (tokens.Count <= directionTokenIndex)
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, "[!] usage: scroll [body|stream] <up|down> [count]");
+            _renderer.Render(context);
+            return;
+        }
+
+        var direction = tokens[directionTokenIndex].ToLowerInvariant();
+        var amount = 1;
+        if (tokens.Count > directionTokenIndex + 1
+            && (!int.TryParse(tokens[directionTokenIndex + 1], out amount) || amount <= 0))
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, "[!] count must be a positive integer");
+            _renderer.Render(context);
+            return;
+        }
+
+        if (direction is not ("up" or "down"))
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, "[!] direction must be up or down");
+            _renderer.Render(context);
+            return;
+        }
+
+        var delta = direction == "up" ? -amount : amount;
+        if (section == "stream")
+        {
+            if (context.FollowStreamScroll)
+            {
+                context.StreamScrollOffset = Math.Max(0, context.CommandStream.Count - 1);
+            }
+
+            context.FollowStreamScroll = false;
+            context.StreamScrollOffset += delta;
+            if (context.StreamScrollOffset >= context.CommandStream.Count)
+            {
+                context.FollowStreamScroll = true;
+                context.StreamScrollOffset = int.MaxValue;
+            }
+        }
+        else
+        {
+            context.BodyScrollOffset += delta;
+        }
+
+        AddStream(context, $"{context.PromptLabel} > {input}");
+        _renderer.Render(context);
+    }
+
     private void HandleStepUp(CliSessionState session, Action<string> log)
     {
         var context = session.Inspector;
@@ -296,6 +381,9 @@ internal sealed class InspectorModeService
             context.Fields.Clear();
             context.SelectedComponentIndex = null;
             context.SelectedComponentName = null;
+            context.BodyScrollOffset = 0;
+            context.FollowStreamScroll = true;
+            context.StreamScrollOffset = int.MaxValue;
             AddStream(context, $"{context.PromptLabel} > :i");
             AddStream(context, "[i] stepped up to component list");
             _renderer.Render(context);
@@ -317,6 +405,9 @@ internal sealed class InspectorModeService
         context.Fields.Clear();
         context.SelectedComponentIndex = null;
         context.SelectedComponentName = null;
+        context.BodyScrollOffset = 0;
+        context.FollowStreamScroll = true;
+        context.StreamScrollOffset = int.MaxValue;
         await PopulateComponentsAsync(context, session, forceRefresh: true);
         AddStream(context, $"{context.PromptLabel} > {rawCommand}");
         AddStream(context, $"[i] entering inspector for: {context.TargetPath.TrimStart('/')}");
@@ -341,6 +432,9 @@ internal sealed class InspectorModeService
         context.Depth = InspectorDepth.ComponentFields;
         context.SelectedComponentIndex = componentIndex;
         context.SelectedComponentName = component.Name;
+        context.BodyScrollOffset = 0;
+        context.FollowStreamScroll = true;
+        context.StreamScrollOffset = int.MaxValue;
         await PopulateFieldsAsync(context, session, componentIndex, forceRefresh: true);
         AddStream(context, $"UnityCLI:{context.TargetPath} [inspect] > {rawCommand}");
         AddStream(context, $"[i] inspecting component: {component.Name}");
@@ -524,6 +618,11 @@ internal sealed class InspectorModeService
         if (context.CommandStream.Count > 200)
         {
             context.CommandStream.RemoveRange(0, context.CommandStream.Count - 200);
+        }
+
+        if (context.FollowStreamScroll)
+        {
+            context.StreamScrollOffset = int.MaxValue;
         }
     }
 

--- a/src/unifocl/Services/InspectorTuiRenderer.cs
+++ b/src/unifocl/Services/InspectorTuiRenderer.cs
@@ -3,26 +3,45 @@ using Spectre.Console;
 internal sealed class InspectorTuiRenderer
 {
     private const int InnerWidth = 78;
-    private const int BodyHeight = 9;
-    private const int StreamHeight = 10;
+    private const int MinBodyRows = 4;
+    private const int MinStreamRows = 4;
+    private const int ReservedPromptRows = 4;
+    private const int FrameOverheadRows = 5;
 
     public void Render(InspectorContext context)
     {
         AnsiConsole.Clear();
+        var availableRows = Math.Max(MinBodyRows + MinStreamRows, Console.WindowHeight - ReservedPromptRows);
+        var dynamicRows = Math.Max(MinBodyRows + MinStreamRows, availableRows - FrameOverheadRows);
 
-        var frame = new List<string>
+        var bodyRows = BuildBodyRows(context).ToList();
+        var streamRows = BuildStreamRows(context).ToList();
+        var hasStreamPane = streamRows.Count > 0;
+        var (bodyViewportRows, streamViewportRows) = hasStreamPane
+            ? AllocateViewportRows(dynamicRows, bodyRows.Count, streamRows.Count)
+            : (Math.Max(1, dynamicRows), 0);
+        var bodyOffset = context.BodyScrollOffset;
+        var streamOffset = context.StreamScrollOffset;
+        var visibleBody = SliceRows(bodyRows, bodyViewportRows, ref bodyOffset, followTail: false);
+        var visibleStream = hasStreamPane
+            ? SliceRows(streamRows, streamViewportRows, ref streamOffset, context.FollowStreamScroll)
+            : Array.Empty<string>();
+        context.BodyScrollOffset = bodyOffset;
+        context.StreamScrollOffset = streamOffset;
+
+        var frame = new List<string>(FrameOverheadRows + visibleBody.Count + (hasStreamPane ? visibleStream.Count + 1 : 0))
         {
             Border('┌', '┐'),
             Line(BuildHeader(context)),
             Border('├', '┤')
         };
 
-        frame.AddRange(context.Depth == InspectorDepth.ComponentList
-            ? BuildComponentBody(context)
-            : BuildFieldBody(context));
-
-        frame.Add(Border('├', '┤'));
-        frame.AddRange(BuildStreamBody(context));
+        frame.AddRange(visibleBody.Select(Line));
+        if (hasStreamPane)
+        {
+            frame.Add(Border('├', '┤'));
+            frame.AddRange(visibleStream.Select(Line));
+        }
         frame.Add(Border('└', '┘'));
 
         foreach (var line in frame)
@@ -31,56 +50,62 @@ internal sealed class InspectorTuiRenderer
         }
     }
 
-    private static IEnumerable<string> BuildComponentBody(InspectorContext context)
+    private static IEnumerable<string> BuildBodyRows(InspectorContext context)
     {
-        var lines = new List<string> { Line("COMPONENTS:") };
-        foreach (var component in context.Components)
-        {
-            lines.Add(Line($" [{component.Index}] {component.Name}"));
-        }
-
-        while (lines.Count < BodyHeight)
-        {
-            lines.Add(Line(string.Empty));
-        }
-
-        return lines.Take(BodyHeight);
+        return context.Depth == InspectorDepth.ComponentList
+            ? BuildComponentRows(context)
+            : BuildFieldRows(context);
     }
 
-    private static IEnumerable<string> BuildFieldBody(InspectorContext context)
+    private static IEnumerable<string> BuildComponentRows(InspectorContext context)
+    {
+        var lines = new List<string> { "COMPONENTS:" };
+        foreach (var component in context.Components)
+        {
+            lines.Add($" [{component.Index}] {component.Name}");
+        }
+
+        if (lines.Count == 1)
+        {
+            lines.Add(" [empty]");
+        }
+
+        return lines;
+    }
+
+    private static IEnumerable<string> BuildFieldRows(InspectorContext context)
     {
         var lines = new List<string>
         {
-            Line($"{PadRight("FIELD", 20)}{PadRight("VALUE", 26)}TYPE"),
-            Line(new string('─', InnerWidth - 1))
+            $"{PadRight("FIELD", 20)}{PadRight("VALUE", 26)}TYPE",
+            new string('─', InnerWidth - 1)
         };
 
         foreach (var field in context.Fields)
         {
             var typeCell = $"[{field.Type}]";
-            lines.Add(Line($"{PadRight(field.Name, 20)}{PadRight(field.Value, 26)}{typeCell}"));
+            lines.Add($"{PadRight(field.Name, 20)}{PadRight(field.Value, 26)}{typeCell}");
         }
 
-        while (lines.Count < BodyHeight)
+        if (context.Fields.Count == 0)
         {
-            lines.Add(Line(string.Empty));
+            lines.Add(" [empty]");
         }
 
-        return lines.Take(BodyHeight);
+        return lines;
     }
 
-    private static IEnumerable<string> BuildStreamBody(InspectorContext context)
+    private static IEnumerable<string> BuildStreamRows(InspectorContext context)
     {
-        var stream = context.CommandStream
-            .TakeLast(StreamHeight)
+        var rows = context.CommandStream
+            .Where(line => !line.StartsWith("UnityCLI:", StringComparison.OrdinalIgnoreCase))
             .ToList();
-
-        while (stream.Count < StreamHeight)
+        if (rows.Count == 0)
         {
-            stream.Add(string.Empty);
+            return [];
         }
 
-        return stream.Select(Line);
+        return rows;
     }
 
     private static string BuildHeader(InspectorContext context)
@@ -100,6 +125,63 @@ internal sealed class InspectorTuiRenderer
     {
         var trimmed = content.Length > InnerWidth ? content[..InnerWidth] : content;
         return $"│{trimmed.PadRight(InnerWidth)}│";
+    }
+
+    private static (int BodyRows, int StreamRows) AllocateViewportRows(int dynamicRows, int bodyCount, int streamCount)
+    {
+        var preferredBody = Math.Max(MinBodyRows, bodyCount);
+        var preferredStream = Math.Max(MinStreamRows, streamCount);
+        var preferredTotal = preferredBody + preferredStream;
+        if (preferredTotal <= dynamicRows)
+        {
+            return (preferredBody, preferredStream);
+        }
+
+        var streamRows = Math.Min(preferredStream, Math.Max(MinStreamRows, dynamicRows / 3));
+        var bodyRows = dynamicRows - streamRows;
+        if (bodyRows < MinBodyRows)
+        {
+            bodyRows = MinBodyRows;
+            streamRows = Math.Max(MinStreamRows, dynamicRows - bodyRows);
+        }
+
+        return (Math.Max(1, bodyRows), Math.Max(1, streamRows));
+    }
+
+    private static IReadOnlyList<string> SliceRows(
+        IReadOnlyList<string> source,
+        int viewportRows,
+        ref int offset,
+        bool followTail)
+    {
+        viewportRows = Math.Max(1, viewportRows);
+        var rows = source.Count == 0 ? new List<string> { string.Empty } : source.ToList();
+        var maxOffset = Math.Max(0, rows.Count - viewportRows);
+        if (followTail)
+        {
+            offset = maxOffset;
+        }
+
+        offset = Math.Clamp(offset, 0, maxOffset);
+        var visible = rows.Skip(offset).Take(viewportRows).ToList();
+        while (visible.Count < viewportRows)
+        {
+            visible.Add(string.Empty);
+        }
+
+        var hiddenAbove = offset;
+        var hiddenBelow = Math.Max(0, rows.Count - (offset + visible.Count));
+        if (hiddenAbove > 0 && visible.Count > 0)
+        {
+            visible[0] = $"... {hiddenAbove} line(s) above ...";
+        }
+
+        if (hiddenBelow > 0 && visible.Count > 1)
+        {
+            visible[^1] = $"... {hiddenBelow} line(s) below ...";
+        }
+
+        return visible;
     }
 
     private static string PadRight(string value, int width)


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Aligns Inspector and Hierarchy TUI rendering behavior with Project mode by using content-based viewport sizing instead of fixed row caps.
  - Keeps headers pinned while body/log panes scroll through overflow content.
  - Removes mocked `UnityCLI:` prompt-echo lines from in-window log panes and hides the extra log pane when there is no non-mock content.
  - Adds explicit scroll commands for in-frame navigation:
    - Inspector: `scroll [body|stream] <up|down> [count]`
    - Hierarchy: `scroll [tree|log] <up|down> [count]`
  - Adds missing `ProjectViewState.CommandTranscript` property referenced by session reset.
- Why is this change needed?
  - Inspector/Hierarchy previously truncated content with hard-coded heights, which diverged from Project mode behavior and made long lists/logs inaccessible.
  - Prompt-echo log lines added visual noise and looked like mock output inside frame windows.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Services/InspectorTuiRenderer.cs`
  - `src/unifocl/Services/InspectorModeService.cs`
  - `src/unifocl/Services/HierarchyTui.cs`
  - `src/unifocl/Models/InspectorModels.cs`
  - `src/unifocl/Program.cs`
  - `src/unifocl/Models/ProjectViewModels.cs`
- Out-of-scope / intentionally not addressed:
  - No protocol/model changes in `src/unifocl.unity`.
  - No daemon command contract changes.

## How to Test
1. Build the CLI project:
   - `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Run CLI and enter Inspector mode on a target with enough components/fields/log output.
3. Confirm:
   - Header remains pinned.
   - Body/stream panes are content-sized and scrollable.
   - `scroll [body|stream] up|down [n]` works.
   - No `UnityCLI:` mock prompt-echo lines are shown in the in-window stream.
4. Run `/hierarchy` and confirm:
   - Header remains pinned.
   - Tree/log panes are content-sized and scrollable.
   - `scroll [tree|log] up|down [n]` works.
   - Log pane is hidden when empty/non-applicable.

Expected results:
- No truncation from fixed pane heights.
- Overflow is navigable via scroll commands with visible above/below indicators.
- Build succeeds.

## Screenshots / Terminal Output (if applicable)
- Build output (local): success
  - `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
  - Warnings observed: `NU1900` (nuget vulnerability feed not reachable in sandbox network)

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Changes are limited to TUI rendering/state and command routing in existing local CLI workflows.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
