### PR TITLE
Ignore .meta files in CLI tree and enforce mainline sync rule

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -15,6 +15,7 @@ The agent must treat the following as **non-negotiable principles**:
 - **Security:** Never commit secrets or machine-local credentials/tokens
 - **Build Command:** Run builds or tests on `src/unifocl/unifocl.csproj` with `--disable-build-servers -v minimal`
 - **Repository Rules:** Always branch from `main` before any actions and create PRs using `.github/pull_request_template.md` in English
+- **Mainline Sync Rule:** Before finalizing work (push/PR), merge latest `main` (or `origin/main`) to detect upstream leading changes early and resolve any conflicts before continuing
 - **Deployment:** NEVER deploy or publish artifacts without permission
 
 ---

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -255,6 +255,7 @@ internal sealed class ProjectViewService
             .OrderBy(dir => dir.Name, StringComparer.OrdinalIgnoreCase);
         var files = Directory.EnumerateFiles(absolutePath)
             .Select(path => new FileInfo(path))
+            .Where(file => !file.Extension.Equals(".meta", StringComparison.OrdinalIgnoreCase))
             .OrderBy(file => file.Name, StringComparer.OrdinalIgnoreCase);
 
         foreach (var file in files)


### PR DESCRIPTION
## Summary
- Exclude Unity `.meta` files from the CLI project tree listing in `ProjectViewService`.
- Add a repository policy rule in `AGENT.md` to merge latest `main`/`origin/main` before push/PR and resolve conflicts if they occur.
- This keeps project navigation cleaner and enforces earlier upstream conflict detection.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Services/ProjectViewService.cs`
  - `AGENT.md`
- Out-of-scope / intentionally not addressed:
  - No changes to Unity-side asset index protocol
  - No UI layout or command-routing changes

## How to Test
1. Run: `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Open a Unity project in CLI project view mode and list files under `Assets`.
3. Confirm `.meta` files are not shown in the file list.

Expected results:
- Build succeeds.
- `.meta` files are omitted from CLI tree entries.

## Screenshots / Terminal Output (if applicable)
- `dotnet build` succeeded locally.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Change is limited to local file filtering and repository workflow documentation.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
