### PR TITLE
Harden CLI error handling and markup safety

### DIFF
--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -108,40 +108,105 @@ RenderInitialLog(streamLog);
 
 while (true)
 {
-    var rawInput = ReadInput(commands, projectCommands, streamLog, session);
+    string? rawInput;
+    try
+    {
+        rawInput = ReadInput(commands, projectCommands, streamLog, session);
+    }
+    catch (Exception ex)
+    {
+        LogUnhandledException(streamLog, ex, "input");
+        continue;
+    }
+
     if (rawInput is null)
     {
-        await projectLifecycleService.PerformSafeExitCleanupAsync(
-            session,
-            daemonControlService,
-            daemonRuntime,
-            line => AppendLog(streamLog, line));
+        try
+        {
+            await projectLifecycleService.PerformSafeExitCleanupAsync(
+                session,
+                daemonControlService,
+                daemonRuntime,
+                line => AppendLog(streamLog, line));
+        }
+        catch (Exception ex)
+        {
+            LogUnhandledException(streamLog, ex, "shutdown");
+        }
+
         CliTheme.MarkupLine("[grey]Input stream closed. Session ended.[/]");
         return;
     }
 
-    var input = rawInput.Trim();
-    if (string.IsNullOrWhiteSpace(input))
+    try
     {
-        continue;
-    }
-
-    if (!input.StartsWith('/'))
-    {
-        var handledProjectCommand = await projectCommandRouterService.TryHandleProjectCommandAsync(
-            input,
-            session,
-            daemonControlService,
-            daemonRuntime,
-            line => AppendLog(streamLog, line));
-        if (!handledProjectCommand)
+        var input = rawInput.Trim();
+        if (string.IsNullOrWhiteSpace(input))
         {
-            AppendLog(streamLog, "[grey]system[/]: unknown project command; use / for command palette");
+            continue;
         }
 
-        if (handledProjectCommand && session.AutoEnterHierarchyRequested)
+        if (!input.StartsWith('/'))
         {
-            session.AutoEnterHierarchyRequested = false;
+            var handledProjectCommand = await projectCommandRouterService.TryHandleProjectCommandAsync(
+                input,
+                session,
+                daemonControlService,
+                daemonRuntime,
+                line => AppendLog(streamLog, line));
+            if (!handledProjectCommand)
+            {
+                AppendLog(streamLog, "[grey]system[/]: unknown project command; use / for command palette");
+            }
+
+            if (handledProjectCommand && session.AutoEnterHierarchyRequested)
+            {
+                session.AutoEnterHierarchyRequested = false;
+                session.ContextMode = CliContextMode.Hierarchy;
+                await hierarchyTui.RunAsync(
+                    session,
+                    daemonControlService,
+                    daemonRuntime,
+                    line => AppendLog(streamLog, line));
+                if (session.Mode == CliMode.Project)
+                {
+                    session.ContextMode = session.Inspector is null ? CliContextMode.Project : CliContextMode.Inspector;
+                }
+            }
+
+            continue;
+        }
+
+        if (input == "/")
+        {
+            continue;
+        }
+
+        input = NormalizeSlashCommand(input);
+        var matched = MatchCommand(input, commands);
+        if (matched is null)
+        {
+            AppendLog(streamLog, $"[grey]system[/]: unknown command [white]{Markup.Escape(input)}[/]");
+            continue;
+        }
+
+        if (matched.Trigger == "/quit")
+        {
+            CliTheme.MarkupLine("[grey]Session closed.[/]");
+            return;
+        }
+
+        if (matched.Trigger == "/clear")
+        {
+            streamLog.Clear();
+            SeedBootLog(streamLog);
+            AnsiConsole.Clear();
+            RenderInitialLog(streamLog);
+            continue;
+        }
+
+        if (matched.Trigger == "/hierarchy")
+        {
             session.ContextMode = CliContextMode.Hierarchy;
             await hierarchyTui.RunAsync(
                 session,
@@ -152,139 +217,100 @@ while (true)
             {
                 session.ContextMode = session.Inspector is null ? CliContextMode.Project : CliContextMode.Inspector;
             }
-        }
-        continue;
-    }
-
-    if (input == "/")
-    {
-        continue;
-    }
-
-    input = NormalizeSlashCommand(input);
-    var matched = MatchCommand(input, commands);
-    if (matched is null)
-    {
-        AppendLog(streamLog, $"[grey]system[/]: unknown command [white]{Markup.Escape(input)}[/]");
-        continue;
-    }
-
-    if (matched.Trigger == "/quit")
-    {
-        CliTheme.MarkupLine("[grey]Session closed.[/]");
-        return;
-    }
-
-    if (matched.Trigger == "/clear")
-    {
-        streamLog.Clear();
-        SeedBootLog(streamLog);
-        AnsiConsole.Clear();
-        RenderInitialLog(streamLog);
-        continue;
-    }
-
-    if (matched.Trigger == "/hierarchy")
-    {
-        session.ContextMode = CliContextMode.Hierarchy;
-        await hierarchyTui.RunAsync(
-            session,
-            daemonControlService,
-            daemonRuntime,
-            line => AppendLog(streamLog, line));
-        if (session.Mode == CliMode.Project)
-        {
-            session.ContextMode = session.Inspector is null ? CliContextMode.Project : CliContextMode.Inspector;
-        }
-        continue;
-    }
-
-    if (matched.Trigger == "/project")
-    {
-        if (session.Mode != CliMode.Project || string.IsNullOrWhiteSpace(session.CurrentProjectPath))
-        {
-            AppendLog(streamLog, "[yellow]mode[/]: open a project first with /open");
             continue;
         }
 
-        session.ContextMode = CliContextMode.Project;
-        session.Inspector = null;
-        await projectCommandRouterService.TryHandleProjectCommandAsync(
-            string.Empty,
-            session,
-            daemonControlService,
-            daemonRuntime,
-            line => AppendLog(streamLog, line));
-        continue;
-    }
-
-    if (matched.Trigger == "/inspect")
-    {
-        if (session.Mode != CliMode.Project || string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+        if (matched.Trigger == "/project")
         {
-            AppendLog(streamLog, "[yellow]mode[/]: open a project first with /open");
-            continue;
-        }
+            if (session.Mode != CliMode.Project || string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+            {
+                AppendLog(streamLog, "[yellow]mode[/]: open a project first with /open");
+                continue;
+            }
 
-        var inspectInput = input.Length > "/inspect".Length
-            ? $"inspect {input["/inspect".Length..].Trim()}"
-            : "inspect";
-        await projectCommandRouterService.TryHandleProjectCommandAsync(
-            inspectInput,
-            session,
-            daemonControlService,
-            daemonRuntime,
-            line => AppendLog(streamLog, line));
-        if (session.Inspector is not null)
-        {
-            session.ContextMode = CliContextMode.Inspector;
-        }
-        continue;
-    }
-
-    if (matched.Trigger is "/keybinds" or "/shortcuts")
-    {
-        WriteKeybindsHelp(streamLog, session);
-        continue;
-    }
-
-    AppendLog(streamLog, $"[bold deepskyblue1]unifocl[/] [grey]>[/] [white]{Markup.Escape(input)}[/]");
-    if (matched.Trigger.StartsWith("/daemon", StringComparison.Ordinal))
-    {
-        await daemonControlService.HandleDaemonCommandAsync(
-            input,
-            matched.Trigger,
-            daemonRuntime,
-            session,
-            line => AppendLog(streamLog, line),
-            streamLog);
-        continue;
-    }
-    if (await projectLifecycleService.TryHandleLifecycleCommandAsync(
-            input,
-            matched,
-            session,
-            daemonControlService,
-            daemonRuntime,
-            line => AppendLog(streamLog, line)))
-    {
-        if ((matched.Trigger == "/open" || matched.Trigger == "/new" || matched.Trigger == "/clone")
-            && session.Mode == CliMode.Project
-            && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
-        {
+            session.ContextMode = CliContextMode.Project;
+            session.Inspector = null;
             await projectCommandRouterService.TryHandleProjectCommandAsync(
                 string.Empty,
                 session,
                 daemonControlService,
                 daemonRuntime,
                 line => AppendLog(streamLog, line));
+            continue;
         }
 
-        continue;
-    }
+        if (matched.Trigger == "/inspect")
+        {
+            if (session.Mode != CliMode.Project || string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+            {
+                AppendLog(streamLog, "[yellow]mode[/]: open a project first with /open");
+                continue;
+            }
 
-    AppendLog(streamLog, $"[yellow]command[/]: not implemented yet -> {Markup.Escape(matched.Signature)}");
-    AppendLog(streamLog, "[grey]hint[/]: run /help for implemented commands and mode-specific workflows");
+            var inspectInput = input.Length > "/inspect".Length
+                ? $"inspect {input["/inspect".Length..].Trim()}"
+                : "inspect";
+            await projectCommandRouterService.TryHandleProjectCommandAsync(
+                inspectInput,
+                session,
+                daemonControlService,
+                daemonRuntime,
+                line => AppendLog(streamLog, line));
+            if (session.Inspector is not null)
+            {
+                session.ContextMode = CliContextMode.Inspector;
+            }
+            continue;
+        }
+
+        if (matched.Trigger is "/keybinds" or "/shortcuts")
+        {
+            WriteKeybindsHelp(streamLog, session);
+            continue;
+        }
+
+        AppendLog(streamLog, $"[bold deepskyblue1]unifocl[/] [grey]>[/] [white]{Markup.Escape(input)}[/]");
+        if (matched.Trigger.StartsWith("/daemon", StringComparison.Ordinal))
+        {
+            await daemonControlService.HandleDaemonCommandAsync(
+                input,
+                matched.Trigger,
+                daemonRuntime,
+                session,
+                line => AppendLog(streamLog, line),
+                streamLog);
+            continue;
+        }
+        if (await projectLifecycleService.TryHandleLifecycleCommandAsync(
+                input,
+                matched,
+                session,
+                daemonControlService,
+                daemonRuntime,
+                line => AppendLog(streamLog, line)))
+        {
+            if ((matched.Trigger == "/open" || matched.Trigger == "/new" || matched.Trigger == "/clone")
+                && session.Mode == CliMode.Project
+                && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+            {
+                await projectCommandRouterService.TryHandleProjectCommandAsync(
+                    string.Empty,
+                    session,
+                    daemonControlService,
+                    daemonRuntime,
+                    line => AppendLog(streamLog, line));
+            }
+
+            continue;
+        }
+
+        AppendLog(streamLog, $"[yellow]command[/]: not implemented yet -> {Markup.Escape(matched.Signature)}");
+        AppendLog(streamLog, "[grey]hint[/]: run /help for implemented commands and mode-specific workflows");
+    }
+    catch (Exception ex)
+    {
+        LogUnhandledException(streamLog, ex, "command");
+    }
 }
 
 static string? ReadInput(
@@ -295,7 +321,7 @@ static string? ReadInput(
 {
     if (Console.IsInputRedirected)
     {
-        CliTheme.Markup($"[bold deepskyblue1]{Markup.Escape(BuildPromptLabel(session))}[/] [grey]>[/] ");
+        CliTheme.Markup($"{BuildPromptLabelMarkup(session)} [grey]>[/] ");
         return Console.ReadLine();
     }
 
@@ -454,7 +480,7 @@ static int RenderComposerFrame(
     lines.AddRange(new[]
     {
         "[grey]Input[/]",
-        $"[bold deepskyblue1]{Markup.Escape(BuildPromptLabel(session))}[/] [grey]>[/] [bold white]{Markup.Escape(input)}[/]"
+        $"{BuildPromptLabelMarkup(session)} [grey]>[/] [bold white]{Markup.Escape(input)}[/]"
     });
 
     if (suppressIntellisense)
@@ -499,6 +525,11 @@ static int RenderComposerFrame(
 
 static IEnumerable<string> BuildComposerUnityLogPane(CliSessionState session)
 {
+    if (session.UnityLogPane.Count == 0)
+    {
+        return [];
+    }
+
     const int maxLogRows = 6;
     const int fallbackPaneWidth = 78;
     var paneWidth = Math.Max(30, (Console.IsOutputRedirected ? fallbackPaneWidth : Console.WindowWidth) - 2);
@@ -510,10 +541,6 @@ static IEnumerable<string> BuildComposerUnityLogPane(CliSessionState session)
     };
 
     var visible = session.UnityLogPane.Skip(Math.Max(0, session.UnityLogPane.Count - maxLogRows)).ToList();
-    if (visible.Count == 0)
-    {
-        visible.Add("[no Unity logs]");
-    }
 
     for (var i = 0; i < maxLogRows; i++)
     {
@@ -546,20 +573,23 @@ static string FitForPane(string text, int width)
     return Markup.Escape(normalized);
 }
 
-static string BuildPromptLabel(CliSessionState session)
+static string BuildPromptLabelMarkup(CliSessionState session)
 {
     var context = session.Inspector;
     if (context is not null)
     {
-        return context.PromptLabel;
+        var escapedPromptPath = Markup.Escape(context.PromptPath);
+        return context.Depth == InspectorDepth.ComponentList
+            ? $"[bold deepskyblue1]UnityCLI[/][grey]:[/][{CliTheme.Info}]{escapedPromptPath}[/] [grey][inspect][/]"
+            : $"[bold deepskyblue1]UnityCLI[/][grey]:[/][{CliTheme.Info}]{escapedPromptPath}[/]";
     }
 
     if (session.ContextMode == CliContextMode.Project && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
     {
-        return "unifocl:project";
+        return $"[bold deepskyblue1]unifocl[/][grey]:[/][{CliTheme.Info}]{Markup.Escape(session.CurrentProjectPath)}[/]";
     }
 
-    return "unifocl";
+    return "[bold deepskyblue1]unifocl[/]";
 }
 
 static void ClearComposerFrame(int renderedLines)
@@ -1060,4 +1090,12 @@ static void AppendLog(List<string> streamLog, string line)
 {
     streamLog.Add(line);
     CliTheme.MarkupLine(line);
+}
+
+static void LogUnhandledException(List<string> streamLog, Exception ex, string phase)
+{
+    var typeName = ex.GetType().Name;
+    AppendLog(streamLog, $"[red]error[/]: unhandled {Markup.Escape(phase)} exception <{Markup.Escape(typeName)}>");
+    AppendLog(streamLog, $"[red]error[/]: {Markup.Escape(ex.Message)}");
+    AppendLog(streamLog, "[yellow]system[/]: recovered and continuing session");
 }

--- a/src/unifocl/Services/CliTheme.cs
+++ b/src/unifocl/Services/CliTheme.cs
@@ -46,12 +46,29 @@ internal static class CliTheme
 
     public static void MarkupLine(string markupLine)
     {
-        AnsiConsole.MarkupLine(ApplyMarkupPalette(markupLine));
+        var themed = ApplyMarkupPalette(markupLine);
+        try
+        {
+            AnsiConsole.MarkupLine(themed);
+        }
+        catch (InvalidOperationException)
+        {
+            // Fallback to plain output if invalid Spectre markup slips through.
+            AnsiConsole.MarkupLine(Spectre.Console.Markup.Escape(themed));
+        }
     }
 
     public static void Markup(string markup)
     {
-        AnsiConsole.Markup(ApplyMarkupPalette(markup));
+        var themed = ApplyMarkupPalette(markup);
+        try
+        {
+            AnsiConsole.Markup(themed);
+        }
+        catch (InvalidOperationException)
+        {
+            AnsiConsole.Markup(Spectre.Console.Markup.Escape(themed));
+        }
     }
 
     public static string CursorWrapEscaped(string escapedContent)

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -108,7 +108,7 @@ internal sealed class ProjectLifecycleService
         var args = ParseCommandArgs(input, matched.Trigger);
         if (args.Count < 1)
         {
-            log("[red]error[/]: usage /new <project-name> [unity-version]");
+            log("[red]error[/]: usage /new <project-name> <unity-version?>");
             return true;
         }
 
@@ -270,7 +270,7 @@ internal sealed class ProjectLifecycleService
         var args = ParseCommandArgs(input, matched.Trigger);
         if (args.Count > 1)
         {
-            log("[red]error[/]: usage /init [path-to-project]");
+            log("[red]error[/]: usage /init <path-to-project?>");
             return Task.FromResult(true);
         }
 
@@ -309,7 +309,7 @@ internal sealed class ProjectLifecycleService
         var args = ParseCommandArgs(input, matched.Trigger);
         if (args.Count > 1)
         {
-            log("[red]error[/]: usage /recent [n]");
+            log("[red]error[/]: usage /recent <n?>");
             return Task.FromResult(true);
         }
 
@@ -351,7 +351,7 @@ internal sealed class ProjectLifecycleService
         var args = ParseCommandArgs(input, matched.Trigger);
         if (args.Count == 0)
         {
-            log("[red]error[/]: usage /config <get|set|list|reset> [theme] [value]");
+            log("[red]error[/]: usage /config <get|set|list|reset> <theme?> <value?>");
             return Task.FromResult(true);
         }
 
@@ -453,7 +453,7 @@ internal sealed class ProjectLifecycleService
     {
         if (args.Count > 1)
         {
-            log("[red]error[/]: usage /config reset [theme]");
+            log("[red]error[/]: usage /config reset <theme?>");
             return Task.FromResult(true);
         }
 
@@ -484,7 +484,7 @@ internal sealed class ProjectLifecycleService
 
     private static bool LogConfigUsage(Action<string> log)
     {
-        log("[red]error[/]: usage /config <get|set|list|reset> [theme] [value]");
+        log("[red]error[/]: usage /config <get|set|list|reset> <theme?> <value?>");
         return true;
     }
 


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Prevents the CLI from crashing when placeholder text like `[path-to-project]` is logged and interpreted as Spectre style markup.
  - Adds resilient error handling in the main REPL loop so unhandled runtime exceptions are reported and the session continues instead of abruptly terminating.
  - Hides the Unity log pane in the composer when there are no Unity log entries.
  - Ensures prompt label rendering uses explicit markup so project path coloring/styling is consistently assigned.
- Why is this change needed?
  - Users were hitting fatal runtime errors (`Could not find color or style 'path-to-project'`) and full process termination on unexpected exceptions, interrupting CLI workflows.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Program.cs`
  - `src/unifocl/Services/CliTheme.cs`
  - `src/unifocl/Services/ProjectLifecycleService.cs`
- Out-of-scope / intentionally not addressed:
  - New functional commands or protocol changes.
  - Unity-side editor bridge behavior.

## How to Test
1. Build: `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Start the CLI and run invalid `/init` usage to confirm usage text no longer crashes due to bracketed placeholders.
3. Trigger an unexpected runtime error path (or malformed markup log) and confirm the app logs the error and continues session interaction.

Expected results:
- Build succeeds.
- No abrupt app termination from markup/style parse errors.
- Unhandled exceptions are surfaced as CLI errors and the loop recovers.

## Screenshots / Terminal Output (if applicable)
- Local verification output:
  - `Build succeeded. 0 Warning(s), 0 Error(s)`

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No secrets, credentials, or external integrations added.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
