### PR TITLE
Fix Unity API compatibility checks and add Unity log pane

### DIFF
--- a/src/unifocl.unity.compatcheck/README.md
+++ b/src/unifocl.unity.compatcheck/README.md
@@ -1,0 +1,25 @@
+# Unity Compatibility Check
+
+This project compiles `src/unifocl.unity/EditorScripts` against real Unity assemblies.
+
+Required input:
+- `UnityEditorManagedDir`: path to Unity's Managed folder that contains `UnityEditor.dll`.
+
+Optional input:
+- `UnityProjectPath`: Unity project root path. When set, all DLLs from `Library/ScriptAssemblies` are referenced, including `Assembly-CSharp` and every asmdef output.
+
+You can pass these as MSBuild properties or environment variables:
+- `UNIFOCL_UNITY_EDITOR_MANAGED_DIR`
+- `UNIFOCL_UNITY_PROJECT_PATH`
+
+Example:
+
+```bash
+dotnet build src/unifocl.unity.compatcheck/unifocl.unity.compatcheck.csproj \
+  -p:UnityEditorManagedDir="/Applications/Unity/Hub/Editor/6000.2.6f2/Unity.app/Contents/Managed" \
+  -p:UnityProjectPath="/absolute/path/to/YourUnityProject"
+```
+
+Notes:
+- If `UnityProjectPath` is omitted, checks still validate Unity API and BCL compatibility, but cannot validate references to project-defined types.
+- If `Library/ScriptAssemblies` is missing, open the project in Unity once to generate script assembly DLLs.

--- a/src/unifocl.unity.compatcheck/unifocl.unity.compatcheck.csproj
+++ b/src/unifocl.unity.compatcheck/unifocl.unity.compatcheck.csproj
@@ -1,0 +1,46 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <DefineConstants>$(DefineConstants);UNITY_EDITOR</DefineConstants>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <NoWarn>$(NoWarn);CS0649;CS1701;CS1702</NoWarn>
+    <UnityEditorManagedDir Condition="'$(UnityEditorManagedDir)' == ''">$(UNIFOCL_UNITY_EDITOR_MANAGED_DIR)</UnityEditorManagedDir>
+    <UnityProjectPath Condition="'$(UnityProjectPath)' == ''">$(UNIFOCL_UNITY_PROJECT_PATH)</UnityProjectPath>
+    <UnityScriptAssembliesDir Condition="'$(UnityScriptAssembliesDir)' == '' and '$(UnityProjectPath)' != ''">$(UnityProjectPath)/Library/ScriptAssemblies</UnityScriptAssembliesDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../unifocl.unity/SharedModels/*.cs" />
+    <Compile Include="../unifocl.unity/EditorScripts/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UnityEditorManagedDir)' != '' and Exists('$(UnityEditorManagedDir)')">
+    <UnityManagedAssembly Include="$(UnityEditorManagedDir)/*.dll" />
+    <Reference Include="@(UnityManagedAssembly)">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(UnityScriptAssembliesDir)' != '' and Exists('$(UnityScriptAssembliesDir)')">
+    <UnityProjectAssembly Include="$(UnityScriptAssembliesDir)/*.dll" />
+    <Reference Include="@(UnityProjectAssembly)">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <Target Name="ValidateUnityCompatibilityInputs" BeforeTargets="ResolveReferences">
+    <Error Condition="'$(UnityEditorManagedDir)' == ''"
+           Text="UnityEditorManagedDir is required. Set -p:UnityEditorManagedDir=&lt;Unity Managed folder&gt; or env UNIFOCL_UNITY_EDITOR_MANAGED_DIR." />
+    <Error Condition="!Exists('$(UnityEditorManagedDir)')"
+           Text="UnityEditorManagedDir does not exist: '$(UnityEditorManagedDir)'." />
+    <Error Condition="!Exists('$(UnityEditorManagedDir)/UnityEditor.dll')"
+           Text="UnityEditor.dll was not found under UnityEditorManagedDir: '$(UnityEditorManagedDir)'." />
+    <Warning Condition="'$(UnityProjectPath)' == ''"
+             Text="UnityProjectPath is not set. Project-specific assemblies (Assembly-CSharp and asmdefs) will not be referenced." />
+    <Warning Condition="'$(UnityProjectPath)' != '' and !Exists('$(UnityScriptAssembliesDir)')"
+             Text="Unity script assemblies were not found at '$(UnityScriptAssembliesDir)'. Open the project in Unity once to generate all asmdef DLLs." />
+  </Target>
+</Project>

--- a/src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs
@@ -689,7 +689,11 @@ namespace UniFocl.EditorBridge
                 normalized = normalized[1..^1];
             }
 
-            var parts = normalized.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            var parts = normalized
+                .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Trim())
+                .Where(part => part.Length > 0)
+                .ToArray();
             if (parts.Length != size)
             {
                 return false;

--- a/src/unifocl/Models/CliSessionState.cs
+++ b/src/unifocl/Models/CliSessionState.cs
@@ -23,6 +23,7 @@ internal sealed class CliSessionState
     public InspectorContext? Inspector { get; set; }
     public bool AutoEnterHierarchyRequested { get; set; }
     public ProjectViewState ProjectView { get; } = new();
+    public List<string> UnityLogPane { get; } = [];
 
     public void ResetToBoot()
     {
@@ -44,5 +45,6 @@ internal sealed class CliSessionState
         ProjectView.AssetIndexRevision = 0;
         ProjectView.AssetPathByInstanceId.Clear();
         ProjectView.LastFuzzyMatches.Clear();
+        UnityLogPane.Clear();
     }
 }

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -449,11 +449,13 @@ static int RenderComposerFrame(
     int selectedFuzzyCandidateIndex,
     bool suppressIntellisense)
 {
-    var lines = new List<string>
+    var lines = new List<string>();
+    lines.AddRange(BuildComposerUnityLogPane(session));
+    lines.AddRange(new[]
     {
         "[grey]Input[/]",
         $"[bold deepskyblue1]{Markup.Escape(BuildPromptLabel(session))}[/] [grey]>[/] [bold white]{Markup.Escape(input)}[/]"
-    };
+    });
 
     if (suppressIntellisense)
     {
@@ -493,6 +495,55 @@ static int RenderComposerFrame(
     }
 
     return lines.Count;
+}
+
+static IEnumerable<string> BuildComposerUnityLogPane(CliSessionState session)
+{
+    const int maxLogRows = 6;
+    const int fallbackPaneWidth = 78;
+    var paneWidth = Math.Max(30, (Console.IsOutputRedirected ? fallbackPaneWidth : Console.WindowWidth) - 2);
+    var border = new string('─', paneWidth);
+    var lines = new List<string>
+    {
+        $"┌{border}┐",
+        $"│{FitForPane(" UNITY LOG ", paneWidth)}│"
+    };
+
+    var visible = session.UnityLogPane.Skip(Math.Max(0, session.UnityLogPane.Count - maxLogRows)).ToList();
+    if (visible.Count == 0)
+    {
+        visible.Add("[no Unity logs]");
+    }
+
+    for (var i = 0; i < maxLogRows; i++)
+    {
+        var content = i < visible.Count ? visible[i] : string.Empty;
+        lines.Add($"│{FitForPane(content, paneWidth)}│");
+    }
+
+    lines.Add($"└{border}┘");
+    return lines;
+}
+
+static string FitForPane(string text, int width)
+{
+    if (string.IsNullOrEmpty(text))
+    {
+        return new string(' ', width);
+    }
+
+    var normalized = text.Replace(Environment.NewLine, " ").Replace("\n", " ").Replace("\r", " ");
+    if (normalized.Length > width)
+    {
+        normalized = normalized[..Math.Max(0, width - 1)] + "…";
+    }
+
+    if (normalized.Length < width)
+    {
+        normalized = normalized.PadRight(width);
+    }
+
+    return Markup.Escape(normalized);
 }
 
 static string BuildPromptLabel(CliSessionState session)

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -613,6 +613,11 @@ internal sealed class ProjectLifecycleService
         session.Mode = CliMode.Project;
         session.ContextMode = CliContextMode.Project;
         session.LastOpenedUtc = DateTimeOffset.UtcNow;
+        Environment.SetEnvironmentVariable("UNIFOCL_UNITY_PROJECT_PATH", projectPath);
+        if (!TrySaveLastUnityProjectPath(projectPath, out var configError))
+        {
+            log($"[yellow]config[/]: unable to persist unity project path ({Markup.Escape(configError ?? "unknown error")})");
+        }
         if (!_recentProjectHistoryService.TryRecordProjectOpen(projectPath, session.LastOpenedUtc.Value, out var historyError))
         {
             log($"[yellow]recent[/]: unable to update history ({Markup.Escape(historyError ?? "unknown error")})");
@@ -879,6 +884,16 @@ internal sealed class ProjectLifecycleService
                 config.Theme = themeProperty.GetString();
             }
 
+            if (document.RootElement.TryGetProperty("unityProjectPath", out var unityProjectPathProperty)
+                && unityProjectPathProperty.ValueKind == JsonValueKind.String)
+            {
+                var configuredPath = unityProjectPathProperty.GetString();
+                if (!string.IsNullOrWhiteSpace(configuredPath))
+                {
+                    config.UnityProjectPath = Path.GetFullPath(configuredPath);
+                }
+            }
+
             return true;
         }
         catch (Exception ex)
@@ -903,7 +918,11 @@ internal sealed class ProjectLifecycleService
 
             Directory.CreateDirectory(directory);
             var payload = JsonSerializer.Serialize(
-                new Dictionary<string, string?> { ["theme"] = NormalizeTheme(config.Theme) },
+                new Dictionary<string, string?>
+                {
+                    ["theme"] = NormalizeTheme(config.Theme),
+                    ["unityProjectPath"] = NormalizeProjectPath(config.UnityProjectPath)
+                },
                 new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(path, payload + Environment.NewLine);
             return true;
@@ -947,6 +966,35 @@ internal sealed class ProjectLifecycleService
         return null;
     }
 
+    private static string? NormalizeProjectPath(string? projectPath)
+    {
+        if (string.IsNullOrWhiteSpace(projectPath))
+        {
+            return null;
+        }
+
+        return Path.GetFullPath(projectPath);
+    }
+
+    private static bool TrySaveLastUnityProjectPath(string projectPath, out string? error)
+    {
+        error = null;
+        if (!TryLoadCliConfig(out var config, out var loadError))
+        {
+            error = loadError ?? "failed to read config";
+            return false;
+        }
+
+        config.UnityProjectPath = NormalizeProjectPath(projectPath);
+        if (!TrySaveCliConfig(config, out var saveError))
+        {
+            error = saveError ?? "failed to write config";
+            return false;
+        }
+
+        return true;
+    }
+
     private static string GetCliConfigPath()
     {
         var explicitPath = Environment.GetEnvironmentVariable("UNIFOCL_CONFIG_PATH");
@@ -968,5 +1016,6 @@ internal sealed class ProjectLifecycleService
     private sealed class CliConfig
     {
         public string? Theme { get; set; }
+        public string? UnityProjectPath { get; set; }
     }
 }

--- a/unifocl.sln
+++ b/unifocl.sln
@@ -7,6 +7,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unifocl", "src\unifocl\unifocl.csproj", "{B2BF5ADA-28E6-4492-9CE3-3377A206612A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unifocl.unity.compatcheck", "src\unifocl.unity.compatcheck\unifocl.unity.compatcheck.csproj", "{97016E79-23AD-4256-AEC2-0EA2DF4E34B6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,11 +31,18 @@ Global
 		{B2BF5ADA-28E6-4492-9CE3-3377A206612A}.Release|x64.Build.0 = Release|Any CPU
 		{B2BF5ADA-28E6-4492-9CE3-3377A206612A}.Release|x86.ActiveCfg = Release|Any CPU
 		{B2BF5ADA-28E6-4492-9CE3-3377A206612A}.Release|x86.Build.0 = Release|Any CPU
+		{97016E79-23AD-4256-AEC2-0EA2DF4E34B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97016E79-23AD-4256-AEC2-0EA2DF4E34B6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{97016E79-23AD-4256-AEC2-0EA2DF4E34B6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{97016E79-23AD-4256-AEC2-0EA2DF4E34B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97016E79-23AD-4256-AEC2-0EA2DF4E34B6}.Release|x64.ActiveCfg = Release|Any CPU
+		{97016E79-23AD-4256-AEC2-0EA2DF4E34B6}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B2BF5ADA-28E6-4492-9CE3-3377A206612A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{97016E79-23AD-4256-AEC2-0EA2DF4E34B6} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- Fix Unity editor bridge compile issue by replacing `StringSplitOptions.TrimEntries` usage in `DaemonInspectorService` with Unity-compatible explicit trimming.
- Add a real-assembly-based Unity compatibility check project (`src/unifocl.unity.compatcheck`) to validate editor bridge code against actual Unity managed assemblies.
- Persist last opened Unity project path on successful `/open`, `/new`, and `/clone` flow completion (`unityProjectPath` in CLI config + in-process `UNIFOCL_UNITY_PROJECT_PATH`).
- Add an always-visible TUI `UNITY LOG` pane in the interactive composer while preserving the original CLI log stream behavior.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [x] Docs
- [x] CI/Build
- [x] Chore

## Scope
- Affected areas/components:
- `src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs`
- `src/unifocl.unity.compatcheck/*`
- `src/unifocl/Services/ProjectLifecycleService.cs`
- `src/unifocl/Program.cs`
- `src/unifocl/Models/CliSessionState.cs`
- `unifocl.sln`
- Out-of-scope / intentionally not addressed:
- Wiring live Unity Editor log ingestion into `session.UnityLogPane` endpoint/transport.

## How to Test
1. Build CLI project:
   - `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Build Unity compat check against a local Unity install:
   - `dotnet build src/unifocl.unity.compatcheck/unifocl.unity.compatcheck.csproj --disable-build-servers -v minimal -p:UnityEditorManagedDir="/Applications/Unity/Hub/Editor/6000.2.6f2/Unity.app/Contents/Managed"`
3. Run CLI and verify behavior:
   - Open or create a project (`/open`, `/new`, or `/clone`) and confirm config persistence for `unityProjectPath`.
   - Verify interactive composer shows a `UNITY LOG` pane and existing CLI stream output remains unchanged.

Expected results:
- CLI project builds cleanly.
- Compatibility project builds cleanly (warning if `UnityProjectPath` is not set).
- No `TrimEntries` compile failure in Unity bridge payload code.
- `unityProjectPath` is persisted after successful project open flows.

## Screenshots / Terminal Output (if applicable)
- `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal` -> success (0 errors)
- `dotnet build src/unifocl.unity.compatcheck/unifocl.unity.compatcheck.csproj --disable-build-servers -v minimal -p:UnityEditorManagedDir=...` -> success (0 errors, warning if `UnityProjectPath` unset)

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No credentials/secrets added.
- Only local CLI config persistence for project path was extended.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
