### PR TITLE
Fix project mode asset commands failing on stale paths

### DIFF
--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -425,16 +425,30 @@ internal sealed class ProjectViewService
         state.DbState = ProjectDbState.LockedImporting;
         try
         {
+            var sourcePath = target.RelativePath;
             var response = await ExecuteProjectCommandAsync(
                 session,
-                new ProjectCommandRequestDto("remove-asset", target.RelativePath, null, null));
+                new ProjectCommandRequestDto("remove-asset", sourcePath, null, null));
+            if (!response.Ok && IsAssetNotFoundFailure(response.Message))
+            {
+                var fallbackPath = await ResolveAssetFallbackPathAsync(session, sourcePath, allowDirectoryFallback: target.IsDirectory);
+                if (!string.IsNullOrWhiteSpace(fallbackPath)
+                    && !fallbackPath.Equals(sourcePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    sourcePath = fallbackPath;
+                    response = await ExecuteProjectCommandAsync(
+                        session,
+                        new ProjectCommandRequestDto("remove-asset", sourcePath, null, null));
+                }
+            }
+
             if (!response.Ok)
             {
                 outputs.Add(FormatProjectCommandFailure("remove", response.Message));
                 return true;
             }
 
-            outputs.Add($"[=] removed: {target.RelativePath}");
+            outputs.Add($"[=] removed: {sourcePath}");
             if (!string.IsNullOrWhiteSpace(session.CurrentProjectPath))
             {
                 RefreshTree(session.CurrentProjectPath, state);
@@ -474,6 +488,18 @@ internal sealed class ProjectViewService
         var response = await ExecuteProjectCommandAsync(
             session,
             new ProjectCommandRequestDto("load-asset", target.RelativePath, null, null));
+        if (!response.Ok && IsAssetNotFoundFailure(response.Message))
+        {
+            var fallbackPath = await ResolveAssetFallbackPathAsync(session, target.RelativePath, allowDirectoryFallback: false);
+            if (!string.IsNullOrWhiteSpace(fallbackPath)
+                && !fallbackPath.Equals(target.RelativePath, StringComparison.OrdinalIgnoreCase))
+            {
+                response = await ExecuteProjectCommandAsync(
+                    session,
+                    new ProjectCommandRequestDto("load-asset", fallbackPath, null, null));
+            }
+        }
+
         if (!response.Ok)
         {
             outputs.Add(FormatProjectCommandFailure("load", response.Message));
@@ -510,18 +536,29 @@ internal sealed class ProjectViewService
             return true;
         }
 
-        var parentRelative = Path.GetDirectoryName(target.RelativePath)?.Replace('\\', '/') ?? string.Empty;
-        var finalName = target.IsDirectory
-            ? newName
-            : (Path.HasExtension(newName) ? newName : $"{newName}{Path.GetExtension(target.Name)}");
-        var destinationRelative = string.IsNullOrEmpty(parentRelative) ? finalName : $"{parentRelative}/{finalName}";
+        var sourceRelativePath = target.RelativePath;
+        var destinationRelative = ComputeRenameDestinationPath(sourceRelativePath, target.IsDirectory, newName);
 
         state.DbState = ProjectDbState.LockedImporting;
         try
         {
             var response = await ExecuteProjectCommandAsync(
                 session,
-                new ProjectCommandRequestDto("rename-asset", target.RelativePath, destinationRelative, null));
+                new ProjectCommandRequestDto("rename-asset", sourceRelativePath, destinationRelative, null));
+            if (!response.Ok && IsAssetNotFoundFailure(response.Message))
+            {
+                var fallbackPath = await ResolveAssetFallbackPathAsync(session, sourceRelativePath, allowDirectoryFallback: target.IsDirectory);
+                if (!string.IsNullOrWhiteSpace(fallbackPath)
+                    && !fallbackPath.Equals(sourceRelativePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    sourceRelativePath = fallbackPath;
+                    destinationRelative = ComputeRenameDestinationPath(sourceRelativePath, target.IsDirectory, newName);
+                    response = await ExecuteProjectCommandAsync(
+                        session,
+                        new ProjectCommandRequestDto("rename-asset", sourceRelativePath, destinationRelative, null));
+                }
+            }
+
             if (!response.Ok)
             {
                 outputs.Add(FormatProjectCommandFailure("rename", response.Message));
@@ -555,7 +592,8 @@ internal sealed class ProjectViewService
 
     private static ProjectTreeEntry? FindEntryBySelector(ProjectViewState state, string selector)
     {
-        if (int.TryParse(selector, out var index))
+        var normalizedSelector = NormalizeLoadSelector(selector);
+        if (int.TryParse(normalizedSelector, out var index))
         {
             var visible = state.VisibleEntries.FirstOrDefault(entry => entry.Index == index);
             if (visible is not null)
@@ -573,11 +611,118 @@ internal sealed class ProjectViewService
             return null;
         }
 
-        var normalized = selector.Trim().Replace('\\', '/');
+        var normalized = normalizedSelector.Replace('\\', '/');
         return state.VisibleEntries.FirstOrDefault(entry =>
             entry.Name.Equals(normalized, StringComparison.OrdinalIgnoreCase)
             || entry.RelativePath.Equals(normalized, StringComparison.OrdinalIgnoreCase)
             || entry.RelativePath.EndsWith("/" + normalized, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizeLoadSelector(string selector)
+    {
+        var normalized = selector.Trim();
+        if (normalized.Length >= 2
+            && ((normalized.StartsWith('<') && normalized.EndsWith('>'))
+                || (normalized.StartsWith('"') && normalized.EndsWith('"'))
+                || (normalized.StartsWith('\'') && normalized.EndsWith('\''))))
+        {
+            normalized = normalized[1..^1].Trim();
+        }
+
+        return normalized;
+    }
+
+    private static string ComputeRenameDestinationPath(string sourceRelativePath, bool isDirectory, string newName)
+    {
+        var parentRelative = Path.GetDirectoryName(sourceRelativePath)?.Replace('\\', '/') ?? string.Empty;
+        var sourceName = Path.GetFileName(sourceRelativePath);
+        var finalName = isDirectory
+            ? newName
+            : (Path.HasExtension(newName) ? newName : $"{newName}{Path.GetExtension(sourceName)}");
+        return string.IsNullOrEmpty(parentRelative) ? finalName : $"{parentRelative}/{finalName}";
+    }
+
+    private async Task<string?> ResolveAssetFallbackPathAsync(CliSessionState session, string targetRelativePath, bool allowDirectoryFallback)
+    {
+        var targetPath = targetRelativePath.Replace('\\', '/');
+        if (!string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+        {
+            var targetAbsolutePath = ResolveAbsolutePath(session.CurrentProjectPath, targetPath);
+            if (File.Exists(targetAbsolutePath) || Directory.Exists(targetAbsolutePath))
+            {
+                return targetPath;
+            }
+        }
+
+        await SyncAssetIndexAsync(session);
+        var paths = session.ProjectView.AssetPathByInstanceId.Values
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (paths.Count > 0)
+        {
+            var exact = paths.FirstOrDefault(path => path.Equals(targetPath, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(exact))
+            {
+                return exact;
+            }
+
+            var fileName = Path.GetFileName(targetPath);
+            if (!string.IsNullOrWhiteSpace(fileName))
+            {
+                var sameFileName = paths
+                    .Where(path => Path.GetFileName(path).Equals(fileName, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                if (sameFileName.Count == 1)
+                {
+                    return sameFileName[0];
+                }
+
+                var extension = Path.GetExtension(fileName);
+                if (!string.IsNullOrWhiteSpace(extension))
+                {
+                    var stem = Path.GetFileNameWithoutExtension(fileName);
+                    var sameStem = paths
+                        .Where(path => Path.GetExtension(path).Equals(extension, StringComparison.OrdinalIgnoreCase))
+                        .Where(path => Path.GetFileNameWithoutExtension(path).Equals(stem, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+                    if (sameStem.Count == 1)
+                    {
+                        return sameStem[0];
+                    }
+                }
+            }
+        }
+
+        if (!allowDirectoryFallback || string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+        {
+            return null;
+        }
+
+        var projectAssetsPath = Path.Combine(session.CurrentProjectPath, "Assets");
+        if (!Directory.Exists(projectAssetsPath))
+        {
+            return null;
+        }
+
+        var targetDirectoryName = Path.GetFileName(targetPath.TrimEnd('/', '\\'));
+        if (string.IsNullOrWhiteSpace(targetDirectoryName))
+        {
+            return null;
+        }
+
+        var matchingDirectories = Directory
+            .EnumerateDirectories(projectAssetsPath, targetDirectoryName, SearchOption.AllDirectories)
+            .Select(path => "Assets/" + Path.GetRelativePath(projectAssetsPath, path).Replace('\\', '/'))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return matchingDirectories.Count == 1 ? matchingDirectories[0] : null;
+    }
+
+    private static bool IsAssetNotFoundFailure(string? message)
+    {
+        return !string.IsNullOrWhiteSpace(message)
+               && message.Contains("asset not found", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<bool> HandleFuzzyFindAsync(CliSessionState session, IReadOnlyList<string> tokens, List<string> outputs)


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Hardens project-mode asset commands (`load`, `rm`, `rename`) against `asset not found` failures caused by path/index drift.
  - Adds a shared fallback resolver that retries commands with canonical asset paths from the synced daemon asset index.
  - Normalizes `load` selectors like `<scene>` and quoted selectors so they resolve consistently.
- Why is this change needed?
  - Scene/script/assets may exist with correct logical target, but daemon command can fail when the forwarded path is stale or differently resolved.
  - This adds a safe, single-retry recovery path without changing normal success flow.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Services/ProjectViewService.cs`
  - Project mode command handlers for `load`, `rm`, and `rename`
- Out-of-scope / intentionally not addressed:
  - Unity editor-side daemon command implementation changes
  - Non-project-mode command flows

## How to Test
1. Open a Unity project in CLI project mode.
2. Run `load <scene>` (or quoted selector) and verify it resolves and loads scene/script when initial path resolution is stale.
3. Run `rm <idx>` and `rename <idx> <new-name>` against items that can reproduce stale path mismatch and verify retry succeeds.

Expected results:
- Commands succeed after internal fallback retry when first attempt returns `asset not found`.
- Normal command behavior remains unchanged when first attempt succeeds.

## Screenshots / Terminal Output (if applicable)
- Build command:
  - `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
  - Result: success (0 errors), NU1900 warnings due to unreachable NuGet vulnerability feed in restricted network.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No secrets, credentials, or external data handling changes.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
