### PR TITLE
Fix composer Esc behavior to decline intellisense without erasing input

### DIFF
--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -310,11 +310,19 @@ static string? ReadInteractiveInput(
 {
     var input = new StringBuilder();
     var selectedIntellisenseCandidateIndex = 0;
-    var renderedLines = RenderComposerFrame(input.ToString(), commands, projectCommands, session, selectedIntellisenseCandidateIndex);
+    var intellisenseDismissed = false;
+    var renderedLines = RenderComposerFrame(
+        input.ToString(),
+        commands,
+        projectCommands,
+        session,
+        selectedIntellisenseCandidateIndex,
+        intellisenseDismissed);
 
     while (true)
     {
-        _ = TryGetComposerIntellisenseCandidates(input.ToString(), commands, projectCommands, session, out var candidates);
+        _ = TryGetComposerIntellisenseCandidates(input.ToString(), commands, projectCommands, session, out var allCandidates);
+        var candidates = intellisenseDismissed ? [] : allCandidates;
         if (candidates.Count == 0)
         {
             selectedIntellisenseCandidateIndex = 0;
@@ -344,12 +352,29 @@ static string? ReadInteractiveInput(
                 {
                     input.Remove(input.Length - 1, 1);
                 }
+
+                intellisenseDismissed = false;
                 break;
             case ConsoleKey.Escape:
-                input.Clear();
+                if (!intellisenseDismissed && allCandidates.Count > 0)
+                {
+                    intellisenseDismissed = true;
+                }
+                else
+                {
+                    input.Clear();
+                    intellisenseDismissed = false;
+                }
+
                 selectedIntellisenseCandidateIndex = 0;
                 break;
             case ConsoleKey.UpArrow:
+                if (intellisenseDismissed && allCandidates.Count > 0)
+                {
+                    intellisenseDismissed = false;
+                    candidates = allCandidates;
+                }
+
                 if (candidates.Count > 0)
                 {
                     selectedIntellisenseCandidateIndex = selectedIntellisenseCandidateIndex <= 0
@@ -358,6 +383,12 @@ static string? ReadInteractiveInput(
                 }
                 break;
             case ConsoleKey.DownArrow:
+                if (intellisenseDismissed && allCandidates.Count > 0)
+                {
+                    intellisenseDismissed = false;
+                    candidates = allCandidates;
+                }
+
                 if (candidates.Count > 0)
                 {
                     selectedIntellisenseCandidateIndex = selectedIntellisenseCandidateIndex >= candidates.Count - 1
@@ -387,12 +418,19 @@ static string? ReadInteractiveInput(
                 if (!char.IsControl(key.KeyChar))
                 {
                     input.Append(key.KeyChar);
+                    intellisenseDismissed = false;
                 }
                 break;
         }
 
         ClearComposerFrame(renderedLines);
-        renderedLines = RenderComposerFrame(input.ToString(), commands, projectCommands, session, selectedIntellisenseCandidateIndex);
+        renderedLines = RenderComposerFrame(
+            input.ToString(),
+            commands,
+            projectCommands,
+            session,
+            selectedIntellisenseCandidateIndex,
+            intellisenseDismissed);
     }
 }
 
@@ -401,7 +439,8 @@ static int RenderComposerFrame(
     List<CommandSpec> commands,
     List<CommandSpec> projectCommands,
     CliSessionState session,
-    int selectedFuzzyCandidateIndex)
+    int selectedFuzzyCandidateIndex,
+    bool suppressIntellisense)
 {
     var lines = new List<string>
     {
@@ -409,7 +448,11 @@ static int RenderComposerFrame(
         $"[bold deepskyblue1]{Markup.Escape(BuildPromptLabel(session))}[/] [grey]>[/] [bold white]{Markup.Escape(input)}[/]"
     };
 
-    if (input.StartsWith('/'))
+    if (suppressIntellisense)
+    {
+        lines.Add("[dim]intellisense dismissed (Esc). Type or use ↑/↓ to reopen suggestions.[/]");
+    }
+    else if (input.StartsWith('/'))
     {
         lines.Add(string.Empty);
         lines.AddRange(GetSuggestionLines(input, commands, selectedFuzzyCandidateIndex));
@@ -537,7 +580,7 @@ static void WriteKeybindsHelp(List<string> streamLog, CliSessionState session)
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F6[/] enter/exit hierarchy focus mode (inside /hierarchy)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F7[/] enter/exit project focus mode (project context)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F8[/] enter/exit inspector focus mode (inspector context)");
-    AppendLog(streamLog, "[grey]keybinds[/]: [white]Esc[/] clear composer input");
+    AppendLog(streamLog, "[grey]keybinds[/]: [white]Esc[/] dismiss intellisense (or clear input if already dismissed)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]↑/↓[/] fuzzy candidate selection in composer");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]Enter[/] commit command/input");
 


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Updates composer key handling so pressing `Esc` dismisses intellisense suggestions first instead of clearing typed input.
  - Keeps input clearing available as a secondary action: pressing `Esc` again (or when no suggestions are active) clears the composer input.
  - Adds a composer hint line when intellisense is dismissed and updates `/keybinds` help text accordingly.
- Why is this change needed?
  - Users need a way to decline suggestions without losing in-progress input.

## Related Issues
- Closes #N/A
- Related to #N/A

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Program.cs` composer input loop, frame rendering, keybind help text.
- Out-of-scope / intentionally not addressed:
  - No changes to hierarchy/project/inspector focus-mode `Esc` behavior.
  - No changes to suggestion ranking/matching.

## How to Test
1. Run `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`.
2. Start the CLI and type input that produces intellisense suggestions (for example `/k` or a project command fragment).
3. Press `Esc` once and confirm suggestions are dismissed while typed input remains.
4. Press `Enter` and confirm the raw typed input is submitted (not an auto-committed suggestion).
5. Press `Esc` again (after dismissal) and confirm input is cleared.
6. Press `↑`/`↓` after dismissal and confirm suggestions reopen and navigation works.

Expected results:
- `Esc` declines intellisense without erasing current input on first press.
- Input clear still works as an explicit follow-up action.
- Existing suggestion commit flow via `Enter` remains unchanged when suggestions are active.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->
- Local build output: success (`0` errors), with NU1900 warning due to unreachable NuGet vulnerability feed in current environment.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Input handling/UI behavior only. No credential, auth, network, or data-path changes.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
