### PR TITLE
Auto-attach daemon state on project open

### DIFF
--- a/src/unifocl/Services/DaemonControlService.cs
+++ b/src/unifocl/Services/DaemonControlService.cs
@@ -342,10 +342,8 @@ internal sealed class DaemonControlService
         var existing = runtime.GetByPort(port);
 
         // Unity's InitializeOnLoad bridge can already be serving this port even when it's not in runtime registry.
-        if (await TrySendControlAsync(port, "PING", "PONG"))
+        if (await TryAttachProjectDaemonAsync(projectPath, session, attemptCount: 1))
         {
-            session.AttachedPort = port;
-            await TrySendControlAsync(port, "TOUCH", "OK");
             return true;
         }
 
@@ -369,6 +367,36 @@ internal sealed class DaemonControlService
         session.AttachedPort = port;
         await TrySendControlAsync(port, "TOUCH", "OK");
         return true;
+    }
+
+    public async Task<bool> TryAttachProjectDaemonAsync(
+        string projectPath,
+        CliSessionState session,
+        Action<string>? log = null,
+        int attemptCount = 8,
+        int attemptDelayMs = 250)
+    {
+        var port = ComputeProjectDaemonPort(projectPath);
+        var normalizedAttemptCount = Math.Max(1, attemptCount);
+        var normalizedDelayMs = Math.Max(50, attemptDelayMs);
+
+        for (var attempt = 1; attempt <= normalizedAttemptCount; attempt++)
+        {
+            if (await TrySendControlAsync(port, "PING", "PONG"))
+            {
+                session.AttachedPort = port;
+                await TrySendControlAsync(port, "TOUCH", "OK");
+                return true;
+            }
+
+            if (attempt < normalizedAttemptCount)
+            {
+                await Task.Delay(normalizedDelayMs);
+            }
+        }
+
+        log?.Invoke($"[yellow]daemon[/]: project daemon endpoint 127.0.0.1:{port} is not ready for attachment");
+        return false;
     }
 
     public async Task<bool> TouchAttachedDaemonAsync(CliSessionState session)

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -654,9 +654,16 @@ internal sealed class ProjectLifecycleService
         var daemonPort = DaemonControlService.ComputeProjectDaemonPort(projectPath);
         if (DaemonControlService.IsUnityClientActiveForProject(projectPath))
         {
-            session.AttachedPort = null;
+            await daemonControlService.TryAttachProjectDaemonAsync(projectPath, session, log);
             SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, false));
-            log("[grey]daemon[/]: Unity editor lock detected; routing operations via InitializeOnLoad bridge");
+            if (session.AttachedPort == daemonPort)
+            {
+                log($"[grey]daemon[/]: Unity editor lock detected; attached bridge on [white]127.0.0.1:{daemonPort}[/]");
+            }
+            else
+            {
+                log("[grey]daemon[/]: Unity editor lock detected; routing operations via InitializeOnLoad bridge");
+            }
         }
         else
         {

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -684,10 +684,13 @@ internal sealed class ProjectViewService
             return;
         }
 
-        if (!DaemonControlService.IsUnityClientActiveForProject(session.CurrentProjectPath))
+        if (DaemonControlService.IsUnityClientActiveForProject(session.CurrentProjectPath))
         {
-            await daemonControlService.EnsureProjectDaemonAsync(session.CurrentProjectPath, daemonRuntime, session, _ => { });
+            await daemonControlService.TryAttachProjectDaemonAsync(session.CurrentProjectPath, session);
+            return;
         }
+
+        await daemonControlService.EnsureProjectDaemonAsync(session.CurrentProjectPath, daemonRuntime, session, _ => { });
     }
 
     private static (string TemplateName, string TemplateSource, string Content) ResolveTemplate(string projectPath)


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Auto-attaches to the project daemon endpoint when opening a Unity project, including Unity-lock mode.
  - Adds retry-based daemon attachment to improve readiness at project-open time.
  - Updates project view context bootstrap to attach in Unity-active mode before running commands.
- Why is this change needed?
  - Project operations should work immediately after `/open` without requiring manual daemon attach.
  - Previously, Unity-lock mode explicitly cleared `AttachedPort`, which could leave project operations unavailable by default.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Services/DaemonControlService.cs`
  - `src/unifocl/Services/ProjectLifecycleService.cs`
  - `src/unifocl/Services/ProjectViewService.cs`
- Out-of-scope / intentionally not addressed:
  - No changes to Unity bridge protocol payloads.
  - No daemon process model redesign.

## How to Test
1. Build: `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Open a Unity project via `/open <path>` while Unity is running (lock present).
3. Run project operations that require daemon attachment (e.g. project view commands) and confirm they work without manual `/daemon attach`.

Expected results:
- `/open` leaves the session in a usable attached-ready state when endpoint is available.
- Project operations execute by default after open.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Changes are limited to daemon/session lifecycle flow; no secret handling or auth surface changes.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
