### PR TITLE
Mirror fuzzy keybindings in command intellisense

### DIFF
--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -303,19 +303,19 @@ static string? ReadInteractiveInput(
     CliSessionState session)
 {
     var input = new StringBuilder();
-    var selectedFuzzyCandidateIndex = 0;
-    var renderedLines = RenderComposerFrame(input.ToString(), commands, projectCommands, session, selectedFuzzyCandidateIndex);
+    var selectedIntellisenseCandidateIndex = 0;
+    var renderedLines = RenderComposerFrame(input.ToString(), commands, projectCommands, session, selectedIntellisenseCandidateIndex);
 
     while (true)
     {
-        _ = TryGetFuzzyComposerCandidates(input.ToString(), session, out var fuzzyCandidates, out _, out _);
-        if (fuzzyCandidates.Count == 0)
+        _ = TryGetComposerIntellisenseCandidates(input.ToString(), commands, projectCommands, session, out var candidates);
+        if (candidates.Count == 0)
         {
-            selectedFuzzyCandidateIndex = 0;
+            selectedIntellisenseCandidateIndex = 0;
         }
         else
         {
-            selectedFuzzyCandidateIndex = Math.Clamp(selectedFuzzyCandidateIndex, 0, fuzzyCandidates.Count - 1);
+            selectedIntellisenseCandidateIndex = Math.Clamp(selectedIntellisenseCandidateIndex, 0, candidates.Count - 1);
         }
 
         var key = Console.ReadKey(intercept: true);
@@ -324,12 +324,12 @@ static string? ReadInteractiveInput(
         {
             case ConsoleKey.Enter:
                 Console.WriteLine();
-                if (fuzzyCandidates.Count > 0
-                    && selectedFuzzyCandidateIndex >= 0
-                    && selectedFuzzyCandidateIndex < fuzzyCandidates.Count
-                    && !string.IsNullOrWhiteSpace(fuzzyCandidates[selectedFuzzyCandidateIndex].CommitCommand))
+                if (candidates.Count > 0
+                    && selectedIntellisenseCandidateIndex >= 0
+                    && selectedIntellisenseCandidateIndex < candidates.Count
+                    && !string.IsNullOrWhiteSpace(candidates[selectedIntellisenseCandidateIndex].CommitCommand))
                 {
-                    return fuzzyCandidates[selectedFuzzyCandidateIndex].CommitCommand!;
+                    return candidates[selectedIntellisenseCandidateIndex].CommitCommand!;
                 }
 
                 return input.ToString();
@@ -341,22 +341,22 @@ static string? ReadInteractiveInput(
                 break;
             case ConsoleKey.Escape:
                 input.Clear();
-                selectedFuzzyCandidateIndex = 0;
+                selectedIntellisenseCandidateIndex = 0;
                 break;
             case ConsoleKey.UpArrow:
-                if (fuzzyCandidates.Count > 0)
+                if (candidates.Count > 0)
                 {
-                    selectedFuzzyCandidateIndex = selectedFuzzyCandidateIndex <= 0
-                        ? fuzzyCandidates.Count - 1
-                        : selectedFuzzyCandidateIndex - 1;
+                    selectedIntellisenseCandidateIndex = selectedIntellisenseCandidateIndex <= 0
+                        ? candidates.Count - 1
+                        : selectedIntellisenseCandidateIndex - 1;
                 }
                 break;
             case ConsoleKey.DownArrow:
-                if (fuzzyCandidates.Count > 0)
+                if (candidates.Count > 0)
                 {
-                    selectedFuzzyCandidateIndex = selectedFuzzyCandidateIndex >= fuzzyCandidates.Count - 1
+                    selectedIntellisenseCandidateIndex = selectedIntellisenseCandidateIndex >= candidates.Count - 1
                         ? 0
-                        : selectedFuzzyCandidateIndex + 1;
+                        : selectedIntellisenseCandidateIndex + 1;
                 }
                 break;
             default:
@@ -368,7 +368,7 @@ static string? ReadInteractiveInput(
         }
 
         ClearComposerFrame(renderedLines);
-        renderedLines = RenderComposerFrame(input.ToString(), commands, projectCommands, session, selectedFuzzyCandidateIndex);
+        renderedLines = RenderComposerFrame(input.ToString(), commands, projectCommands, session, selectedIntellisenseCandidateIndex);
     }
 }
 
@@ -388,7 +388,7 @@ static int RenderComposerFrame(
     if (input.StartsWith('/'))
     {
         lines.Add(string.Empty);
-        lines.AddRange(GetSuggestionLines(input, commands));
+        lines.AddRange(GetSuggestionLines(input, commands, selectedFuzzyCandidateIndex));
     }
     else if (TryGetFuzzyQueryIntellisenseLines(input, session, selectedFuzzyCandidateIndex, out var fuzzyLines))
     {
@@ -398,7 +398,7 @@ static int RenderComposerFrame(
     else if (!string.IsNullOrWhiteSpace(input))
     {
         lines.Add(string.Empty);
-        lines.AddRange(GetSuggestionLines(input, projectCommands));
+        lines.AddRange(GetSuggestionLines(input, projectCommands, selectedFuzzyCandidateIndex));
     }
     else if (session.Inspector is not null)
     {
@@ -506,24 +506,80 @@ static void SeedBootLog(List<string> streamLog)
     streamLog.Add(string.Empty);
 }
 
-static IEnumerable<string> GetSuggestionLines(string query, List<CommandSpec> commands)
+static bool TryGetComposerIntellisenseCandidates(
+    string input,
+    List<CommandSpec> commands,
+    List<CommandSpec> projectCommands,
+    CliSessionState session,
+    out List<(string Label, string? CommitCommand)> candidates)
+{
+    candidates = [];
+
+    if (TryGetFuzzyComposerCandidates(input, session, out var fuzzyCandidates, out _, out _))
+    {
+        candidates = fuzzyCandidates
+            .Select(candidate => (candidate.Path, candidate.CommitCommand))
+            .ToList();
+        return true;
+    }
+
+    if (input.StartsWith('/'))
+    {
+        candidates = GetSuggestionMatches(input, commands)
+            .Select(match => (match.Signature, (string?)match.Trigger))
+            .ToList();
+        return true;
+    }
+
+    if (!string.IsNullOrWhiteSpace(input))
+    {
+        candidates = GetSuggestionMatches(input, projectCommands)
+            .Select(match => (match.Signature, (string?)match.Trigger))
+            .ToList();
+        return true;
+    }
+
+    return false;
+}
+
+static IEnumerable<string> GetSuggestionLines(string query, List<CommandSpec> commands, int selectedSuggestionIndex)
+{
+    var matches = GetSuggestionMatches(query, commands);
+    if (matches.Count == 0)
+    {
+        return new[]
+        {
+            "[grey]intellisense[/]: command suggestions [dim](up/down + enter)[/]",
+            $"[dim]no matches for {Markup.Escape(query)}[/]"
+        };
+    }
+
+    var selected = Math.Clamp(selectedSuggestionIndex, 0, matches.Count - 1);
+    var lines = new List<string>
+    {
+        "[grey]intellisense[/]: command suggestions [dim](up/down + enter)[/]"
+    };
+    for (var i = 0; i < matches.Count; i++)
+    {
+        var match = matches[i];
+        var prefix = i == selected ? "[green]>[/]" : "[grey] [/]";
+        var signatureColor = i == selected ? "green" : "grey";
+        lines.Add($"{prefix} [{signatureColor}]{Markup.Escape(match.Signature)}[/] [dim]- {Markup.Escape(match.Description)}[/]");
+    }
+
+    return lines;
+}
+
+static List<CommandSpec> GetSuggestionMatches(string query, List<CommandSpec> commands)
 {
     var normalized = query.Trim().ToLowerInvariant();
-    var matches = commands
+    return commands
         .Where(c => c.Signature.Contains(normalized, StringComparison.OrdinalIgnoreCase)
                     || c.Description.Contains(normalized, StringComparison.OrdinalIgnoreCase)
                     || c.Trigger.StartsWith(normalized, StringComparison.OrdinalIgnoreCase)
                     || normalized.StartsWith(c.Trigger, StringComparison.OrdinalIgnoreCase))
         .Take(14)
         .ToList();
-
-    if (matches.Count == 0)
-    {
-        return new[] { $"[dim]no matches for {Markup.Escape(query)}[/]" };
-    }
-
-    return matches.Select(match =>
-        $"[grey]{Markup.Escape(match.Signature)}[/] [dim]- {Markup.Escape(match.Description)}[/]");
 }
 
 static bool TryGetFuzzyQueryIntellisenseLines(string input, CliSessionState session, int selectedFuzzyCandidateIndex, out List<string> lines)


### PR DESCRIPTION
## Summary
- Mirror fuzzy finder keyboard behavior in general command IntelliSense.
- Add selectable IntelliSense rows for slash commands and project commands, with wrap-around Up/Down navigation and Enter-to-commit.
- Keep fuzzy mode behavior intact while sharing candidate selection logic.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
- `src/unifocl/Program.cs` interactive composer/input loop and suggestion rendering.
- Out-of-scope / intentionally not addressed:
- Any daemon/project command execution logic beyond composer selection/commit behavior.

## How to Test
1. Run `dotnet build src/unifocl/unifocl.csproj`.
2. Start the CLI and type `/` then a partial slash command (for example `/da`).
3. Use Up/Down to move selection, then press Enter to commit the selected suggestion.
4. In project mode, type a partial project command (for example `re`), use Up/Down, then Enter.
5. Verify fuzzy query (`f <query>`) still supports Up/Down and Enter commit as before.

Expected results:
- Slash and project command IntelliSense suggestions are navigable with Up/Down and commit with Enter.
- Selection wraps around at top/bottom.
- Fuzzy behavior remains consistent.

## Screenshots / Terminal Output (if applicable)
- `dotnet build src/unifocl/unifocl.csproj` succeeded with 0 errors.
- Existing NU1900 warnings were observed due to vulnerability-feed/network access in this environment.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Input handling and rendering changes only.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
