### PR TITLE
Apply requested TUI palette and add /config theme variation

### DIFF
--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -6,7 +6,7 @@ if (DaemonControlService.TryParseDaemonServiceArgs(launchArgs, out var serviceOp
 {
     if (daemonParseError is not null)
     {
-        AnsiConsole.MarkupLine($"[red]{Markup.Escape(daemonParseError)}[/]");
+        CliTheme.MarkupLine($"[red]{Markup.Escape(daemonParseError)}[/]");
         Environment.ExitCode = 2;
         return;
     }
@@ -26,8 +26,8 @@ var commands = new List<CommandSpec>
     new("/q", "Alias for /quit", "/q"),
     new("/daemon <start|stop|restart|ps|attach|detach>", "Manage daemon lifecycle", "/daemon"),
     new("/d <start|stop|restart|ps|attach|detach>", "Alias for /daemon", "/d"),
-    new("/config <get|set|list|reset>", "Manage CLI/daemon preferences", "/config"),
-    new("/cfg <get|set|list|reset>", "Alias for /config", "/cfg"),
+    new("/config <get|set|list|reset> [theme]", "Manage CLI preferences (theme)", "/config"),
+    new("/cfg <get|set|list|reset> [theme]", "Alias for /config", "/cfg"),
     new("/status", "Show daemon/editor/project/session status", "/status"),
     new("/st", "Alias for /status", "/st"),
     new("/help [topic]", "Show help by topic", "/help"),
@@ -116,7 +116,7 @@ while (true)
             daemonControlService,
             daemonRuntime,
             line => AppendLog(streamLog, line));
-        AnsiConsole.MarkupLine("[grey]Input stream closed. Session ended.[/]");
+        CliTheme.MarkupLine("[grey]Input stream closed. Session ended.[/]");
         return;
     }
 
@@ -171,7 +171,7 @@ while (true)
 
     if (matched.Trigger == "/quit")
     {
-        AnsiConsole.MarkupLine("[grey]Session closed.[/]");
+        CliTheme.MarkupLine("[grey]Session closed.[/]");
         return;
     }
 
@@ -295,7 +295,7 @@ static string? ReadInput(
 {
     if (Console.IsInputRedirected)
     {
-        AnsiConsole.Markup($"[bold deepskyblue1]{Markup.Escape(BuildPromptLabel(session))}[/] [grey]>[/] ");
+        CliTheme.Markup($"[bold deepskyblue1]{Markup.Escape(BuildPromptLabel(session))}[/] [grey]>[/] ");
         return Console.ReadLine();
     }
 
@@ -439,7 +439,7 @@ static int RenderComposerFrame(
 
     foreach (var line in lines)
     {
-        AnsiConsole.MarkupLine(line);
+        CliTheme.MarkupLine(line);
     }
 
     return lines.Count;
@@ -474,7 +474,7 @@ static void RenderInitialLog(List<string> streamLog)
 {
     foreach (var line in streamLog)
     {
-        AnsiConsole.MarkupLine(line);
+        CliTheme.MarkupLine(line);
     }
 }
 
@@ -522,7 +522,7 @@ static void SeedBootLog(List<string> streamLog)
 
     foreach (var line in logo.Split('\n'))
     {
-        streamLog.Add($"[grey]{Markup.Escape(line)}[/]");
+        streamLog.Add($"[{CliTheme.Brand}]{Markup.Escape(line)}[/]");
     }
 
     streamLog.Add(string.Empty);
@@ -635,9 +635,15 @@ static IEnumerable<string> GetSuggestionLines(string query, List<CommandSpec> co
     for (var i = 0; i < matches.Count; i++)
     {
         var match = matches[i];
-        var prefix = i == selected ? "[green]>[/]" : "[grey] [/]";
-        var signatureColor = i == selected ? "green" : "grey";
-        lines.Add($"{prefix} [{signatureColor}]{Markup.Escape(match.Signature)}[/] [dim]- {Markup.Escape(match.Description)}[/]");
+        var selectedLine = i == selected;
+        var prefix = selectedLine
+            ? $"[{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]>[/]"
+            : "[grey] [/]";
+        var escapedSignature = Markup.Escape(match.Signature);
+        var escapedDescription = Markup.Escape(match.Description);
+        lines.Add(selectedLine
+            ? $"{prefix} [{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{escapedSignature}[/] [dim]- {escapedDescription}[/]"
+            : $"{prefix} [grey]{escapedSignature}[/] [dim]- {escapedDescription}[/]");
     }
 
     return lines;
@@ -674,9 +680,14 @@ static bool TryGetFuzzyQueryIntellisenseLines(string input, CliSessionState sess
     for (var i = 0; i < candidates.Count && i < 10; i++)
     {
         var candidate = candidates[i];
-        var prefix = i == selected ? "[green]>[/]" : "[grey] [/]";
-        var indexColor = i == selected ? "green" : "deepskyblue1";
-        lines.Add($"{prefix} [{indexColor}]{i}[/] {Markup.Escape(candidate.Path)}");
+        var selectedLine = i == selected;
+        var prefix = selectedLine
+            ? $"[{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]>[/]"
+            : "[grey] [/]";
+        var escapedPath = Markup.Escape(candidate.Path);
+        lines.Add(selectedLine
+            ? $"{prefix} [{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{i}[/] [{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{escapedPath}[/]"
+            : $"{prefix} [deepskyblue1]{i}[/] {escapedPath}");
     }
 
     return true;
@@ -917,5 +928,5 @@ static void WriteMockCommandStream(string input, List<string> streamLog)
 static void AppendLog(List<string> streamLog, string line)
 {
     streamLog.Add(line);
-    AnsiConsole.MarkupLine(line);
+    CliTheme.MarkupLine(line);
 }

--- a/src/unifocl/Services/CliTheme.cs
+++ b/src/unifocl/Services/CliTheme.cs
@@ -1,0 +1,151 @@
+using Spectre.Console;
+using System.Text.Json;
+
+internal static class CliTheme
+{
+    private const string BrandColor = "#ffb300";
+    private const string CursorBackgroundColor = "#ffb300";
+    private const string CursorForegroundColor = "#000000";
+
+    private static string _currentTheme = ResolveInitialTheme();
+
+    public static string Brand => BrandColor;
+    public static string CursorBackground => CursorBackgroundColor;
+    public static string CursorForeground => CursorForegroundColor;
+
+    public static string BaseBackground => IsLightMode ? "#fafafa" : "#18181b";
+    public static string SurfaceBackground => IsLightMode ? "#f4f4f5" : "#27272a";
+    public static string TextPrimary => IsLightMode ? "#18181b" : "#e4e4e7";
+    public static string TextSecondary => IsLightMode ? "#52525b" : "#a1a1aa";
+    public static string TextMuted => IsLightMode ? "#a1a1aa" : "#52525b";
+    public static string Success => IsLightMode ? "#16a34a" : "#4ade80";
+    public static string Info => IsLightMode ? "#2563eb" : "#60a5fa";
+    public static string Warning => IsLightMode ? "#ea580c" : "#fb923c";
+    public static string Error => IsLightMode ? "#dc2626" : "#f87171";
+    public static string CurrentTheme => _currentTheme;
+
+    public static string ApplyMarkupPalette(string markup)
+    {
+        if (string.IsNullOrEmpty(markup))
+        {
+            return markup;
+        }
+
+        return markup
+            .Replace("[bold deepskyblue1]", $"[bold {Brand}]")
+            .Replace("[deepskyblue1]", $"[{Brand}]")
+            .Replace("[bold white]", $"[bold {TextPrimary}]")
+            .Replace("[white]", $"[{TextPrimary}]")
+            .Replace("[bold green]", $"[bold {Success}]")
+            .Replace("[green]", $"[{Success}]")
+            .Replace("[yellow]", $"[{Warning}]")
+            .Replace("[red]", $"[{Error}]")
+            .Replace("[grey]", $"[{TextSecondary}]")
+            .Replace("[dim]", $"[{TextMuted}]");
+    }
+
+    public static void MarkupLine(string markupLine)
+    {
+        AnsiConsole.MarkupLine(ApplyMarkupPalette(markupLine));
+    }
+
+    public static void Markup(string markup)
+    {
+        AnsiConsole.Markup(ApplyMarkupPalette(markup));
+    }
+
+    public static string CursorWrapEscaped(string escapedContent)
+    {
+        return $"[{CursorForeground} on {CursorBackground}]{escapedContent}[/]";
+    }
+
+    public static bool TrySetTheme(string theme)
+    {
+        if (!IsSupportedTheme(theme))
+        {
+            return false;
+        }
+
+        _currentTheme = theme.ToLowerInvariant();
+        return true;
+    }
+
+    private static bool IsLightMode => string.Equals(_currentTheme, "light", StringComparison.OrdinalIgnoreCase);
+
+    private static string ResolveInitialTheme()
+    {
+        var theme = Environment.GetEnvironmentVariable("UNIFOCL_THEME");
+        if (IsSupportedTheme(theme))
+        {
+            return theme!.ToLowerInvariant();
+        }
+
+        var configTheme = TryReadThemeFromConfig();
+        if (IsSupportedTheme(configTheme))
+        {
+            return configTheme!.ToLowerInvariant();
+        }
+
+        return "dark";
+    }
+
+    private static bool IsSupportedTheme(string? theme)
+    {
+        return string.Equals(theme, "dark", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(theme, "light", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? TryReadThemeFromConfig()
+    {
+        try
+        {
+            var configPath = ResolveConfigPath();
+            if (string.IsNullOrWhiteSpace(configPath))
+            {
+                return null;
+            }
+
+            if (!File.Exists(configPath))
+            {
+                return null;
+            }
+
+            using var document = JsonDocument.Parse(File.ReadAllText(configPath));
+            if (!document.RootElement.TryGetProperty("theme", out var themeProperty))
+            {
+                return null;
+            }
+
+            return themeProperty.ValueKind == JsonValueKind.String
+                ? themeProperty.GetString()
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? ResolveConfigPath()
+    {
+        var explicitPath = Environment.GetEnvironmentVariable("UNIFOCL_CONFIG_PATH");
+        if (!string.IsNullOrWhiteSpace(explicitPath))
+        {
+            return Path.GetFullPath(explicitPath);
+        }
+
+        var configRoot = Environment.GetEnvironmentVariable("UNIFOCL_CONFIG_ROOT");
+        if (!string.IsNullOrWhiteSpace(configRoot))
+        {
+            return Path.Combine(Path.GetFullPath(configRoot), "config.json");
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+        {
+            return null;
+        }
+
+        return Path.Combine(home, ".unifocl", "config.json");
+    }
+}

--- a/src/unifocl/Services/HierarchyTui.cs
+++ b/src/unifocl/Services/HierarchyTui.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Spectre.Console;
 
 internal sealed class HierarchyTui
 {
@@ -497,26 +498,27 @@ internal sealed class HierarchyTui
             ? " | FOCUS: ON (up/down, tab, shift+tab, esc)"
             : $" | Focus Key: {FocusModeKey}";
 
-        Console.WriteLine(borderTop);
-        Console.WriteLine(ToFrameLine($" UnityCLI v0.1 | MODE: HIERARCHY | Daemon: 127.0.0.1:{daemonPort} | Scene: {scene}{focusLabel}"));
-        Console.WriteLine(borderMid);
+        WriteFrameLine(borderTop);
+        WriteFrameLine(ToFrameLine($" UnityCLI v0.1 | MODE: HIERARCHY | Daemon: 127.0.0.1:{daemonPort} | Scene: {scene}{focusLabel}"));
+        WriteFrameLine(borderMid);
 
         foreach (var line in visibleTree)
         {
-            Console.WriteLine(ToFrameLine($" {line}"));
+            var selected = focusModeEnabled && line.StartsWith("> ", StringComparison.Ordinal);
+            WriteFrameLine(ToFrameLine($" {line}"), selected);
         }
 
         if (hasStreamPane)
         {
-            Console.WriteLine(borderMid);
+            WriteFrameLine(borderMid);
             for (var i = 0; i < visibleCommandLog.Count; i++)
             {
                 var line = visibleCommandLog[i];
-                Console.WriteLine(ToFrameLine($" {line}"));
+                WriteFrameLine(ToFrameLine($" {line}"));
             }
         }
 
-        Console.WriteLine(borderBottom);
+        WriteFrameLine(borderBottom);
     }
 
     private static List<HierarchyTreeLine> BuildTreeLines(
@@ -765,6 +767,12 @@ internal sealed class HierarchyTui
         var sanitized = raw.Replace('\t', ' ');
         var content = sanitized.Length > FrameWidth ? sanitized[..FrameWidth] : sanitized.PadRight(FrameWidth, ' ');
         return $"│{content}│";
+    }
+
+    private static void WriteFrameLine(string line, bool highlight = false)
+    {
+        var escaped = Markup.Escape(line);
+        CliTheme.MarkupLine(highlight ? CliTheme.CursorWrapEscaped(escaped) : escaped);
     }
 
     private static (int TreeRows, int CommandRows) AllocateViewportRows(int dynamicRows, int treeCount, int commandCount)

--- a/src/unifocl/Services/InspectorTuiRenderer.cs
+++ b/src/unifocl/Services/InspectorTuiRenderer.cs
@@ -7,6 +7,7 @@ internal sealed class InspectorTuiRenderer
     private const int MinStreamRows = 4;
     private const int ReservedPromptRows = 4;
     private const int FrameOverheadRows = 5;
+    private sealed record RenderRow(string Content, bool Highlight);
 
     public void Render(
         InspectorContext context,
@@ -40,21 +41,21 @@ internal sealed class InspectorTuiRenderer
             Border('├', '┤')
         };
 
-        frame.AddRange(visibleBody.Select(Line));
+        frame.AddRange(visibleBody.Select(row => Line(row.Content, row.Highlight)));
         if (hasStreamPane)
         {
             frame.Add(Border('├', '┤'));
-            frame.AddRange(visibleStream.Select(Line));
+            frame.AddRange(visibleStream.Select(streamLine => Line(streamLine)));
         }
         frame.Add(Border('└', '┘'));
 
         foreach (var line in frame)
         {
-            AnsiConsole.MarkupLine(Markup.Escape(line));
+            CliTheme.MarkupLine(line);
         }
     }
 
-    private static IEnumerable<string> BuildBodyRows(
+    private static IEnumerable<RenderRow> BuildBodyRows(
         InspectorContext context,
         int? highlightedComponentIndex,
         string? highlightedFieldName)
@@ -64,41 +65,43 @@ internal sealed class InspectorTuiRenderer
             : BuildFieldRows(context, highlightedFieldName);
     }
 
-    private static IEnumerable<string> BuildComponentRows(InspectorContext context, int? highlightedComponentIndex)
+    private static IEnumerable<RenderRow> BuildComponentRows(InspectorContext context, int? highlightedComponentIndex)
     {
-        var lines = new List<string> { "COMPONENTS:" };
+        var lines = new List<RenderRow> { new("COMPONENTS:", false) };
         foreach (var component in context.Components)
         {
-            var marker = highlightedComponentIndex == component.Index ? ">" : " ";
-            lines.Add($"{marker}[{component.Index}] {component.Name}");
+            var selected = highlightedComponentIndex == component.Index;
+            var marker = selected ? ">" : " ";
+            lines.Add(new RenderRow($"{marker}[{component.Index}] {component.Name}", selected));
         }
 
         if (lines.Count == 1)
         {
-            lines.Add(" [empty]");
+            lines.Add(new RenderRow(" [empty]", false));
         }
 
         return lines;
     }
 
-    private static IEnumerable<string> BuildFieldRows(InspectorContext context, string? highlightedFieldName)
+    private static IEnumerable<RenderRow> BuildFieldRows(InspectorContext context, string? highlightedFieldName)
     {
-        var lines = new List<string>
+        var lines = new List<RenderRow>
         {
-            $"{PadRight("FIELD", 20)}{PadRight("VALUE", 26)}TYPE",
-            new string('─', InnerWidth - 1)
+            new($"{PadRight("FIELD", 20)}{PadRight("VALUE", 26)}TYPE", false),
+            new(new string('─', InnerWidth - 1), false)
         };
 
         foreach (var field in context.Fields)
         {
-            var marker = string.Equals(highlightedFieldName, field.Name, StringComparison.OrdinalIgnoreCase) ? ">" : " ";
+            var selected = string.Equals(highlightedFieldName, field.Name, StringComparison.OrdinalIgnoreCase);
+            var marker = selected ? ">" : " ";
             var typeCell = $"[{field.Type}]";
-            lines.Add($"{marker}{PadRight(field.Name, 19)}{PadRight(field.Value, 26)}{typeCell}");
+            lines.Add(new RenderRow($"{marker}{PadRight(field.Name, 19)}{PadRight(field.Value, 26)}{typeCell}", selected));
         }
 
         if (context.Fields.Count == 0)
         {
-            lines.Add(" [empty]");
+            lines.Add(new RenderRow(" [empty]", false));
         }
 
         return lines;
@@ -133,10 +136,12 @@ internal sealed class InspectorTuiRenderer
         return $"{left}{new string('─', InnerWidth)}{right}";
     }
 
-    private static string Line(string content)
+    private static string Line(string content, bool highlight = false)
     {
         var trimmed = content.Length > InnerWidth ? content[..InnerWidth] : content;
-        return $"│{trimmed.PadRight(InnerWidth)}│";
+        var escaped = Markup.Escape(trimmed.PadRight(InnerWidth));
+        var line = $"│{escaped}│";
+        return highlight ? CliTheme.CursorWrapEscaped(line) : line;
     }
 
     private static (int BodyRows, int StreamRows) AllocateViewportRows(int dynamicRows, int bodyCount, int streamCount)
@@ -158,6 +163,42 @@ internal sealed class InspectorTuiRenderer
         }
 
         return (Math.Max(1, bodyRows), Math.Max(1, streamRows));
+    }
+
+    private static IReadOnlyList<RenderRow> SliceRows(
+        IReadOnlyList<RenderRow> source,
+        int viewportRows,
+        ref int offset,
+        bool followTail)
+    {
+        viewportRows = Math.Max(1, viewportRows);
+        var rows = source.Count == 0 ? new List<RenderRow> { new(string.Empty, false) } : source.ToList();
+        var maxOffset = Math.Max(0, rows.Count - viewportRows);
+        if (followTail)
+        {
+            offset = maxOffset;
+        }
+
+        offset = Math.Clamp(offset, 0, maxOffset);
+        var visible = rows.Skip(offset).Take(viewportRows).ToList();
+        while (visible.Count < viewportRows)
+        {
+            visible.Add(new RenderRow(string.Empty, false));
+        }
+
+        var hiddenAbove = offset;
+        var hiddenBelow = Math.Max(0, rows.Count - (offset + visible.Count));
+        if (hiddenAbove > 0 && visible.Count > 0)
+        {
+            visible[0] = new RenderRow($"... {hiddenAbove} line(s) above ...", false);
+        }
+
+        if (hiddenBelow > 0 && visible.Count > 1)
+        {
+            visible[^1] = new RenderRow($"... {hiddenBelow} line(s) below ...", false);
+        }
+
+        return visible;
     }
 
     private static IReadOnlyList<string> SliceRows(

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -25,6 +25,7 @@ internal sealed class ProjectLifecycleService
             "/recent" => await HandleRecentAsync(input, matched, log),
             "/close" => await HandleCloseAsync(session, daemonControlService, daemonRuntime, log),
             "/init" => await HandleInitAsync(input, matched, session, log),
+            "/config" => await HandleConfigAsync(input, matched, log),
             _ => false
         };
     }
@@ -340,6 +341,151 @@ internal sealed class ProjectLifecycleService
         }
 
         return Task.FromResult(true);
+    }
+
+    private Task<bool> HandleConfigAsync(
+        string input,
+        CommandSpec matched,
+        Action<string> log)
+    {
+        var args = ParseCommandArgs(input, matched.Trigger);
+        if (args.Count == 0)
+        {
+            log("[red]error[/]: usage /config <get|set|list|reset> [theme] [value]");
+            return Task.FromResult(true);
+        }
+
+        var action = args[0].Trim().ToLowerInvariant();
+        return action switch
+        {
+            "list" => HandleConfigList(log),
+            "get" => HandleConfigGet(args.Skip(1).ToList(), log),
+            "set" => HandleConfigSet(args.Skip(1).ToList(), log),
+            "reset" => HandleConfigReset(args.Skip(1).ToList(), log),
+            _ => Task.FromResult(LogConfigUsage(log))
+        };
+    }
+
+    private static Task<bool> HandleConfigList(Action<string> log)
+    {
+        var loadResult = TryLoadCliConfig(out var config, out var error);
+        if (!loadResult)
+        {
+            log($"[red]error[/]: {Markup.Escape(error ?? "failed to read config")}");
+            return Task.FromResult(true);
+        }
+
+        var source = string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("UNIFOCL_THEME"))
+            ? "file/default"
+            : "env (UNIFOCL_THEME)";
+        var theme = ResolveEffectiveTheme(config);
+        log("[grey]config[/]: available settings");
+        log($"[grey]config[/]: [white]theme[/] = [white]{theme}[/] [dim](dark|light, source: {source})[/]");
+        return Task.FromResult(true);
+    }
+
+    private static Task<bool> HandleConfigGet(IReadOnlyList<string> args, Action<string> log)
+    {
+        if (args.Count != 1)
+        {
+            log("[red]error[/]: usage /config get <theme>");
+            return Task.FromResult(true);
+        }
+
+        if (!IsThemeKey(args[0]))
+        {
+            log("[red]error[/]: only 'theme' is supported");
+            return Task.FromResult(true);
+        }
+
+        var loadResult = TryLoadCliConfig(out var config, out var error);
+        if (!loadResult)
+        {
+            log($"[red]error[/]: {Markup.Escape(error ?? "failed to read config")}");
+            return Task.FromResult(true);
+        }
+
+        var theme = ResolveEffectiveTheme(config);
+        log($"[grey]config[/]: [white]theme[/] = [white]{theme}[/]");
+        return Task.FromResult(true);
+    }
+
+    private static Task<bool> HandleConfigSet(IReadOnlyList<string> args, Action<string> log)
+    {
+        if (args.Count != 2)
+        {
+            log("[red]error[/]: usage /config set <theme> <dark|light>");
+            return Task.FromResult(true);
+        }
+
+        if (!IsThemeKey(args[0]))
+        {
+            log("[red]error[/]: only 'theme' is supported");
+            return Task.FromResult(true);
+        }
+
+        var requestedTheme = args[1].Trim().ToLowerInvariant();
+        if (requestedTheme is not ("dark" or "light"))
+        {
+            log("[red]error[/]: theme must be 'dark' or 'light'");
+            return Task.FromResult(true);
+        }
+
+        if (!TryLoadCliConfig(out var config, out var loadError))
+        {
+            log($"[red]error[/]: {Markup.Escape(loadError ?? "failed to read config")}");
+            return Task.FromResult(true);
+        }
+
+        config.Theme = requestedTheme;
+        if (!TrySaveCliConfig(config, out var saveError))
+        {
+            log($"[red]error[/]: {Markup.Escape(saveError ?? "failed to write config")}");
+            return Task.FromResult(true);
+        }
+
+        CliTheme.TrySetTheme(requestedTheme);
+        log($"[green]config[/]: theme set to [white]{requestedTheme}[/]");
+        return Task.FromResult(true);
+    }
+
+    private static Task<bool> HandleConfigReset(IReadOnlyList<string> args, Action<string> log)
+    {
+        if (args.Count > 1)
+        {
+            log("[red]error[/]: usage /config reset [theme]");
+            return Task.FromResult(true);
+        }
+
+        if (args.Count == 1 && !IsThemeKey(args[0]))
+        {
+            log("[red]error[/]: only 'theme' is supported");
+            return Task.FromResult(true);
+        }
+
+        if (!TryLoadCliConfig(out var config, out var loadError))
+        {
+            log($"[red]error[/]: {Markup.Escape(loadError ?? "failed to read config")}");
+            return Task.FromResult(true);
+        }
+
+        config.Theme = null;
+        if (!TrySaveCliConfig(config, out var saveError))
+        {
+            log($"[red]error[/]: {Markup.Escape(saveError ?? "failed to write config")}");
+            return Task.FromResult(true);
+        }
+
+        var effective = ResolveEffectiveTheme(config);
+        CliTheme.TrySetTheme(effective);
+        log($"[green]config[/]: theme reset to default [white]{effective}[/]");
+        return Task.FromResult(true);
+    }
+
+    private static bool LogConfigUsage(Action<string> log)
+    {
+        log("[red]error[/]: usage /config <get|set|list|reset> [theme] [value]");
+        return true;
     }
 
     private async Task<bool> HandleCloseAsync(
@@ -705,5 +851,122 @@ internal sealed class ProjectLifecycleService
 
         var firstLine = text.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
         return firstLine is null ? $"exit code {result.ExitCode}" : firstLine;
+    }
+
+    private static bool TryLoadCliConfig(out CliConfig config, out string? error)
+    {
+        config = new CliConfig();
+        error = null;
+
+        try
+        {
+            var path = GetCliConfigPath();
+            if (!File.Exists(path))
+            {
+                return true;
+            }
+
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                error = "invalid config format";
+                return false;
+            }
+
+            if (document.RootElement.TryGetProperty("theme", out var themeProperty)
+                && themeProperty.ValueKind == JsonValueKind.String)
+            {
+                config.Theme = themeProperty.GetString();
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"failed to read config ({ex.Message})";
+            return false;
+        }
+    }
+
+    private static bool TrySaveCliConfig(CliConfig config, out string? error)
+    {
+        error = null;
+        try
+        {
+            var path = GetCliConfigPath();
+            var directory = Path.GetDirectoryName(path);
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                error = "failed to resolve config directory";
+                return false;
+            }
+
+            Directory.CreateDirectory(directory);
+            var payload = JsonSerializer.Serialize(
+                new Dictionary<string, string?> { ["theme"] = NormalizeTheme(config.Theme) },
+                new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(path, payload + Environment.NewLine);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"failed to write config ({ex.Message})";
+            return false;
+        }
+    }
+
+    private static string ResolveEffectiveTheme(CliConfig config)
+    {
+        var fromEnv = Environment.GetEnvironmentVariable("UNIFOCL_THEME");
+        if (NormalizeTheme(fromEnv) is string envTheme)
+        {
+            return envTheme;
+        }
+
+        return NormalizeTheme(config.Theme) ?? "dark";
+    }
+
+    private static bool IsThemeKey(string key)
+    {
+        return key.Equals("theme", StringComparison.OrdinalIgnoreCase)
+               || key.Equals("ui.theme", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? NormalizeTheme(string? theme)
+    {
+        if (string.Equals(theme, "dark", StringComparison.OrdinalIgnoreCase))
+        {
+            return "dark";
+        }
+
+        if (string.Equals(theme, "light", StringComparison.OrdinalIgnoreCase))
+        {
+            return "light";
+        }
+
+        return null;
+    }
+
+    private static string GetCliConfigPath()
+    {
+        var explicitPath = Environment.GetEnvironmentVariable("UNIFOCL_CONFIG_PATH");
+        if (!string.IsNullOrWhiteSpace(explicitPath))
+        {
+            return Path.GetFullPath(explicitPath);
+        }
+
+        var configRoot = Environment.GetEnvironmentVariable("UNIFOCL_CONFIG_ROOT");
+        if (!string.IsNullOrWhiteSpace(configRoot))
+        {
+            return Path.Combine(Path.GetFullPath(configRoot), "config.json");
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".unifocl", "config.json");
+    }
+
+    private sealed class CliConfig
+    {
+        public string? Theme { get; set; }
     }
 }

--- a/src/unifocl/Services/ProjectViewRenderer.cs
+++ b/src/unifocl/Services/ProjectViewRenderer.cs
@@ -4,6 +4,7 @@ internal sealed class ProjectViewRenderer
 {
     private const int FrameWidth = 78;
     private const int CommandRows = 8;
+    private sealed record RenderLine(string Content, bool Highlight);
 
     public IReadOnlyList<string> Render(ProjectViewState state, int? highlightedEntryIndex = null, bool focusModeEnabled = false)
     {
@@ -21,7 +22,7 @@ internal sealed class ProjectViewRenderer
 
         foreach (var treeLine in BuildTreeLines(state, cwd, highlightedEntryIndex))
         {
-            lines.Add(BorderBody(treeLine));
+            lines.Add(BorderBody(treeLine.Content, treeLine.Highlight));
         }
 
         lines.Add(BorderSeparator());
@@ -37,19 +38,20 @@ internal sealed class ProjectViewRenderer
         }
 
         lines.Add(BorderBottom());
-        return lines.Select(Markup.Escape).ToList();
+        return lines;
     }
 
-    private static IEnumerable<string> BuildTreeLines(ProjectViewState state, string cwd, int? highlightedEntryIndex)
+    private static IEnumerable<RenderLine> BuildTreeLines(ProjectViewState state, string cwd, int? highlightedEntryIndex)
     {
-        yield return $" {GetRootLabel(cwd)}";
+        yield return new RenderLine($" {GetRootLabel(cwd)}", false);
         foreach (var entry in state.VisibleEntries)
         {
             var prefix = entry.Depth == 0 ? string.Empty : new string(' ', 1) + string.Concat(Enumerable.Repeat("│   ", entry.Depth));
-            var marker = highlightedEntryIndex == entry.Index ? ">" : " ";
+            var selected = highlightedEntryIndex == entry.Index;
+            var marker = selected ? ">" : " ";
             var branch = $"{marker}{prefix}├── ";
             var label = entry.IsDirectory ? $"{entry.Name}/" : entry.Name;
-            yield return $"{branch}[{entry.Index}] {label}";
+            yield return new RenderLine($"{branch}[{entry.Index}] {label}", selected);
         }
     }
 
@@ -64,11 +66,12 @@ internal sealed class ProjectViewRenderer
     private static string BorderSeparator() => "├" + new string('─', FrameWidth) + "┤";
     private static string BorderBottom() => "└" + new string('─', FrameWidth) + "┘";
 
-    private static string BorderBody(string content)
+    private static string BorderBody(string content, bool highlight = false)
     {
         var normalized = content.Replace(Environment.NewLine, " ").Replace("\n", " ");
-        var adjusted = Fit(normalized, FrameWidth);
-        return $"│{adjusted}│";
+        var adjusted = Markup.Escape(Fit(normalized, FrameWidth));
+        var line = $"│{adjusted}│";
+        return highlight ? CliTheme.CursorWrapEscaped(line) : line;
     }
 
     private static string Fit(string text, int width)

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -633,7 +633,7 @@ internal sealed class ProjectViewService
         var lines = _renderer.Render(state, highlightedEntryIndex, focusModeEnabled);
         foreach (var line in lines)
         {
-            AnsiConsole.MarkupLine(line);
+            CliTheme.MarkupLine(line);
         }
     }
 


### PR DESCRIPTION
## Summary
- This PR introduces the new amber-first TUI palette and applies it consistently across project/hierarchy/inspector/composer rendering paths.
- It adds a new `/config` variation for UI theme management (`list/get/set/reset` for `theme`) with persistence and runtime application.
- This change is needed to align the CLI UI with the requested brand/status palette and to make theme selection user-configurable via existing config command flow.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
- `src/unifocl/Services/CliTheme.cs` (central palette + runtime theme resolution)
- `src/unifocl/Program.cs` (composer/log rendering now uses themed markup and cursor highlight colors)
- `src/unifocl/Services/ProjectViewRenderer.cs` and `src/unifocl/Services/ProjectViewService.cs` (focus-row cursor highlight + themed output)
- `src/unifocl/Services/InspectorTuiRenderer.cs` (focus-row cursor highlight + themed output)
- `src/unifocl/Services/HierarchyTui.cs` (focus-row cursor highlight + themed output)
- `src/unifocl/Services/ProjectLifecycleService.cs` (`/config` command handling for theme persistence)
- Out-of-scope / intentionally not addressed:
- No redesign of non-TUI business logic (daemon/process/project lifecycle semantics unchanged)
- No additional config keys beyond theme in this PR

## How to Test
1. Build: `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Start CLI and verify palette/highlights interactively (`/hierarchy`, project focus `F7`, inspector focus `F8`, composer suggestions): selected row/background should be `#ffb300` with black text.
3. Validate config variation:
   - `/config list`
   - `/config get theme`
   - `/config set theme light`
   - `/config reset theme`

Expected results:
- Theme colors map to requested values; cursor highlight uses amber background + black foreground.
- `/config` theme commands work and update effective theme (environment override still respected).

## Screenshots / Terminal Output (if applicable)
- Terminal validation run included in local checks (build success and `/config` command flow verified).

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No credentials/secrets introduced.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
