### PR TITLE
Fix project bridge stub behavior and unify command error classification

### DIFF
--- a/src/unifocl/Services/DaemonControlService.cs
+++ b/src/unifocl/Services/DaemonControlService.cs
@@ -122,7 +122,7 @@ internal sealed class DaemonControlService
         var hierarchyBridge = new HierarchyDaemonBridge(options.ProjectPath);
         using var assetIndexBridge = new AssetIndexDaemonBridge(options.ProjectPath);
         var inspectorBridge = new InspectorDaemonBridge();
-        var projectBridge = new ProjectDaemonBridge();
+        var projectBridge = new ProjectDaemonBridge(options.ProjectPath);
 
         runtime.Upsert(state);
         using var cts = new CancellationTokenSource();

--- a/src/unifocl/Services/ProjectDaemonBridge.cs
+++ b/src/unifocl/Services/ProjectDaemonBridge.cs
@@ -2,7 +2,17 @@ using System.Text.Json;
 
 internal sealed class ProjectDaemonBridge
 {
+    public const string StubbedBridgePrefix = "stubbed bridge:";
+
     private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly string _projectPath;
+
+    public ProjectDaemonBridge(string? projectPath)
+    {
+        _projectPath = string.IsNullOrWhiteSpace(projectPath)
+            ? Directory.GetCurrentDirectory()
+            : projectPath;
+    }
 
     public bool TryHandle(string? commandLine, out string response)
     {
@@ -12,9 +22,221 @@ internal sealed class ProjectDaemonBridge
             return false;
         }
 
-        response = JsonSerializer.Serialize(
-            new ProjectCommandResponseDto(false, "project commands require Unity editor bridge", null),
-            _jsonOptions);
+        var payload = commandLine["PROJECT_CMD ".Length..];
+        ProjectCommandRequestDto? request;
+        try
+        {
+            request = JsonSerializer.Deserialize<ProjectCommandRequestDto>(payload, _jsonOptions);
+        }
+        catch (JsonException)
+        {
+            response = SerializeError($"{StubbedBridgePrefix} invalid project command payload");
+            return true;
+        }
+
+        if (request is null || string.IsNullOrWhiteSpace(request.Action))
+        {
+            response = SerializeError($"{StubbedBridgePrefix} missing project command payload");
+            return true;
+        }
+
+        var result = request.Action switch
+        {
+            "mk-script" => HandleCreateScript(request),
+            "rename-asset" => HandleRenameAsset(request),
+            "remove-asset" => HandleRemoveAsset(request),
+            "load-asset" => HandleLoadAsset(request),
+            _ => new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} unsupported action: {request.Action}", null)
+        };
+        response = JsonSerializer.Serialize(result, _jsonOptions);
         return true;
+    }
+
+    private ProjectCommandResponseDto HandleCreateScript(ProjectCommandRequestDto request)
+    {
+        if (!IsValidAssetPath(request.AssetPath) || string.IsNullOrWhiteSpace(request.Content))
+        {
+            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} mk-script requires assetPath and content", null);
+        }
+
+        var absolutePath = ResolveAssetPath(request.AssetPath!);
+        if (File.Exists(absolutePath))
+        {
+            return new ProjectCommandResponseDto(false, $"asset already exists: {request.AssetPath}", null);
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(absolutePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(absolutePath, request.Content);
+            return new ProjectCommandResponseDto(true, "script created (stubbed bridge fallback)", "script");
+        }
+        catch (Exception ex)
+        {
+            return new ProjectCommandResponseDto(false, $"failed to create script: {ex.Message}", null);
+        }
+    }
+
+    private ProjectCommandResponseDto HandleRenameAsset(ProjectCommandRequestDto request)
+    {
+        if (!IsValidAssetPath(request.AssetPath) || !IsValidAssetPath(request.NewAssetPath))
+        {
+            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} rename-asset requires assetPath and newAssetPath", null);
+        }
+
+        var sourcePath = ResolveAssetPath(request.AssetPath!);
+        var targetPath = ResolveAssetPath(request.NewAssetPath!);
+        if (!File.Exists(sourcePath) && !Directory.Exists(sourcePath))
+        {
+            return new ProjectCommandResponseDto(false, $"asset not found: {request.AssetPath}", null);
+        }
+
+        if (File.Exists(targetPath) || Directory.Exists(targetPath))
+        {
+            return new ProjectCommandResponseDto(false, $"target already exists: {request.NewAssetPath}", null);
+        }
+
+        try
+        {
+            var targetDirectory = Path.GetDirectoryName(targetPath);
+            if (!string.IsNullOrWhiteSpace(targetDirectory))
+            {
+                Directory.CreateDirectory(targetDirectory);
+            }
+
+            if (Directory.Exists(sourcePath))
+            {
+                Directory.Move(sourcePath, targetPath);
+            }
+            else
+            {
+                File.Move(sourcePath, targetPath);
+            }
+
+            MoveMetaIfPresent(sourcePath, targetPath);
+            return new ProjectCommandResponseDto(true, "asset renamed (stubbed bridge fallback)", null);
+        }
+        catch (Exception ex)
+        {
+            return new ProjectCommandResponseDto(false, $"failed to rename asset: {ex.Message}", null);
+        }
+    }
+
+    private ProjectCommandResponseDto HandleRemoveAsset(ProjectCommandRequestDto request)
+    {
+        if (!IsValidAssetPath(request.AssetPath))
+        {
+            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} remove-asset requires assetPath", null);
+        }
+
+        var absolutePath = ResolveAssetPath(request.AssetPath!);
+        if (!File.Exists(absolutePath) && !Directory.Exists(absolutePath))
+        {
+            return new ProjectCommandResponseDto(false, $"asset not found: {request.AssetPath}", null);
+        }
+
+        try
+        {
+            if (Directory.Exists(absolutePath))
+            {
+                Directory.Delete(absolutePath, recursive: true);
+            }
+            else
+            {
+                File.Delete(absolutePath);
+            }
+
+            DeleteMetaIfPresent(absolutePath);
+            return new ProjectCommandResponseDto(true, "asset removed (stubbed bridge fallback)", null);
+        }
+        catch (Exception ex)
+        {
+            return new ProjectCommandResponseDto(false, $"failed to remove asset: {ex.Message}", null);
+        }
+    }
+
+    private ProjectCommandResponseDto HandleLoadAsset(ProjectCommandRequestDto request)
+    {
+        if (!IsValidAssetPath(request.AssetPath))
+        {
+            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} load-asset requires assetPath", null);
+        }
+
+        var assetPath = request.AssetPath!;
+        var absolutePath = ResolveAssetPath(assetPath);
+        if (!File.Exists(absolutePath))
+        {
+            return new ProjectCommandResponseDto(false, $"asset not found: {request.AssetPath}", null);
+        }
+
+        var extension = Path.GetExtension(assetPath);
+        if (extension.Equals(".unity", StringComparison.OrdinalIgnoreCase))
+        {
+            return new ProjectCommandResponseDto(
+                true,
+                "scene path resolved (stubbed bridge fallback; Unity scene load unavailable)",
+                "scene");
+        }
+
+        if (extension.Equals(".cs", StringComparison.OrdinalIgnoreCase))
+        {
+            return new ProjectCommandResponseDto(
+                true,
+                "script path resolved (stubbed bridge fallback; Unity script open unavailable)",
+                "script");
+        }
+
+        return new ProjectCommandResponseDto(
+            false,
+            $"unsupported asset type: {extension} (supported: .unity, .cs)",
+            null);
+    }
+
+    private static bool IsValidAssetPath(string? assetPath)
+    {
+        return !string.IsNullOrWhiteSpace(assetPath)
+               && assetPath.StartsWith("Assets/", StringComparison.Ordinal)
+               && !assetPath.Contains("..", StringComparison.Ordinal);
+    }
+
+    private string ResolveAssetPath(string assetPath)
+    {
+        return Path.GetFullPath(Path.Combine(_projectPath, assetPath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static void MoveMetaIfPresent(string sourcePath, string targetPath)
+    {
+        var sourceMeta = sourcePath + ".meta";
+        var targetMeta = targetPath + ".meta";
+        if (!File.Exists(sourceMeta))
+        {
+            return;
+        }
+
+        if (File.Exists(targetMeta))
+        {
+            File.Delete(targetMeta);
+        }
+
+        File.Move(sourceMeta, targetMeta);
+    }
+
+    private static void DeleteMetaIfPresent(string absolutePath)
+    {
+        var metaPath = absolutePath + ".meta";
+        if (File.Exists(metaPath))
+        {
+            File.Delete(metaPath);
+        }
+    }
+
+    private string SerializeError(string message)
+    {
+        return JsonSerializer.Serialize(new ProjectCommandResponseDto(false, message, null), _jsonOptions);
     }
 }

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -397,7 +397,7 @@ internal sealed class ProjectViewService
 
             if (!response.Ok)
             {
-                outputs.Add($"[x] create failed: {response.Message}");
+                outputs.Add(FormatProjectCommandFailure("create", response.Message));
                 return true;
             }
 
@@ -430,7 +430,7 @@ internal sealed class ProjectViewService
                 new ProjectCommandRequestDto("remove-asset", target.RelativePath, null, null));
             if (!response.Ok)
             {
-                outputs.Add($"[x] remove failed: {response.Message}");
+                outputs.Add(FormatProjectCommandFailure("remove", response.Message));
                 return true;
             }
 
@@ -476,7 +476,7 @@ internal sealed class ProjectViewService
             new ProjectCommandRequestDto("load-asset", target.RelativePath, null, null));
         if (!response.Ok)
         {
-            outputs.Add($"[x] load failed: {response.Message}");
+            outputs.Add(FormatProjectCommandFailure("load", response.Message));
             return true;
         }
 
@@ -524,7 +524,7 @@ internal sealed class ProjectViewService
                 new ProjectCommandRequestDto("rename-asset", target.RelativePath, destinationRelative, null));
             if (!response.Ok)
             {
-                outputs.Add($"[x] rename failed: {response.Message}");
+                outputs.Add(FormatProjectCommandFailure("rename", response.Message));
                 return true;
             }
 
@@ -833,6 +833,37 @@ $"using UnityEngine;{Environment.NewLine}{Environment.NewLine}public class #NAME
             "animation" => ext is ".anim" or ".controller",
             _ => path.Contains(typeFilter, StringComparison.OrdinalIgnoreCase)
         };
+    }
+
+    private static string FormatProjectCommandFailure(string action, string? message)
+    {
+        var (category, hint) = ClassifyProjectBridgeFailure(message);
+        var details = string.IsNullOrWhiteSpace(message) ? "unknown error" : message;
+        return string.IsNullOrWhiteSpace(hint)
+            ? $"[x] {action} failed ({category}): {details}"
+            : $"[x] {action} failed ({category}): {details} [grey]{hint}[/]";
+    }
+
+    private static (string Category, string Hint) ClassifyProjectBridgeFailure(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return ("bridge runtime error", "Command is implemented; inspect bridge logs for details.");
+        }
+
+        if (message.StartsWith(ProjectDaemonBridge.StubbedBridgePrefix, StringComparison.Ordinal))
+        {
+            return ("stubbed bridge", "This daemon path is not implemented; run with Unity editor bridge attached.");
+        }
+
+        if (message.Contains("daemon did not return", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("daemon returned", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("daemon is not attached", StringComparison.OrdinalIgnoreCase))
+        {
+            return ("bridge transport error", "Bridge connection failed; ensure daemon/editor bridge is running and attached.");
+        }
+
+        return ("bridge runtime error", "Command is implemented; bridge returned an operational error.");
     }
 
     private static List<string> Tokenize(string input)


### PR DESCRIPTION
## Summary
- Implemented `ProjectDaemonBridge` command handling instead of returning a constant stub failure.
- Added fallback implementations for `mk-script`, `rename-asset`, `remove-asset`, and `load-asset` in daemon-side bridge mode.
- Unified project command error classification for `mk script`, `load`, `rename`, and `rm` to clearly distinguish:
  - `stubbed bridge`
  - `bridge transport error`
  - `bridge runtime error`
- Passed project path into `ProjectDaemonBridge` initialization so fallback file operations resolve correctly.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Services/ProjectDaemonBridge.cs`
  - `src/unifocl/Services/ProjectViewService.cs`
  - `src/unifocl/Services/DaemonControlService.cs`
- Out-of-scope / intentionally not addressed:
  - Unity editor-side bridge behavior in `src/unifocl.unity`
  - Additional UI copy beyond project command failures

## How to Test
1. `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Run CLI in project mode and trigger `mk script`, `load`, `rename`, and `rm` paths with/without attached bridge.
3. Verify failure messages now classify root cause category consistently.

Expected results:
- Build succeeds.
- All four commands show consistent and explicit failure category/hint text.
- Stubbed-path failures are clearly distinguished from transport/runtime failures.

## Screenshots / Terminal Output (if applicable)
- Build output:
  - `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
  - `Build succeeded. 0 Warning(s), 0 Error(s)`

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No credentials, tokens, or secrets introduced.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
