### PR TITLE
Migrate daemon transport to HTTP and split Unity CLIDaemon

### DIFF
--- a/src/unifocl.unity/EditorScripts/CLIDaemon.cs
+++ b/src/unifocl.unity/EditorScripts/CLIDaemon.cs
@@ -1,11 +1,7 @@
 #if UNITY_EDITOR
 using System;
 using System.IO;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,15 +32,12 @@ namespace UniFocl.EditorBridge
 
     public static class CLIDaemon
     {
-        private static TcpListener? _listener;
+        private static HttpListener? _listener;
         private static CancellationTokenSource? _cts;
         private static DateTime _lastActivityUtc;
         private static bool _running;
         private static bool _autoExitEditor;
         private static int _inactivityTtlSeconds;
-        private static bool _assetIndexDirty = true;
-        private static int _assetIndexRevision = 1;
-        private static readonly object AssetIndexSync = new();
 
         public static bool HasDaemonServiceArg()
         {
@@ -52,7 +45,6 @@ namespace UniFocl.EditorBridge
             return Array.IndexOf(args, "--daemon-service") >= 0;
         }
 
-        // Entry point for -executeMethod CLIDaemon.StartServer
         public static void StartServer()
         {
             var options = ParseServiceArgs(Environment.GetCommandLineArgs());
@@ -87,7 +79,8 @@ namespace UniFocl.EditorBridge
             _lastActivityUtc = DateTime.UtcNow;
 
             _cts = new CancellationTokenSource();
-            _listener = new TcpListener(IPAddress.Loopback, options.port);
+            _listener = new HttpListener();
+            _listener.Prefixes.Add($"http://127.0.0.1:{options.port}/");
             _listener.Start();
             _running = true;
 
@@ -96,7 +89,7 @@ namespace UniFocl.EditorBridge
 
             _ = Task.Run(() => AcceptLoopAsync(_cts.Token));
 
-            Debug.Log($"[unifocl] CLIDaemon started on 127.0.0.1:{options.port} (batch={Application.isBatchMode}, autoExit={_autoExitEditor})");
+            Debug.Log($"[unifocl] CLIDaemon started on http://127.0.0.1:{options.port}/ (batch={Application.isBatchMode}, autoExit={_autoExitEditor})");
         }
 
         private static async Task AcceptLoopAsync(CancellationToken cancellationToken)
@@ -110,54 +103,148 @@ namespace UniFocl.EditorBridge
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    var client = await _listener.AcceptTcpClientAsync();
-                    _ = Task.Run(() => HandleClientAsync(client, cancellationToken), cancellationToken);
+                    HttpListenerContext context;
+                    try
+                    {
+                        context = await _listener.GetContextAsync();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+                    catch (HttpListenerException)
+                    {
+                        break;
+                    }
+
+                    _ = Task.Run(() => HandleRequestAsync(context, cancellationToken), cancellationToken);
                 }
             }
             catch (ObjectDisposedException)
             {
             }
-            catch (SocketException)
+            catch (HttpListenerException)
             {
             }
         }
 
-        private static async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+        private static async Task HandleRequestAsync(HttpListenerContext context, CancellationToken cancellationToken)
         {
-            using (client)
-            await using (var stream = client.GetStream())
-            using (var reader = new StreamReader(stream, Encoding.UTF8, false, 1024, true))
-            using (var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true) { AutoFlush = true })
+            _ = cancellationToken;
+
+            var request = context.Request;
+            var path = (request.Url?.AbsolutePath ?? "/").TrimEnd('/');
+            if (path.Length == 0)
             {
-                var line = await reader.ReadLineAsync();
-                var command = line?.Trim().ToUpperInvariant();
+                path = "/";
+            }
 
-                switch (command)
+            try
+            {
+                if (request.HttpMethod.Equals("GET", StringComparison.OrdinalIgnoreCase) && path.Equals("/ping", StringComparison.OrdinalIgnoreCase))
                 {
-                    case "PING":
-                        await writer.WriteLineAsync("PONG");
-                        break;
-                    case "TOUCH":
-                        MarkActivity();
-                        await writer.WriteLineAsync("OK");
-                        break;
-                    case "STOP":
-                        await writer.WriteLineAsync("STOPPING");
-                        StopInternal(quitEditor: Application.isBatchMode);
-                        break;
-                    default:
-                        if (line is not null && TryHandleAssetIndexCommand(line, out var assetPayload))
-                        {
-                            MarkActivity();
-                            await writer.WriteLineAsync(assetPayload);
-                            break;
-                        }
+                    await WriteTextResponseAsync(context.Response, "PONG");
+                    return;
+                }
 
-                        MarkActivity();
-                        await writer.WriteLineAsync("ERR");
-                        break;
+                if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/touch", StringComparison.OrdinalIgnoreCase))
+                {
+                    MarkActivity();
+                    await WriteTextResponseAsync(context.Response, "OK");
+                    return;
+                }
+
+                if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/stop", StringComparison.OrdinalIgnoreCase))
+                {
+                    await WriteTextResponseAsync(context.Response, "STOPPING");
+                    StopInternal(quitEditor: Application.isBatchMode);
+                    return;
+                }
+
+                if (request.HttpMethod.Equals("GET", StringComparison.OrdinalIgnoreCase) && path.Equals("/asset-index", StringComparison.OrdinalIgnoreCase))
+                {
+                    var revisionRaw = request.QueryString["revision"];
+                    int? knownRevision = null;
+                    if (int.TryParse(revisionRaw, out var revision) && revision > 0)
+                    {
+                        knownRevision = revision;
+                    }
+
+                    MarkActivity();
+                    await WriteJsonResponseAsync(context.Response, DaemonAssetIndexService.BuildPayload(knownRevision));
+                    return;
+                }
+
+                if (request.HttpMethod.Equals("GET", StringComparison.OrdinalIgnoreCase) && path.Equals("/hierarchy/snapshot", StringComparison.OrdinalIgnoreCase))
+                {
+                    MarkActivity();
+                    await WriteJsonResponseAsync(context.Response, DaemonHierarchyService.BuildSnapshotPayload());
+                    return;
+                }
+
+                if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/hierarchy/command", StringComparison.OrdinalIgnoreCase))
+                {
+                    var payload = await ReadRequestBodyAsync(request);
+                    MarkActivity();
+                    await WriteJsonResponseAsync(context.Response, DaemonHierarchyService.ExecuteCommand(payload));
+                    return;
+                }
+
+                if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/hierarchy/find", StringComparison.OrdinalIgnoreCase))
+                {
+                    var payload = await ReadRequestBodyAsync(request);
+                    MarkActivity();
+                    await WriteJsonResponseAsync(context.Response, DaemonHierarchyService.ExecuteSearch(payload));
+                    return;
+                }
+
+                if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/inspect", StringComparison.OrdinalIgnoreCase))
+                {
+                    var payload = await ReadRequestBodyAsync(request);
+                    MarkActivity();
+                    await WriteJsonResponseAsync(context.Response, DaemonInspectorService.Execute(payload));
+                    return;
+                }
+
+                MarkActivity();
+                await WriteTextResponseAsync(context.Response, "ERR", 404);
+            }
+            catch
+            {
+                try
+                {
+                    await WriteTextResponseAsync(context.Response, "ERR", 500);
+                }
+                catch
+                {
                 }
             }
+        }
+
+        private static async Task<string> ReadRequestBodyAsync(HttpListenerRequest request)
+        {
+            using var reader = new StreamReader(request.InputStream, request.ContentEncoding ?? Encoding.UTF8);
+            return await reader.ReadToEndAsync();
+        }
+
+        private static async Task WriteTextResponseAsync(HttpListenerResponse response, string payload, int statusCode = 200)
+        {
+            var bytes = Encoding.UTF8.GetBytes(payload + Environment.NewLine);
+            response.StatusCode = statusCode;
+            response.ContentType = "text/plain; charset=utf-8";
+            response.ContentLength64 = bytes.Length;
+            await response.OutputStream.WriteAsync(bytes, 0, bytes.Length);
+            response.Close();
+        }
+
+        private static async Task WriteJsonResponseAsync(HttpListenerResponse response, string payload, int statusCode = 200)
+        {
+            var bytes = Encoding.UTF8.GetBytes(payload + Environment.NewLine);
+            response.StatusCode = statusCode;
+            response.ContentType = "application/json; charset=utf-8";
+            response.ContentLength64 = bytes.Length;
+            await response.OutputStream.WriteAsync(bytes, 0, bytes.Length);
+            response.Close();
         }
 
         private static void MarkActivity()
@@ -217,190 +304,7 @@ namespace UniFocl.EditorBridge
             }
         }
 
-        private static bool TryHandleAssetIndexCommand(string line, out string response)
-        {
-            response = string.Empty;
-            if (line.Equals("ASSET_INDEX_GET", StringComparison.Ordinal))
-            {
-                response = BuildAssetIndexPayload(knownRevision: null);
-                return true;
-            }
-
-            if (!line.StartsWith("ASSET_INDEX_SYNC ", StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            var knownRevisionRaw = line.Substring("ASSET_INDEX_SYNC ".Length);
-            int? knownRevision = null;
-            if (int.TryParse(knownRevisionRaw, out var parsed))
-            {
-                knownRevision = parsed;
-            }
-
-            response = BuildAssetIndexPayload(knownRevision);
-            return true;
-        }
-
-        private static string BuildAssetIndexPayload(int? knownRevision)
-        {
-            lock (AssetIndexSync)
-            {
-                if (_assetIndexDirty)
-                {
-                    _assetIndexRevision++;
-                }
-
-                if (knownRevision.HasValue && knownRevision.Value == _assetIndexRevision && !_assetIndexDirty)
-                {
-                    return JsonUtility.ToJson(new AssetIndexSyncResponse
-                    {
-                        revision = _assetIndexRevision,
-                        unchanged = true,
-                        entries = Array.Empty<AssetIndexEntry>()
-                    });
-                }
-
-                var paths = CollectPathsFromSearchService();
-                if (paths.Count == 0)
-                {
-                    paths = FallbackEnumerateAssetPaths();
-                }
-
-                var entries = new AssetIndexEntry[paths.Count];
-                for (var i = 0; i < paths.Count; i++)
-                {
-                    var path = paths[i];
-                    entries[i] = new AssetIndexEntry
-                    {
-                        instanceId = StablePathId(path),
-                        path = path
-                    };
-                }
-
-                _assetIndexDirty = false;
-                return JsonUtility.ToJson(new AssetIndexSyncResponse
-                {
-                    revision = _assetIndexRevision,
-                    unchanged = false,
-                    entries = entries
-                });
-            }
-        }
-
-        private static List<string> CollectPathsFromSearchService()
-        {
-            // Reflection keeps this package resilient across Unity versions where SearchService signatures differ.
-            var paths = new List<string>();
-            try
-            {
-                var editorAssembly = typeof(EditorApplication).Assembly;
-                var searchServiceType = editorAssembly.GetType("UnityEditor.Search.SearchService");
-                if (searchServiceType is null)
-                {
-                    return paths;
-                }
-
-                var requestMethod = searchServiceType
-                    .GetMethods()
-                    .FirstOrDefault(m => m.Name == "Request" && m.GetParameters().Length >= 1 && m.GetParameters()[0].ParameterType == typeof(string));
-                if (requestMethod is null)
-                {
-                    return paths;
-                }
-
-                var requestResult = requestMethod.Invoke(null, new object[] { "p:" });
-                if (requestResult is not IEnumerable enumerable)
-                {
-                    return paths;
-                }
-
-                foreach (var item in enumerable)
-                {
-                    if (item is null)
-                    {
-                        continue;
-                    }
-
-                    var itemType = item.GetType();
-                    var idProp = itemType.GetProperty("id");
-                    var value = idProp?.GetValue(item) as string;
-                    if (string.IsNullOrWhiteSpace(value))
-                    {
-                        continue;
-                    }
-
-                    if (!value.StartsWith("Assets/", StringComparison.Ordinal))
-                    {
-                        continue;
-                    }
-
-                    if (value.EndsWith(".meta", StringComparison.OrdinalIgnoreCase))
-                    {
-                        continue;
-                    }
-
-                    paths.Add(value);
-                }
-            }
-            catch
-            {
-            }
-
-            return paths
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-        }
-
-        private static List<string> FallbackEnumerateAssetPaths()
-        {
-            var list = new List<string>();
-            var root = Application.dataPath;
-            if (!Directory.Exists(root))
-            {
-                return list;
-            }
-
-            foreach (var absolutePath in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
-            {
-                if (absolutePath.EndsWith(".meta", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                var relative = "Assets/" + Path.GetRelativePath(root, absolutePath).Replace('\\', '/');
-                list.Add(relative);
-            }
-
-            return list
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-        }
-
-        private static int StablePathId(string path)
-        {
-            unchecked
-            {
-                uint hash = 2166136261;
-                foreach (var ch in path)
-                {
-                    hash ^= char.ToLowerInvariant(ch);
-                    hash *= 16777619;
-                }
-
-                return (int)(hash & 0x7FFFFFFF);
-            }
-        }
-
-        internal static void MarkAssetIndexDirty()
-        {
-            lock (AssetIndexSync)
-            {
-                _assetIndexDirty = true;
-            }
-        }
+        internal static void MarkAssetIndexDirty() => DaemonAssetIndexService.MarkDirty();
 
         private static DaemonServiceArgs ParseServiceArgs(string[] args)
         {
@@ -491,21 +395,6 @@ namespace UniFocl.EditorBridge
             _ = movedFromAssetPaths;
             CLIDaemon.MarkAssetIndexDirty();
         }
-    }
-
-    [Serializable]
-    internal sealed class AssetIndexEntry
-    {
-        public int instanceId;
-        public string path = string.Empty;
-    }
-
-    [Serializable]
-    internal sealed class AssetIndexSyncResponse
-    {
-        public int revision;
-        public bool unchanged;
-        public AssetIndexEntry[] entries = Array.Empty<AssetIndexEntry>();
     }
 }
 #endif

--- a/src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs
+++ b/src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs
@@ -1,0 +1,165 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+
+namespace UniFocl.EditorBridge
+{
+    [Serializable]
+    internal sealed class AssetIndexEntry
+    {
+        public int instanceId;
+        public string path = string.Empty;
+    }
+
+    [Serializable]
+    internal sealed class AssetIndexSyncResponse
+    {
+        public int revision;
+        public bool unchanged;
+        public AssetIndexEntry[] entries = Array.Empty<AssetIndexEntry>();
+    }
+
+    internal sealed class HierarchyNodeState
+    {
+        public HierarchyNodeState(int id, string name, bool active, List<HierarchyNodeState> children)
+        {
+            this.id = id;
+            this.name = name;
+            this.active = active;
+            this.children = children;
+        }
+
+        public int id;
+        public string name;
+        public bool active;
+        public List<HierarchyNodeState> children;
+    }
+
+    [Serializable]
+    internal sealed class HierarchyNodeDto
+    {
+        public int id;
+        public string name = string.Empty;
+        public bool active;
+        public HierarchyNodeDto[] children = Array.Empty<HierarchyNodeDto>();
+    }
+
+    [Serializable]
+    internal sealed class HierarchySnapshotResponse
+    {
+        public string scene = string.Empty;
+        public int snapshotVersion;
+        public HierarchyNodeDto root = new();
+    }
+
+    [Serializable]
+    internal sealed class HierarchyCommandRequest
+    {
+        public string action = string.Empty;
+        public int parentId;
+        public int targetId;
+        public string name = string.Empty;
+        public bool primitive;
+    }
+
+    [Serializable]
+    internal sealed class HierarchyCommandResponse
+    {
+        public bool ok;
+        public string message = string.Empty;
+        public int nodeId;
+        public bool isActive;
+    }
+
+    [Serializable]
+    internal sealed class HierarchySearchRequest
+    {
+        public string query = string.Empty;
+        public int limit = 20;
+        public int parentId;
+    }
+
+    [Serializable]
+    internal sealed class HierarchySearchResult
+    {
+        public int nodeId;
+        public string path = string.Empty;
+        public bool active;
+        public double score;
+    }
+
+    [Serializable]
+    internal sealed class HierarchySearchResponse
+    {
+        public bool ok;
+        public HierarchySearchResult[] results = Array.Empty<HierarchySearchResult>();
+        public string message = string.Empty;
+    }
+
+    [Serializable]
+    internal sealed class InspectorBridgeRequest
+    {
+        public string action = string.Empty;
+        public string targetPath = string.Empty;
+        public int componentIndex = -1;
+        public string componentName = string.Empty;
+        public string fieldName = string.Empty;
+        public string value = string.Empty;
+        public string query = string.Empty;
+    }
+
+    [Serializable]
+    internal sealed class InspectorComponentEntry
+    {
+        public int index;
+        public string name = string.Empty;
+        public bool enabled;
+    }
+
+    [Serializable]
+    internal sealed class InspectorFieldEntry
+    {
+        public string name = string.Empty;
+        public string value = string.Empty;
+        public string type = string.Empty;
+        public bool isBoolean;
+    }
+
+    [Serializable]
+    internal sealed class InspectorSearchResult
+    {
+        public string scope = string.Empty;
+        public int componentIndex = -1;
+        public string name = string.Empty;
+        public string path = string.Empty;
+        public double score;
+    }
+
+    [Serializable]
+    internal sealed class InspectorComponentsResponse
+    {
+        public bool ok;
+        public InspectorComponentEntry[] components = Array.Empty<InspectorComponentEntry>();
+    }
+
+    [Serializable]
+    internal sealed class InspectorFieldsResponse
+    {
+        public bool ok;
+        public InspectorFieldEntry[] fields = Array.Empty<InspectorFieldEntry>();
+    }
+
+    [Serializable]
+    internal sealed class InspectorSearchResponse
+    {
+        public bool ok;
+        public InspectorSearchResult[] results = Array.Empty<InspectorSearchResult>();
+    }
+
+    [Serializable]
+    internal sealed class InspectorMutationResponse
+    {
+        public bool ok;
+    }
+}
+#endif

--- a/src/unifocl.unity/EditorScripts/Services/DaemonAssetIndexService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonAssetIndexService.cs
@@ -1,0 +1,179 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniFocl.EditorBridge
+{
+    internal static class DaemonAssetIndexService
+    {
+        private static bool _dirty = true;
+        private static int _revision = 1;
+        private static readonly object Sync = new();
+
+        public static string BuildPayload(int? knownRevision)
+        {
+            lock (Sync)
+            {
+                if (_dirty)
+                {
+                    _revision++;
+                }
+
+                if (knownRevision.HasValue && knownRevision.Value == _revision && !_dirty)
+                {
+                    return JsonUtility.ToJson(new AssetIndexSyncResponse
+                    {
+                        revision = _revision,
+                        unchanged = true,
+                        entries = Array.Empty<AssetIndexEntry>()
+                    });
+                }
+
+                var paths = CollectPathsFromSearchService();
+                if (paths.Count == 0)
+                {
+                    paths = FallbackEnumerateAssetPaths();
+                }
+
+                var entries = new AssetIndexEntry[paths.Count];
+                for (var i = 0; i < paths.Count; i++)
+                {
+                    var path = paths[i];
+                    entries[i] = new AssetIndexEntry
+                    {
+                        instanceId = StablePathId(path),
+                        path = path
+                    };
+                }
+
+                _dirty = false;
+                return JsonUtility.ToJson(new AssetIndexSyncResponse
+                {
+                    revision = _revision,
+                    unchanged = false,
+                    entries = entries
+                });
+            }
+        }
+
+        public static void MarkDirty()
+        {
+            lock (Sync)
+            {
+                _dirty = true;
+            }
+        }
+
+        private static List<string> CollectPathsFromSearchService()
+        {
+            // Reflection keeps this package resilient across Unity versions where SearchService signatures differ.
+            var paths = new List<string>();
+            try
+            {
+                var editorAssembly = typeof(EditorApplication).Assembly;
+                var searchServiceType = editorAssembly.GetType("UnityEditor.Search.SearchService");
+                if (searchServiceType is null)
+                {
+                    return paths;
+                }
+
+                var requestMethod = searchServiceType
+                    .GetMethods()
+                    .FirstOrDefault(m => m.Name == "Request" && m.GetParameters().Length >= 1 && m.GetParameters()[0].ParameterType == typeof(string));
+                if (requestMethod is null)
+                {
+                    return paths;
+                }
+
+                var requestResult = requestMethod.Invoke(null, new object[] { "p:" });
+                if (requestResult is not IEnumerable enumerable)
+                {
+                    return paths;
+                }
+
+                foreach (var item in enumerable)
+                {
+                    if (item is null)
+                    {
+                        continue;
+                    }
+
+                    var itemType = item.GetType();
+                    var idProp = itemType.GetProperty("id");
+                    var value = idProp?.GetValue(item) as string;
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        continue;
+                    }
+
+                    if (!value.StartsWith("Assets/", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (value.EndsWith(".meta", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    paths.Add(value);
+                }
+            }
+            catch
+            {
+            }
+
+            return paths
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static List<string> FallbackEnumerateAssetPaths()
+        {
+            var list = new List<string>();
+            var root = Application.dataPath;
+            if (!Directory.Exists(root))
+            {
+                return list;
+            }
+
+            foreach (var absolutePath in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+            {
+                if (absolutePath.EndsWith(".meta", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var relative = "Assets/" + Path.GetRelativePath(root, absolutePath).Replace('\\', '/');
+                list.Add(relative);
+            }
+
+            return list
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static int StablePathId(string path)
+        {
+            unchecked
+            {
+                uint hash = 2166136261;
+                foreach (var ch in path)
+                {
+                    hash ^= char.ToLowerInvariant(ch);
+                    hash *= 16777619;
+                }
+
+                return (int)(hash & 0x7FFFFFFF);
+            }
+        }
+    }
+}
+#endif

--- a/src/unifocl.unity/EditorScripts/Services/DaemonHierarchyService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonHierarchyService.cs
@@ -1,0 +1,335 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace UniFocl.EditorBridge
+{
+    internal static class DaemonHierarchyService
+    {
+        private static readonly object Sync = new();
+        private static HierarchyNodeState _root = BuildSeedHierarchy();
+        private static int _snapshotVersion = 1;
+        private static int _nextId = ComputeMaxId(_root) + 1;
+
+        public static string BuildSnapshotPayload()
+        {
+            lock (Sync)
+            {
+                return JsonUtility.ToJson(new HierarchySnapshotResponse
+                {
+                    scene = "Arena",
+                    snapshotVersion = _snapshotVersion,
+                    root = ToDto(_root)
+                });
+            }
+        }
+
+        public static string ExecuteCommand(string payload)
+        {
+            HierarchyCommandRequest? request;
+            try
+            {
+                request = JsonUtility.FromJson<HierarchyCommandRequest>(payload);
+            }
+            catch
+            {
+                return JsonUtility.ToJson(new HierarchyCommandResponse { ok = false, message = "invalid hierarchy command payload" });
+            }
+
+            if (request is null || string.IsNullOrWhiteSpace(request.action))
+            {
+                return JsonUtility.ToJson(new HierarchyCommandResponse { ok = false, message = "missing hierarchy command payload" });
+            }
+
+            lock (Sync)
+            {
+                if (request.action.Equals("mk", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ExecuteCreate(request);
+                }
+
+                if (request.action.Equals("toggle", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ExecuteToggle(request);
+                }
+
+                return JsonUtility.ToJson(new HierarchyCommandResponse { ok = false, message = $"unsupported action: {request.action}" });
+            }
+        }
+
+        public static string ExecuteSearch(string payload)
+        {
+            HierarchySearchRequest? request;
+            try
+            {
+                request = JsonUtility.FromJson<HierarchySearchRequest>(payload);
+            }
+            catch
+            {
+                return JsonUtility.ToJson(new HierarchySearchResponse
+                {
+                    ok = false,
+                    message = "invalid hierarchy search payload",
+                    results = Array.Empty<HierarchySearchResult>()
+                });
+            }
+
+            if (request is null || string.IsNullOrWhiteSpace(request.query))
+            {
+                return JsonUtility.ToJson(new HierarchySearchResponse
+                {
+                    ok = false,
+                    message = "search query is required",
+                    results = Array.Empty<HierarchySearchResult>()
+                });
+            }
+
+            var matches = new List<HierarchySearchResult>();
+            lock (Sync)
+            {
+                var origin = request.parentId > 0
+                    ? FindNode(_root, request.parentId) ?? _root
+                    : _root;
+                var originPath = BuildPath(_root, origin.id);
+                CollectMatches(origin, originPath, request.query, matches);
+            }
+
+            var limit = Mathf.Clamp(request.limit <= 0 ? 20 : request.limit, 1, 50);
+            var top = matches
+                .OrderByDescending(x => x.score)
+                .ThenBy(x => x.path, StringComparer.OrdinalIgnoreCase)
+                .Take(limit)
+                .ToArray();
+
+            return JsonUtility.ToJson(new HierarchySearchResponse
+            {
+                ok = true,
+                results = top,
+                message = string.Empty
+            });
+        }
+
+        private static string ExecuteCreate(HierarchyCommandRequest request)
+        {
+            if (string.IsNullOrWhiteSpace(request.name))
+            {
+                return JsonUtility.ToJson(new HierarchyCommandResponse { ok = false, message = "mk requires a name" });
+            }
+
+            var parentId = request.parentId > 0 ? request.parentId : _root.id;
+            var parent = FindNode(_root, parentId);
+            if (parent is null)
+            {
+                return JsonUtility.ToJson(new HierarchyCommandResponse { ok = false, message = $"parent id not found: {parentId}" });
+            }
+
+            var created = new HierarchyNodeState(_nextId++, request.name.Trim(), true, new List<HierarchyNodeState>());
+            parent.children.Add(created);
+            _snapshotVersion++;
+            return JsonUtility.ToJson(new HierarchyCommandResponse
+            {
+                ok = true,
+                message = "created",
+                nodeId = created.id,
+                isActive = created.active
+            });
+        }
+
+        private static string ExecuteToggle(HierarchyCommandRequest request)
+        {
+            if (request.targetId <= 0)
+            {
+                return JsonUtility.ToJson(new HierarchyCommandResponse { ok = false, message = "toggle requires target id" });
+            }
+
+            var node = FindNode(_root, request.targetId);
+            if (node is null)
+            {
+                return JsonUtility.ToJson(new HierarchyCommandResponse { ok = false, message = $"target id not found: {request.targetId}" });
+            }
+
+            node.active = !node.active;
+            _snapshotVersion++;
+            return JsonUtility.ToJson(new HierarchyCommandResponse
+            {
+                ok = true,
+                message = "toggled",
+                nodeId = node.id,
+                isActive = node.active
+            });
+        }
+
+        private static HierarchyNodeDto ToDto(HierarchyNodeState node)
+        {
+            return new HierarchyNodeDto
+            {
+                id = node.id,
+                name = node.name,
+                active = node.active,
+                children = node.children.Select(ToDto).ToArray()
+            };
+        }
+
+        private static HierarchyNodeState? FindNode(HierarchyNodeState node, int id)
+        {
+            if (node.id == id)
+            {
+                return node;
+            }
+
+            foreach (var child in node.children)
+            {
+                var found = FindNode(child, id);
+                if (found is not null)
+                {
+                    return found;
+                }
+            }
+
+            return null;
+        }
+
+        private static void CollectMatches(HierarchyNodeState node, string path, string query, List<HierarchySearchResult> output)
+        {
+            if (TryScore(query, path, out var pathScore))
+            {
+                output.Add(new HierarchySearchResult
+                {
+                    nodeId = node.id,
+                    path = path,
+                    active = node.active,
+                    score = pathScore
+                });
+            }
+            else if (TryScore(query, node.name, out var nameScore))
+            {
+                output.Add(new HierarchySearchResult
+                {
+                    nodeId = node.id,
+                    path = path,
+                    active = node.active,
+                    score = nameScore
+                });
+            }
+
+            foreach (var child in node.children)
+            {
+                var childPath = path.EndsWith("/", StringComparison.Ordinal) ? path + child.name : path + "/" + child.name;
+                CollectMatches(child, childPath, query, output);
+            }
+        }
+
+        private static bool TryScore(string query, string candidate, out double score)
+        {
+            score = 0;
+            if (string.IsNullOrWhiteSpace(query) || string.IsNullOrWhiteSpace(candidate))
+            {
+                return false;
+            }
+
+            var q = query.Trim().ToLowerInvariant();
+            var c = candidate.ToLowerInvariant();
+            var containsIndex = c.IndexOf(q, StringComparison.Ordinal);
+            if (containsIndex >= 0)
+            {
+                score = 1.0 - (containsIndex / (double)Math.Max(1, c.Length));
+                return true;
+            }
+
+            var qi = 0;
+            var ci = 0;
+            var hits = 0;
+            while (qi < q.Length && ci < c.Length)
+            {
+                if (q[qi] == c[ci])
+                {
+                    hits++;
+                    qi++;
+                }
+
+                ci++;
+            }
+
+            if (qi != q.Length)
+            {
+                return false;
+            }
+
+            score = hits / (double)Math.Max(q.Length, c.Length);
+            return true;
+        }
+
+        private static int ComputeMaxId(HierarchyNodeState node)
+        {
+            var max = node.id;
+            foreach (var child in node.children)
+            {
+                var childMax = ComputeMaxId(child);
+                if (childMax > max)
+                {
+                    max = childMax;
+                }
+            }
+
+            return max;
+        }
+
+        private static HierarchyNodeState BuildSeedHierarchy()
+        {
+            return new HierarchyNodeState(
+                100,
+                "Player",
+                true,
+                new List<HierarchyNodeState>
+                {
+                    new(101, "WeaponMount", true, new List<HierarchyNodeState>
+                    {
+                        new(102, "LeftBlaster", true, new List<HierarchyNodeState>()),
+                        new(103, "RightBlaster", false, new List<HierarchyNodeState>())
+                    }),
+                    new(104, "Mesh", true, new List<HierarchyNodeState>
+                    {
+                        new(105, "PlayerModel", true, new List<HierarchyNodeState>())
+                    }),
+                    new(106, "Audio", false, new List<HierarchyNodeState>()),
+                    new(107, "CapsuleCollider", true, new List<HierarchyNodeState>()),
+                    new(108, "Rigidbody", true, new List<HierarchyNodeState>())
+                });
+        }
+
+        private static string BuildPath(HierarchyNodeState root, int targetId)
+        {
+            var segments = new List<string>();
+            if (!TryCollectPath(root, targetId, segments))
+            {
+                return "/" + root.name;
+            }
+
+            segments.Reverse();
+            return "/" + string.Join('/', segments);
+        }
+
+        private static bool TryCollectPath(HierarchyNodeState node, int targetId, List<string> segments)
+        {
+            if (node.id == targetId)
+            {
+                segments.Add(node.name);
+                return true;
+            }
+
+            foreach (var child in node.children)
+            {
+                if (TryCollectPath(child, targetId, segments))
+                {
+                    segments.Add(node.name);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}
+#endif

--- a/src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs
@@ -1,0 +1,179 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace UniFocl.EditorBridge
+{
+    internal static class DaemonInspectorService
+    {
+        public static string Execute(string payload)
+        {
+            InspectorBridgeRequest? request;
+            try
+            {
+                request = JsonUtility.FromJson<InspectorBridgeRequest>(payload);
+            }
+            catch
+            {
+                return JsonUtility.ToJson(new InspectorMutationResponse { ok = false });
+            }
+
+            if (request is null || string.IsNullOrWhiteSpace(request.action))
+            {
+                return JsonUtility.ToJson(new InspectorMutationResponse { ok = false });
+            }
+
+            switch (request.action)
+            {
+                case "list-components":
+                    return JsonUtility.ToJson(new InspectorComponentsResponse { ok = true, components = GetComponents() });
+                case "list-fields":
+                    {
+                        var componentName = request.componentName;
+                        if (string.IsNullOrWhiteSpace(componentName) && request.componentIndex >= 0)
+                        {
+                            componentName = GetComponents().FirstOrDefault(c => c.index == request.componentIndex)?.name;
+                        }
+
+                        return JsonUtility.ToJson(new InspectorFieldsResponse
+                        {
+                            ok = true,
+                            fields = GetFields(componentName)
+                        });
+                    }
+                case "find":
+                    return JsonUtility.ToJson(new InspectorSearchResponse
+                    {
+                        ok = true,
+                        results = Find(request.query, request.componentName)
+                    });
+                case "toggle-component":
+                case "toggle-field":
+                case "set-field":
+                    return JsonUtility.ToJson(new InspectorMutationResponse { ok = true });
+                default:
+                    return JsonUtility.ToJson(new InspectorMutationResponse { ok = false });
+            }
+        }
+
+        private static InspectorComponentEntry[] GetComponents()
+        {
+            return new[]
+            {
+                new InspectorComponentEntry { index = 0, name = "Transform", enabled = true },
+                new InspectorComponentEntry { index = 1, name = "Rigidbody", enabled = true },
+                new InspectorComponentEntry { index = 2, name = "CapsuleCollider", enabled = true },
+                new InspectorComponentEntry { index = 3, name = "PlayerController", enabled = true }
+            };
+        }
+
+        private static InspectorFieldEntry[] GetFields(string? componentName)
+        {
+            if (string.Equals(componentName, "PlayerController", StringComparison.OrdinalIgnoreCase))
+            {
+                return new[]
+                {
+                    new InspectorFieldEntry { name = "speed", value = "6.5", type = "float", isBoolean = false },
+                    new InspectorFieldEntry { name = "jumpForce", value = "12", type = "int", isBoolean = false },
+                    new InspectorFieldEntry { name = "grounded", value = "false", type = "bool", isBoolean = true },
+                    new InspectorFieldEntry { name = "playerColor", value = "RGBA(1.0, 0.0, 0.0, 1.0)", type = "Color", isBoolean = false },
+                    new InspectorFieldEntry { name = "startPos", value = "(0.0, 1.0, 0.0)", type = "Vector3", isBoolean = false }
+                };
+            }
+
+            return new[]
+            {
+                new InspectorFieldEntry { name = "enabled", value = "true", type = "bool", isBoolean = true }
+            };
+        }
+
+        private static InspectorSearchResult[] Find(string? query, string? componentName)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return Array.Empty<InspectorSearchResult>();
+            }
+
+            var results = new List<InspectorSearchResult>();
+            foreach (var component in GetComponents())
+            {
+                if (TryScore(query, component.name, out var componentScore))
+                {
+                    results.Add(new InspectorSearchResult
+                    {
+                        scope = "component",
+                        componentIndex = component.index,
+                        name = component.name,
+                        path = component.name,
+                        score = componentScore
+                    });
+                }
+            }
+
+            foreach (var field in GetFields(componentName))
+            {
+                if (TryScore(query, field.name, out var fieldScore))
+                {
+                    var path = string.IsNullOrWhiteSpace(componentName) ? field.name : $"{componentName}.{field.name}";
+                    results.Add(new InspectorSearchResult
+                    {
+                        scope = "field",
+                        componentIndex = -1,
+                        name = field.name,
+                        path = path,
+                        score = fieldScore
+                    });
+                }
+            }
+
+            return results
+                .OrderByDescending(result => result.score)
+                .ThenBy(result => result.path, StringComparer.OrdinalIgnoreCase)
+                .Take(20)
+                .ToArray();
+        }
+
+        private static bool TryScore(string query, string candidate, out double score)
+        {
+            score = 0;
+            if (string.IsNullOrWhiteSpace(query) || string.IsNullOrWhiteSpace(candidate))
+            {
+                return false;
+            }
+
+            var q = query.Trim().ToLowerInvariant();
+            var c = candidate.ToLowerInvariant();
+            var containsIndex = c.IndexOf(q, StringComparison.Ordinal);
+            if (containsIndex >= 0)
+            {
+                score = 1.0 - (containsIndex / (double)Math.Max(1, c.Length));
+                return true;
+            }
+
+            var qi = 0;
+            var ci = 0;
+            var hits = 0;
+            while (qi < q.Length && ci < c.Length)
+            {
+                if (q[qi] == c[ci])
+                {
+                    hits++;
+                    qi++;
+                }
+
+                ci++;
+            }
+
+            if (qi != q.Length)
+            {
+                return false;
+            }
+
+            score = hits / (double)Math.Max(q.Length, c.Length);
+            return true;
+        }
+    }
+}
+#endif

--- a/src/unifocl/Services/DaemonControlService.cs
+++ b/src/unifocl/Services/DaemonControlService.cs
@@ -1,13 +1,14 @@
 using Spectre.Console;
 using System.Diagnostics;
 using System.Net;
-using System.Net.Sockets;
+using System.Net.Http;
 using System.Reflection;
 using System.Text;
 
 internal sealed class DaemonControlService
 {
     private const int DefaultInactivityTimeoutSeconds = 600;
+    private static readonly HttpClient Http = new();
 
     public async Task HandleDaemonCommandAsync(
         string input,
@@ -141,68 +142,140 @@ internal sealed class DaemonControlService
             }
         }, cts.Token);
 
-        TcpListener? listener = null;
+        HttpListener? listener = null;
         try
         {
-            listener = new TcpListener(IPAddress.Loopback, options.Port);
+            listener = new HttpListener();
+            listener.Prefixes.Add($"http://127.0.0.1:{options.Port}/");
             listener.Start();
 
             while (!cts.Token.IsCancellationRequested)
             {
-                var client = await listener.AcceptTcpClientAsync(cts.Token);
+                HttpListenerContext context;
+                try
+                {
+                    context = await listener.GetContextAsync().WaitAsync(cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (HttpListenerException)
+                {
+                    break;
+                }
+
                 _ = Task.Run(async () =>
                 {
-                    await using var stream = client.GetStream();
-                    using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
-                    using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
-                    var line = await reader.ReadLineAsync();
-                    var command = line?.Trim().ToUpperInvariant();
-
-                    switch (command)
+                    var request = context.Request;
+                    var path = (request.Url?.AbsolutePath ?? "/").TrimEnd('/');
+                    if (path.Length == 0)
                     {
-                        case "PING":
-                            await writer.WriteLineAsync("PONG");
-                            break;
-                        case "TOUCH":
-                            lastActivityUtc = DateTime.UtcNow;
-                            await writer.WriteLineAsync("OK");
-                            break;
-                        case "STOP":
-                            await writer.WriteLineAsync("STOPPING");
-                            cts.Cancel();
-                            break;
-                        default:
-                            if (assetIndexBridge.TryHandle(line, out var assetResponse))
-                            {
-                                lastActivityUtc = DateTime.UtcNow;
-                                await writer.WriteLineAsync(assetResponse);
-                            }
-                            else if (hierarchyBridge.TryHandle(line, out var hierarchyResponse))
-                            {
-                                lastActivityUtc = DateTime.UtcNow;
-                                await writer.WriteLineAsync(hierarchyResponse);
-                            }
-                            else if (inspectorBridge.TryHandle(line, out var inspectorResponse))
-                            {
-                                lastActivityUtc = DateTime.UtcNow;
-                                await writer.WriteLineAsync(inspectorResponse);
-                            }
-                            else
-                            {
-                                lastActivityUtc = DateTime.UtcNow;
-                                await writer.WriteLineAsync("ERR");
-                            }
-                            break;
+                        path = "/";
                     }
 
-                    client.Dispose();
+                    try
+                    {
+                        if (request.HttpMethod.Equals("GET", StringComparison.OrdinalIgnoreCase) && path.Equals("/ping", StringComparison.OrdinalIgnoreCase))
+                        {
+                            await WriteTextResponseAsync(context.Response, "PONG");
+                            return;
+                        }
+
+                        if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/touch", StringComparison.OrdinalIgnoreCase))
+                        {
+                            lastActivityUtc = DateTime.UtcNow;
+                            await WriteTextResponseAsync(context.Response, "OK");
+                            return;
+                        }
+
+                        if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/stop", StringComparison.OrdinalIgnoreCase))
+                        {
+                            await WriteTextResponseAsync(context.Response, "STOPPING");
+                            cts.Cancel();
+                            return;
+                        }
+
+                        if (request.HttpMethod.Equals("GET", StringComparison.OrdinalIgnoreCase) && path.Equals("/asset-index", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var revisionRaw = request.QueryString["revision"];
+                            var command = int.TryParse(revisionRaw, out var revision) && revision > 0
+                                ? $"ASSET_INDEX_SYNC {revision}"
+                                : "ASSET_INDEX_GET";
+                            if (assetIndexBridge.TryHandle(command, out var assetResponse))
+                            {
+                                lastActivityUtc = DateTime.UtcNow;
+                                await WriteJsonResponseAsync(context.Response, assetResponse);
+                                return;
+                            }
+                        }
+
+                        if (request.HttpMethod.Equals("GET", StringComparison.OrdinalIgnoreCase) && path.Equals("/hierarchy/snapshot", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (hierarchyBridge.TryHandle("HIERARCHY_GET", out var hierarchySnapshot))
+                            {
+                                lastActivityUtc = DateTime.UtcNow;
+                                await WriteJsonResponseAsync(context.Response, hierarchySnapshot);
+                                return;
+                            }
+                        }
+
+                        if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/hierarchy/command", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var payload = await ReadRequestBodyAsync(request);
+                            if (hierarchyBridge.TryHandle($"HIERARCHY_CMD {payload}", out var hierarchyResponse))
+                            {
+                                lastActivityUtc = DateTime.UtcNow;
+                                await WriteJsonResponseAsync(context.Response, hierarchyResponse);
+                                return;
+                            }
+                        }
+
+                        if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/hierarchy/find", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var payload = await ReadRequestBodyAsync(request);
+                            if (hierarchyBridge.TryHandle($"HIERARCHY_FIND {payload}", out var hierarchySearch))
+                            {
+                                lastActivityUtc = DateTime.UtcNow;
+                                await WriteJsonResponseAsync(context.Response, hierarchySearch);
+                                return;
+                            }
+                        }
+
+                        if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/inspect", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var payload = await ReadRequestBodyAsync(request);
+                            if (inspectorBridge.TryHandle($"INSPECT {payload}", out var inspectorResponse))
+                            {
+                                lastActivityUtc = DateTime.UtcNow;
+                                await WriteJsonResponseAsync(context.Response, inspectorResponse);
+                                return;
+                            }
+                        }
+
+                        lastActivityUtc = DateTime.UtcNow;
+                        await WriteTextResponseAsync(context.Response, "ERR", statusCode: 404);
+                    }
+                    catch
+                    {
+                        if (context.Response.OutputStream.CanWrite)
+                        {
+                            try
+                            {
+                                await WriteTextResponseAsync(context.Response, "ERR", statusCode: 500);
+                            }
+                            catch
+                            {
+                            }
+                        }
+                    }
                 }, cts.Token);
             }
         }
         catch (OperationCanceledException)
         {
         }
-        catch (SocketException)
+        catch (HttpListenerException)
         {
         }
         finally
@@ -219,6 +292,32 @@ internal sealed class DaemonControlService
             listener?.Stop();
             runtime.Remove(options.Port);
         }
+    }
+
+    private static async Task<string> ReadRequestBodyAsync(HttpListenerRequest request)
+    {
+        using var reader = new StreamReader(request.InputStream, request.ContentEncoding ?? Encoding.UTF8);
+        return await reader.ReadToEndAsync();
+    }
+
+    private static async Task WriteTextResponseAsync(HttpListenerResponse response, string payload, int statusCode = 200)
+    {
+        var bytes = Encoding.UTF8.GetBytes(payload + Environment.NewLine);
+        response.StatusCode = statusCode;
+        response.ContentType = "text/plain; charset=utf-8";
+        response.ContentLength64 = bytes.Length;
+        await response.OutputStream.WriteAsync(bytes);
+        response.Close();
+    }
+
+    private static async Task WriteJsonResponseAsync(HttpListenerResponse response, string jsonPayload, int statusCode = 200)
+    {
+        var bytes = Encoding.UTF8.GetBytes(jsonPayload + Environment.NewLine);
+        response.StatusCode = statusCode;
+        response.ContentType = "application/json; charset=utf-8";
+        response.ContentLength64 = bytes.Length;
+        await response.OutputStream.WriteAsync(bytes);
+        response.Close();
     }
 
     public async Task<bool> EnsureProjectDaemonAsync(
@@ -680,17 +779,38 @@ internal sealed class DaemonControlService
 
     private static async Task<bool> TrySendControlAsync(int port, string request, string expectedResponse)
     {
+        var endpoint = request switch
+        {
+            "PING" => ("GET", $"http://127.0.0.1:{port}/ping"),
+            "TOUCH" => ("POST", $"http://127.0.0.1:{port}/touch"),
+            "STOP" => ("POST", $"http://127.0.0.1:{port}/stop"),
+            _ => default
+        };
+        if (string.IsNullOrWhiteSpace(endpoint.Item2))
+        {
+            return false;
+        }
+
         try
         {
-            using var client = new TcpClient();
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-            await client.ConnectAsync(IPAddress.Loopback, port, cts.Token);
-            await using var stream = client.GetStream();
-            using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
-            using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
-            await writer.WriteLineAsync(request);
-            var response = await reader.ReadLineAsync();
-            return string.Equals(response, expectedResponse, StringComparison.Ordinal);
+            HttpResponseMessage response;
+            if (endpoint.Item1 == "GET")
+            {
+                response = await Http.GetAsync(endpoint.Item2, cts.Token);
+            }
+            else
+            {
+                response = await Http.PostAsync(endpoint.Item2, new StringContent(string.Empty, Encoding.UTF8, "text/plain"), cts.Token);
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return false;
+            }
+
+            var payload = (await response.Content.ReadAsStringAsync(cts.Token)).Trim();
+            return string.Equals(payload, expectedResponse, StringComparison.Ordinal);
         }
         catch
         {

--- a/src/unifocl/Services/EditorDependencyInitializerService.cs
+++ b/src/unifocl/Services/EditorDependencyInitializerService.cs
@@ -9,6 +9,10 @@ internal sealed class EditorDependencyInitializerService
     private const string EmbeddedPackageFolder = "daemon-package";
     private const string ExcludeEntry = "Packages/com.unifocl.cli/";
     private const string DaemonSourceResource = "Payload/EditorScripts/CLIDaemon.cs";
+    private const string DaemonRuntimeModelsResource = "Payload/EditorScripts/Models/DaemonBridgeModels.cs";
+    private const string DaemonAssetIndexServiceResource = "Payload/EditorScripts/Services/DaemonAssetIndexService.cs";
+    private const string DaemonHierarchyServiceResource = "Payload/EditorScripts/Services/DaemonHierarchyService.cs";
+    private const string DaemonInspectorServiceResource = "Payload/EditorScripts/Services/DaemonInspectorService.cs";
     private const string SharedModelsSourceResource = "Payload/SharedModels/BridgeModels.cs";
 
     public OperationResult InitializeProject(string projectPath, Action<string> log)
@@ -102,7 +106,11 @@ internal sealed class EditorDependencyInitializerService
         {
             Path.Combine(packagePath, "Editor", "UniFocl.EditorBridge.asmdef"),
             Path.Combine(packagePath, "Editor", "CLIDaemon.cs"),
-            Path.Combine(packagePath, "Editor", "BridgeModels.cs")
+            Path.Combine(packagePath, "Editor", "BridgeModels.cs"),
+            Path.Combine(packagePath, "Editor", "Models", "DaemonBridgeModels.cs"),
+            Path.Combine(packagePath, "Editor", "Services", "DaemonAssetIndexService.cs"),
+            Path.Combine(packagePath, "Editor", "Services", "DaemonHierarchyService.cs"),
+            Path.Combine(packagePath, "Editor", "Services", "DaemonInspectorService.cs")
         };
         foreach (var requiredFile in requiredFiles)
         {
@@ -144,6 +152,8 @@ internal sealed class EditorDependencyInitializerService
             var payloadPath = GetGlobalPayloadPath();
             Directory.CreateDirectory(payloadPath);
             Directory.CreateDirectory(Path.Combine(payloadPath, "Editor"));
+            Directory.CreateDirectory(Path.Combine(payloadPath, "Editor", "Models"));
+            Directory.CreateDirectory(Path.Combine(payloadPath, "Editor", "Services"));
 
             var packageJson =
                 """
@@ -181,20 +191,29 @@ internal sealed class EditorDependencyInitializerService
             File.WriteAllText(Path.Combine(payloadPath, "package.json"), packageJson + Environment.NewLine, Encoding.UTF8);
             File.WriteAllText(Path.Combine(payloadPath, "Editor", "UniFocl.EditorBridge.asmdef"), asmdef + Environment.NewLine, Encoding.UTF8);
 
-            var daemonSource = ReadEmbeddedResource(DaemonSourceResource);
-            if (daemonSource is null)
+            var resourceToTarget = new (string Resource, string RelativePath)[]
             {
-                return OperationResult.Fail($"missing embedded resource {DaemonSourceResource}");
+                (DaemonSourceResource, Path.Combine("Editor", "CLIDaemon.cs")),
+                (SharedModelsSourceResource, Path.Combine("Editor", "BridgeModels.cs")),
+                (DaemonRuntimeModelsResource, Path.Combine("Editor", "Models", "DaemonBridgeModels.cs")),
+                (DaemonAssetIndexServiceResource, Path.Combine("Editor", "Services", "DaemonAssetIndexService.cs")),
+                (DaemonHierarchyServiceResource, Path.Combine("Editor", "Services", "DaemonHierarchyService.cs")),
+                (DaemonInspectorServiceResource, Path.Combine("Editor", "Services", "DaemonInspectorService.cs"))
+            };
+
+            foreach (var item in resourceToTarget)
+            {
+                var source = ReadEmbeddedResource(item.Resource);
+                if (source is null)
+                {
+                    return OperationResult.Fail($"missing embedded resource {item.Resource}");
+                }
+
+                var targetPath = Path.Combine(payloadPath, item.RelativePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+                File.WriteAllText(targetPath, source, Encoding.UTF8);
             }
 
-            var modelsSource = ReadEmbeddedResource(SharedModelsSourceResource);
-            if (modelsSource is null)
-            {
-                return OperationResult.Fail($"missing embedded resource {SharedModelsSourceResource}");
-            }
-
-            File.WriteAllText(Path.Combine(payloadPath, "Editor", "CLIDaemon.cs"), daemonSource, Encoding.UTF8);
-            File.WriteAllText(Path.Combine(payloadPath, "Editor", "BridgeModels.cs"), modelsSource, Encoding.UTF8);
             return OperationResult.Success();
         }
         catch (Exception ex)

--- a/src/unifocl/Services/HierarchyDaemonClient.cs
+++ b/src/unifocl/Services/HierarchyDaemonClient.cs
@@ -1,15 +1,15 @@
-using System.Net;
-using System.Net.Sockets;
+using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 
 internal sealed class HierarchyDaemonClient
 {
+    private static readonly HttpClient Http = new();
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     public async Task<HierarchySnapshotDto?> GetSnapshotAsync(int port)
     {
-        var payload = await SendRequestAsync(port, "HIERARCHY_GET");
+        var payload = await SendGetAsync($"http://127.0.0.1:{port}/hierarchy/snapshot");
         if (payload is null)
         {
             return null;
@@ -27,8 +27,7 @@ internal sealed class HierarchyDaemonClient
 
     public async Task<HierarchyCommandResponseDto> ExecuteAsync(int port, HierarchyCommandRequestDto request)
     {
-        var json = JsonSerializer.Serialize(request, JsonOptions);
-        var payload = await SendRequestAsync(port, $"HIERARCHY_CMD {json}");
+        var payload = await SendPostJsonAsync($"http://127.0.0.1:{port}/hierarchy/command", request);
         if (payload is null)
         {
             return new HierarchyCommandResponseDto(false, "daemon did not return a hierarchy response", null, null);
@@ -47,8 +46,7 @@ internal sealed class HierarchyDaemonClient
 
     public async Task<HierarchySearchResponseDto?> SearchAsync(int port, HierarchySearchRequestDto request)
     {
-        var json = JsonSerializer.Serialize(request, JsonOptions);
-        var payload = await SendRequestAsync(port, $"HIERARCHY_FIND {json}");
+        var payload = await SendPostJsonAsync($"http://127.0.0.1:{port}/hierarchy/find", request);
         if (payload is null)
         {
             return null;
@@ -66,8 +64,10 @@ internal sealed class HierarchyDaemonClient
 
     public async Task<AssetIndexSyncResponseDto?> SyncAssetIndexAsync(int port, int knownRevision)
     {
-        var command = knownRevision <= 0 ? "ASSET_INDEX_GET" : $"ASSET_INDEX_SYNC {knownRevision}";
-        var payload = await SendRequestAsync(port, command);
+        var uri = knownRevision <= 0
+            ? $"http://127.0.0.1:{port}/asset-index"
+            : $"http://127.0.0.1:{port}/asset-index?revision={knownRevision}";
+        var payload = await SendGetAsync(uri);
         if (payload is null)
         {
             return null;
@@ -83,18 +83,39 @@ internal sealed class HierarchyDaemonClient
         }
     }
 
-    private static async Task<string?> SendRequestAsync(int port, string request)
+    private static async Task<string?> SendGetAsync(string uri)
     {
         try
         {
-            using var client = new TcpClient();
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-            await client.ConnectAsync(IPAddress.Loopback, port, cts.Token);
-            await using var stream = client.GetStream();
-            using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
-            using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
-            await writer.WriteLineAsync(request);
-            return await reader.ReadLineAsync();
+            var response = await Http.GetAsync(uri, cts.Token);
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            return (await response.Content.ReadAsStringAsync(cts.Token)).Trim();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> SendPostJsonAsync<T>(string uri, T payload)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            var json = JsonSerializer.Serialize(payload, JsonOptions);
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var response = await Http.PostAsync(uri, content, cts.Token);
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            return (await response.Content.ReadAsStringAsync(cts.Token)).Trim();
         }
         catch
         {

--- a/src/unifocl/Services/InspectorModeService.cs
+++ b/src/unifocl/Services/InspectorModeService.cs
@@ -1,5 +1,4 @@
-using System.Net;
-using System.Net.Sockets;
+using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 
@@ -7,6 +6,7 @@ internal sealed class InspectorModeService
 {
     private readonly InspectorTuiRenderer _renderer = new();
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
+    private static readonly HttpClient Http = new();
 
     public async Task<bool> TryHandleInspectorCommandAsync(
         string input,
@@ -868,16 +868,16 @@ internal sealed class InspectorModeService
 
         try
         {
-            using var client = new TcpClient();
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
-            await client.ConnectAsync(IPAddress.Loopback, port.Value, cts.Token);
-            await using var stream = client.GetStream();
-            using var writer = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true) { AutoFlush = true };
-            using var reader = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
             var json = JsonSerializer.Serialize(request, _jsonOptions);
-            await writer.WriteLineAsync($"INSPECT {json}");
-            var response = await reader.ReadLineAsync();
-            return response;
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var response = await Http.PostAsync($"http://127.0.0.1:{port.Value}/inspect", content, cts.Token);
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            return (await response.Content.ReadAsStringAsync(cts.Token)).Trim();
         }
         catch
         {

--- a/src/unifocl/unifocl.csproj
+++ b/src/unifocl/unifocl.csproj
@@ -13,6 +13,10 @@
 
   <ItemGroup>
     <EmbeddedResource Include="../unifocl.unity/EditorScripts/CLIDaemon.cs" LogicalName="Payload/EditorScripts/CLIDaemon.cs" />
+    <EmbeddedResource Include="../unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs" LogicalName="Payload/EditorScripts/Models/DaemonBridgeModels.cs" />
+    <EmbeddedResource Include="../unifocl.unity/EditorScripts/Services/DaemonAssetIndexService.cs" LogicalName="Payload/EditorScripts/Services/DaemonAssetIndexService.cs" />
+    <EmbeddedResource Include="../unifocl.unity/EditorScripts/Services/DaemonHierarchyService.cs" LogicalName="Payload/EditorScripts/Services/DaemonHierarchyService.cs" />
+    <EmbeddedResource Include="../unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs" LogicalName="Payload/EditorScripts/Services/DaemonInspectorService.cs" />
     <EmbeddedResource Include="../unifocl.unity/SharedModels/BridgeModels.cs" LogicalName="Payload/SharedModels/BridgeModels.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Migrates daemon transport from raw TCP line protocol to HTTP endpoints for CLI daemon control and bridge operations.
- Updates Unity-side `CLIDaemon` to the same HTTP endpoint model (`/ping`, `/touch`, `/stop`, `/asset-index`, `/hierarchy/*`, `/inspect`).
- Splits heavy Unity daemon implementation into focused files:
  - `EditorScripts/Models/DaemonBridgeModels.cs`
  - `EditorScripts/Services/DaemonAssetIndexService.cs`
  - `EditorScripts/Services/DaemonHierarchyService.cs`
  - `EditorScripts/Services/DaemonInspectorService.cs`
- Updates embedded payload wiring so `/init` installs and validates the new split files.
- Merged latest `main` into this branch before finalizing changes.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Services/DaemonControlService.cs`
  - `src/unifocl/Services/HierarchyDaemonClient.cs`
  - `src/unifocl/Services/InspectorModeService.cs`
  - `src/unifocl/Services/EditorDependencyInitializerService.cs`
  - `src/unifocl/unifocl.csproj`
  - `src/unifocl.unity/EditorScripts/*`
- Out-of-scope / intentionally not addressed:
  - Full Unity runtime/scene API integration for hierarchy/inspector operations.
  - Additional protocol versioning/schema changes beyond current endpoint migration.

## How to Test
1. Run `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`.
2. Run CLI daemon mode and verify HTTP control endpoints respond (`/ping`, `/touch`, `/stop`).
3. Open a Unity project and run `/init`, then verify the embedded package includes split model/service files and daemon endpoints respond.

Expected results:
- Build succeeds.
- Daemon lifecycle and bridge requests operate over HTTP.
- Unity embedded payload installs without missing-file validation errors.

## Screenshots / Terminal Output (if applicable)
- Local verification: `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal` succeeded (warnings only: NU1900 due vulnerability feed access in restricted environment).

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Localhost daemon transport changed to HTTP; no secret handling logic added.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
