### PR TITLE
Fix command IntelliSense Enter to insert suggestion instead of executing

### DIFF
--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -364,16 +364,20 @@ static string? ReadInteractiveInput(
         switch (key.Key)
         {
             case ConsoleKey.Enter:
-                Console.WriteLine();
                 if (intellisenseSelectionArmed
                     && candidates.Count > 0
                     && selectedIntellisenseCandidateIndex >= 0
                     && selectedIntellisenseCandidateIndex < candidates.Count
                     && !string.IsNullOrWhiteSpace(candidates[selectedIntellisenseCandidateIndex].CommitCommand))
                 {
-                    return candidates[selectedIntellisenseCandidateIndex].CommitCommand!;
+                    input.Clear();
+                    input.Append(candidates[selectedIntellisenseCandidateIndex].CommitCommand!);
+                    intellisenseDismissed = false;
+                    intellisenseSelectionArmed = false;
+                    break;
                 }
 
+                Console.WriteLine();
                 return input.ToString();
             case ConsoleKey.Backspace:
                 if (input.Length > 0)
@@ -717,7 +721,7 @@ static void WriteKeybindsHelp(List<string> streamLog, CliSessionState session)
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F8[/] enter/exit inspector focus mode (inspector context)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]Esc[/] dismiss intellisense (or clear input if already dismissed)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]↑/↓[/] fuzzy candidate selection in composer");
-    AppendLog(streamLog, "[grey]keybinds[/]: [white]Enter[/] commit command/input");
+    AppendLog(streamLog, "[grey]keybinds[/]: [white]Enter[/] insert selected intellisense suggestion, or commit input when none selected");
 
     AppendLog(streamLog, "[grey]keybinds[/]: hierarchy focus");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]↑/↓[/] move highlighted GameObject");
@@ -800,7 +804,7 @@ static IEnumerable<string> GetSuggestionLines(string query, List<CommandSpec> co
     {
         return new[]
         {
-            "[grey]intellisense[/]: command suggestions [dim](up/down + enter)[/]",
+            "[grey]intellisense[/]: command suggestions [dim](up/down + enter to insert)[/]",
             $"[dim]no matches for {Markup.Escape(query)}[/]"
         };
     }
@@ -808,7 +812,7 @@ static IEnumerable<string> GetSuggestionLines(string query, List<CommandSpec> co
     var selected = Math.Clamp(selectedSuggestionIndex, 0, matches.Count - 1);
     var lines = new List<string>
     {
-        "[grey]intellisense[/]: command suggestions [dim](up/down + enter)[/]"
+        "[grey]intellisense[/]: command suggestions [dim](up/down + enter to insert)[/]"
     };
     for (var i = 0; i < matches.Count; i++)
     {
@@ -848,7 +852,7 @@ static bool TryGetFuzzyQueryIntellisenseLines(string input, CliSessionState sess
         return false;
     }
 
-    lines.Add($"[grey]fuzzy[/]: {Markup.Escape(modeLabel)} [dim](up/down + enter)[/]");
+    lines.Add($"[grey]fuzzy[/]: {Markup.Escape(modeLabel)} [dim](up/down + enter to insert)[/]");
     if (candidates.Count == 0)
     {
         lines.Add($"[dim]{Markup.Escape(emptyLabel)}[/]");


### PR DESCRIPTION
## Summary
- Change composer IntelliSense Enter behavior to insert the selected suggestion into the input buffer instead of immediately executing it.
- Keep command execution on Enter only when no IntelliSense selection is armed.
- Update IntelliSense and keybind hint text to reflect "enter to insert" behavior.
- This is needed because commands requiring arguments could not be completed when suggestion selection immediately executed.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
- `src/unifocl/Program.cs` interactive composer input handling and IntelliSense hint strings.
- Out-of-scope / intentionally not addressed:
- No changes to daemon commands, project/inspector/hierarchy command handlers, or command matching rules.

## How to Test
1. Build CLI project:
   - `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Run CLI, type a partial command that has IntelliSense results (for example in project mode, type `load`).
3. Use `↑/↓` to select a suggestion and press `Enter`.
4. Confirm the selected command is inserted into input and not executed yet.
5. Add required arguments and press `Enter` again.

Expected results:
- Enter with active IntelliSense selection inserts suggestion into composer input.
- Command executes only when Enter is pressed without an active selection.

## Screenshots / Terminal Output (if applicable)
- Local build output:
  - `Build succeeded.`
  - `0 Warning(s)`
  - `0 Error(s)`

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Input handling/UI behavior only; no credential, network, or persistence behavior changed.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
