### PR TITLE
Fix Enter key overriding IntelliSense during argument input

### DIFF
--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -311,6 +311,7 @@ static string? ReadInteractiveInput(
     var input = new StringBuilder();
     var selectedIntellisenseCandidateIndex = 0;
     var intellisenseDismissed = false;
+    var intellisenseSelectionArmed = false;
     var renderedLines = RenderComposerFrame(
         input.ToString(),
         commands,
@@ -338,7 +339,8 @@ static string? ReadInteractiveInput(
         {
             case ConsoleKey.Enter:
                 Console.WriteLine();
-                if (candidates.Count > 0
+                if (intellisenseSelectionArmed
+                    && candidates.Count > 0
                     && selectedIntellisenseCandidateIndex >= 0
                     && selectedIntellisenseCandidateIndex < candidates.Count
                     && !string.IsNullOrWhiteSpace(candidates[selectedIntellisenseCandidateIndex].CommitCommand))
@@ -354,6 +356,7 @@ static string? ReadInteractiveInput(
                 }
 
                 intellisenseDismissed = false;
+                intellisenseSelectionArmed = false;
                 break;
             case ConsoleKey.Escape:
                 if (!intellisenseDismissed && allCandidates.Count > 0)
@@ -367,6 +370,7 @@ static string? ReadInteractiveInput(
                 }
 
                 selectedIntellisenseCandidateIndex = 0;
+                intellisenseSelectionArmed = false;
                 break;
             case ConsoleKey.UpArrow:
                 if (intellisenseDismissed && allCandidates.Count > 0)
@@ -380,6 +384,7 @@ static string? ReadInteractiveInput(
                     selectedIntellisenseCandidateIndex = selectedIntellisenseCandidateIndex <= 0
                         ? candidates.Count - 1
                         : selectedIntellisenseCandidateIndex - 1;
+                    intellisenseSelectionArmed = true;
                 }
                 break;
             case ConsoleKey.DownArrow:
@@ -394,6 +399,7 @@ static string? ReadInteractiveInput(
                     selectedIntellisenseCandidateIndex = selectedIntellisenseCandidateIndex >= candidates.Count - 1
                         ? 0
                         : selectedIntellisenseCandidateIndex + 1;
+                    intellisenseSelectionArmed = true;
                 }
                 break;
             case ConsoleKey.F7:
@@ -419,6 +425,7 @@ static string? ReadInteractiveInput(
                 {
                     input.Append(key.KeyChar);
                     intellisenseDismissed = false;
+                    intellisenseSelectionArmed = false;
                 }
                 break;
         }


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Fixes composer Enter behavior so IntelliSense suggestions are only committed after explicit suggestion navigation (Up/Down).
  - Prevents Enter from overriding typed command arguments with the first suggestion.
- Why is this change needed?
  - While entering command arguments, pressing Enter could be interpreted as suggestion confirmation, causing incorrect command execution.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Program.cs` (`ReadInteractiveInput` key handling)
- Out-of-scope / intentionally not addressed:
  - Suggestion ranking/matching logic
  - Rendering/UI text changes

## How to Test
1. Run `dotnet run --project src/unifocl/unifocl.csproj`.
2. Type a command with arguments that also has IntelliSense candidates visible (for example, start typing a project command and continue with an argument).
3. Press `Enter` without using `Up`/`Down` to select a candidate.
4. Repeat, but first use `Up`/`Down`, then press `Enter`.

Expected results:
- Without `Up`/`Down`, `Enter` submits the exact typed input.
- After `Up`/`Down`, `Enter` commits the selected IntelliSense candidate.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->
- `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal` succeeds (0 errors).
- Environment warning observed: `NU1900` while fetching NuGet vulnerability metadata from `https://api.nuget.org/v3/index.json`.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Input handling change only; no credential, transport, or persistence behavior modified.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
