### PR TITLE
Add indexed confirm and interactive selector to /recent

### DIFF
--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -44,7 +44,7 @@ var commands = new List<CommandSpec>
     // Extended lifecycle (kept for compatibility)
     new("/new <project-name> [unity-version]", "Bootstrap a new Unity project", "/new"),
     new("/clone <git-url>", "Clone repo and set local CLI bridge config", "/clone"),
-    new("/recent [n]", "List recently opened projects", "/recent"),
+    new("/recent [idx]", "Open recent projects (interactive or by index)", "/recent"),
     new("/daemon start [--port 8080] [--unity <path>] [--project <path>] [--headless]", "Start always-warm daemon", "/daemon start"),
     new("/daemon stop", "Stop daemon", "/daemon stop"),
     new("/daemon restart", "Restart daemon", "/daemon restart"),
@@ -289,7 +289,7 @@ while (true)
                 daemonRuntime,
                 line => AppendLog(streamLog, line)))
         {
-            if ((matched.Trigger == "/open" || matched.Trigger == "/new" || matched.Trigger == "/clone")
+            if ((matched.Trigger == "/open" || matched.Trigger == "/new" || matched.Trigger == "/clone" || matched.Trigger == "/recent")
                 && session.Mode == CliMode.Project
                 && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
             {

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -22,7 +22,7 @@ internal sealed class ProjectLifecycleService
             "/open" => await HandleOpenAsync(input, matched, session, daemonControlService, daemonRuntime, log),
             "/new" => await HandleNewAsync(input, matched, session, daemonControlService, daemonRuntime, log),
             "/clone" => await HandleCloneAsync(input, matched, session, daemonControlService, daemonRuntime, log),
-            "/recent" => await HandleRecentAsync(input, matched, log),
+            "/recent" => await HandleRecentAsync(input, matched, session, daemonControlService, daemonRuntime, log),
             "/close" => await HandleCloseAsync(session, daemonControlService, daemonRuntime, log),
             "/init" => await HandleInitAsync(input, matched, session, log),
             "/config" => await HandleConfigAsync(input, matched, log),
@@ -304,23 +304,19 @@ internal sealed class ProjectLifecycleService
     private Task<bool> HandleRecentAsync(
         string input,
         CommandSpec matched,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
         Action<string> log)
     {
         var args = ParseCommandArgs(input, matched.Trigger);
         if (args.Count > 1)
         {
-            log("[red]error[/]: usage /recent <n?>");
+            log("[red]error[/]: usage /recent <idx?>");
             return Task.FromResult(true);
         }
 
-        var count = 10;
-        if (args.Count == 1 && (!int.TryParse(args[0], out count) || count <= 0))
-        {
-            log("[red]error[/]: n must be a positive integer");
-            return Task.FromResult(true);
-        }
-
-        if (!_recentProjectHistoryService.TryGetRecentProjects(count, out var entries, out var historyError))
+        if (!_recentProjectHistoryService.TryGetRecentProjects(100, out var entries, out var historyError))
         {
             log($"[red]error[/]: {Markup.Escape(historyError ?? "failed to load recent projects")}");
             return Task.FromResult(true);
@@ -332,6 +328,56 @@ internal sealed class ProjectLifecycleService
             return Task.FromResult(true);
         }
 
+        LogRecentEntries(entries, log);
+
+        if (args.Count == 1)
+        {
+            if (!int.TryParse(args[0], out var idx) || idx <= 0)
+            {
+                log("[red]error[/]: idx must be a positive integer");
+                return Task.FromResult(true);
+            }
+
+            if (idx > entries.Count)
+            {
+                log($"[red]error[/]: idx {idx} is out of range (1-{entries.Count})");
+                return Task.FromResult(true);
+            }
+
+            var selectedEntry = entries[idx - 1];
+            var confirmMessage = $"Open recent project [white]{idx}[/]: [white]{Markup.Escape(selectedEntry.ProjectPath)}[/]?";
+            if (!AnsiConsole.Confirm(confirmMessage, defaultValue: true))
+            {
+                log("[grey]recent[/]: cancelled");
+                return Task.FromResult(true);
+            }
+
+            return OpenRecentSelectionAsync(selectedEntry, session, daemonControlService, daemonRuntime, log);
+        }
+
+        if (Console.IsInputRedirected)
+        {
+            log("[yellow]recent[/]: interactive selection requires a TTY; use /recent <idx> to open a project");
+            return Task.FromResult(true);
+        }
+
+        var selected = AnsiConsole.Prompt(
+            new SelectionPrompt<RecentProjectEntry>()
+                .Title("Select a recent project to open")
+                .PageSize(Math.Min(entries.Count, 10))
+                .UseConverter(entry =>
+                {
+                    var index = entries.IndexOf(entry) + 1;
+                    var opened = entry.LastOpenedUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz");
+                    return $"{index}. {entry.ProjectPath} ({opened})";
+                })
+                .AddChoices(entries));
+
+        return OpenRecentSelectionAsync(selected, session, daemonControlService, daemonRuntime, log);
+    }
+
+    private static void LogRecentEntries(IReadOnlyList<RecentProjectEntry> entries, Action<string> log)
+    {
         log("[grey]recent[/]: most recently opened projects");
         for (var i = 0; i < entries.Count; i++)
         {
@@ -339,8 +385,24 @@ internal sealed class ProjectLifecycleService
             var opened = entry.LastOpenedUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz");
             log($"[grey]recent[/]: [white]{i + 1}[/]. [white]{Markup.Escape(entry.ProjectPath)}[/] [dim]({opened})[/]");
         }
+    }
 
-        return Task.FromResult(true);
+    private Task<bool> OpenRecentSelectionAsync(
+        RecentProjectEntry selectedEntry,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        log($"[grey]recent[/]: opening [white]{Markup.Escape(selectedEntry.ProjectPath)}[/]");
+        return TryOpenProjectAsync(
+            selectedEntry.ProjectPath,
+            session,
+            daemonControlService,
+            daemonRuntime,
+            _editorDependencyInitializerService,
+            promptForInitialization: true,
+            log);
     }
 
     private Task<bool> HandleConfigAsync(


### PR DESCRIPTION
## Summary
- Update `/recent` to support two open flows instead of list-only output.
- `/recent <idx>` now prints recents, validates index, and asks for confirmation before opening.
- `/recent` now opens an interactive selection mode (up/down + Enter) to open a highlighted recent project.
- Route `/recent` open path through normal project open lifecycle so project context refreshes like `/open`.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Services/ProjectLifecycleService.cs`
  - `src/unifocl/Program.cs`
- Out-of-scope / intentionally not addressed:
  - Multi-select recent projects
  - Persisting a dedicated cursor state outside the selection prompt

## How to Test
1. Run the CLI in an interactive terminal.
2. Execute `/recent` and verify selection UI appears; move with up/down and press Enter on an item.
3. Execute `/recent 1` (or another valid index), verify confirmation prompt appears, answer yes, and verify project opens.
4. Execute `/recent 9999` and verify out-of-range validation message.

Expected results:
- `/recent` opens selected project via interactive selector.
- `/recent <idx>` requires confirmation before opening.
- Invalid index values are rejected with clear errors.

## Screenshots / Terminal Output (if applicable)
- `dotnet build src/unifocl/unifocl.csproj` -> success, 0 warnings, 0 errors.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Command flow changes only; no new external I/O surface beyond existing project-open paths.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.