### PR TITLE
Improve Unity daemon preflight, startup reliability, and compile-error handling

### DIFF
--- a/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace UniFocl.EditorBridge
 {
@@ -117,13 +118,49 @@ namespace UniFocl.EditorBridge
             var extension = Path.GetExtension(request.assetPath);
             if (extension.Equals(".unity", StringComparison.OrdinalIgnoreCase))
             {
-                if (!File.Exists(Path.Combine(GetProjectRoot(), request.assetPath.Replace('/', Path.DirectorySeparatorChar))))
+                var requestedScenePath = request.assetPath.Replace('\\', '/');
+                if (!File.Exists(Path.Combine(GetProjectRoot(), requestedScenePath.Replace('/', Path.DirectorySeparatorChar))))
                 {
                     return JsonUtility.ToJson(new ProjectCommandResponse { ok = false, message = $"scene not found: {request.assetPath}" });
                 }
 
-                EditorSceneManager.OpenScene(request.assetPath);
-                return JsonUtility.ToJson(new ProjectCommandResponse { ok = true, message = "scene loaded", kind = "scene" });
+                try
+                {
+                    var loadedScene = EditorSceneManager.OpenScene(requestedScenePath, OpenSceneMode.Single);
+                    if (!loadedScene.IsValid() || !loadedScene.isLoaded)
+                    {
+                        return JsonUtility.ToJson(new ProjectCommandResponse { ok = false, message = $"scene load failed: {requestedScenePath}" });
+                    }
+
+                    var loadedScenePath = loadedScene.path.Replace('\\', '/');
+                    if (!loadedScenePath.Equals(requestedScenePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return JsonUtility.ToJson(new ProjectCommandResponse
+                        {
+                            ok = false,
+                            message = $"scene load failed: requested '{requestedScenePath}', loaded '{loadedScenePath}'"
+                        });
+                    }
+
+                    if (!SceneManager.SetActiveScene(loadedScene))
+                    {
+                        return JsonUtility.ToJson(new ProjectCommandResponse
+                        {
+                            ok = false,
+                            message = $"scene load failed: unable to activate scene '{requestedScenePath}'"
+                        });
+                    }
+
+                    return JsonUtility.ToJson(new ProjectCommandResponse { ok = true, message = "scene loaded", kind = "scene" });
+                }
+                catch (Exception ex)
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = $"scene load failed: {ex.Message}"
+                    });
+                }
             }
 
             if (extension.Equals(".cs", StringComparison.OrdinalIgnoreCase))

--- a/src/unifocl/Models/CliSessionState.cs
+++ b/src/unifocl/Models/CliSessionState.cs
@@ -24,6 +24,8 @@ internal sealed class CliSessionState
     public bool AutoEnterHierarchyRequested { get; set; }
     public ProjectViewState ProjectView { get; } = new();
     public List<string> UnityLogPane { get; } = [];
+    public bool SafeModeEnabled { get; set; }
+    public CompileErrorState? LastCompileError { get; set; }
 
     public void ResetToBoot()
     {
@@ -46,5 +48,13 @@ internal sealed class CliSessionState
         ProjectView.AssetPathByInstanceId.Clear();
         ProjectView.LastFuzzyMatches.Clear();
         UnityLogPane.Clear();
+        SafeModeEnabled = false;
+        LastCompileError = null;
     }
 }
+
+internal sealed record CompileErrorState(
+    string ProjectPath,
+    DateTimeOffset OccurredAtUtc,
+    string Summary,
+    IReadOnlyList<string> Lines);

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -590,7 +590,8 @@ static string BuildPromptLabelMarkup(CliSessionState session)
 
     if (session.ContextMode == CliContextMode.Project && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
     {
-        return $"[bold deepskyblue1]unifocl[/][grey]:[/][{CliTheme.Info}]{Markup.Escape(session.CurrentProjectPath)}[/]";
+        var safeLabel = session.SafeModeEnabled ? " [yellow][safe][/]" : string.Empty;
+        return $"[bold deepskyblue1]unifocl[/][grey]:[/][{CliTheme.Info}]{Markup.Escape(session.CurrentProjectPath)}[/]{safeLabel}";
     }
 
     return "[bold deepskyblue1]unifocl[/]";

--- a/src/unifocl/Services/DaemonControlService.cs
+++ b/src/unifocl/Services/DaemonControlService.cs
@@ -8,7 +8,9 @@ using System.Text;
 internal sealed class DaemonControlService
 {
     private const int DefaultInactivityTimeoutSeconds = 600;
+    private const int ProcessOutputTailMaxLines = 40;
     private static readonly HttpClient Http = new();
+    private DaemonStartupFailure? _lastStartupFailure;
 
     public async Task HandleDaemonCommandAsync(
         string input,
@@ -336,7 +338,8 @@ internal sealed class DaemonControlService
         string projectPath,
         DaemonRuntime runtime,
         CliSessionState session,
-        Action<string> log)
+        Action<string> log,
+        bool requireUnityBridge = false)
     {
         var port = ComputeProjectDaemonPort(projectPath);
         var existing = runtime.GetByPort(port);
@@ -344,17 +347,37 @@ internal sealed class DaemonControlService
         // Unity's InitializeOnLoad bridge can already be serving this port even when it's not in runtime registry.
         if (await TryAttachProjectDaemonAsync(projectPath, session, attemptCount: 1))
         {
-            return true;
+            if (!requireUnityBridge || IsUnityBridgeCapable(existing))
+            {
+                return true;
+            }
         }
 
         if (existing is not null)
         {
+            var stopped = await TrySendControlAsync(port, "STOP", "STOPPING");
+            if (stopped)
+            {
+                var deadline = DateTime.UtcNow.AddSeconds(4);
+                while (DateTime.UtcNow < deadline && ProcessUtil.IsAlive(existing.Pid))
+                {
+                    await Task.Delay(120);
+                }
+            }
+
             runtime.Remove(port);
+        }
+
+        var unityPath = ResolveDefaultUnityPath(projectPath);
+        if (requireUnityBridge && string.IsNullOrWhiteSpace(unityPath))
+        {
+            log("[red]daemon[/]: scene load requires Unity editor bridge, but no Unity editor path is configured");
+            return false;
         }
 
         var startOptions = new DaemonStartOptions(
             port,
-            ResolveDefaultUnityPath(),
+            unityPath,
             projectPath,
             Headless: true);
 
@@ -367,6 +390,17 @@ internal sealed class DaemonControlService
         session.AttachedPort = port;
         await TrySendControlAsync(port, "TOUCH", "OK");
         return true;
+    }
+
+    private static bool IsUnityBridgeCapable(DaemonInstance? instance)
+    {
+        if (instance is null)
+        {
+            // Port is serving but not from runtime registry (likely InitializeOnLoad Unity bridge).
+            return true;
+        }
+
+        return !string.IsNullOrWhiteSpace(instance.UnityPath);
     }
 
     public async Task<bool> TryAttachProjectDaemonAsync(
@@ -506,15 +540,60 @@ internal sealed class DaemonControlService
             return false;
         }
 
-        var ready = await WaitForDaemonReadyAsync(startOptions.Port, TimeSpan.FromSeconds(25));
+        var outputTail = new Queue<string>();
+        StartBackgroundOutputDrain(
+            process,
+            startOptions.Headless,
+            line => CaptureProcessOutputLine(outputTail, line));
+
+        var startupTimeout = startOptions.Headless
+            ? TimeSpan.FromSeconds(120)
+            : TimeSpan.FromSeconds(25);
+        if (startOptions.Headless)
+        {
+            log($"[grey]daemon[/]: starting Unity headless bridge on port {startOptions.Port} (timeout {startupTimeout.TotalSeconds:0}s)");
+        }
+
+        var ready = await WaitForDaemonReadyAsync(startOptions.Port, startupTimeout, startOptions.Headless
+            ? elapsed => log($"[grey]daemon[/]: startup in progress... {elapsed.TotalSeconds:0}s elapsed")
+            : null);
         if (!ready)
         {
-            log($"[red]daemon[/]: process launched (pid {process.Id}) but not responding on port {startOptions.Port}");
+            if (process.HasExited)
+            {
+                var details = BuildProcessFailureSummary(outputTail);
+                var compileLines = ExtractCompileErrorLines(outputTail);
+                _lastStartupFailure = new DaemonStartupFailure(
+                    IsCompileError: compileLines.Count > 0,
+                    Summary: string.IsNullOrWhiteSpace(details) ? $"process exited with code {process.ExitCode}" : details,
+                    Lines: compileLines.Count > 0 ? compileLines : outputTail.ToList());
+                log($"[red]daemon[/]: process exited before daemon became ready (pid {process.Id}, exit {process.ExitCode})");
+                if (!string.IsNullOrWhiteSpace(details))
+                {
+                    log($"[red]daemon[/]: startup output -> {Markup.Escape(details)}");
+                }
+            }
+            else
+            {
+                _lastStartupFailure = new DaemonStartupFailure(
+                    IsCompileError: false,
+                    Summary: $"daemon did not respond on port {startOptions.Port} within {startupTimeout.TotalSeconds:0}s",
+                    Lines: outputTail.ToList());
+                log($"[red]daemon[/]: process launched (pid {process.Id}) but not responding on port {startOptions.Port} within {startupTimeout.TotalSeconds:0}s");
+            }
+
             return false;
         }
 
+        _lastStartupFailure = null;
         log($"[green]daemon[/]: started [white]pid={process.Id}[/] [white]port={startOptions.Port}[/] [white]headless={startOptions.Headless}[/]");
         return true;
+    }
+
+    public bool TryGetLastStartupFailure(out DaemonStartupFailure? failure)
+    {
+        failure = _lastStartupFailure;
+        return failure is not null;
     }
 
     private async Task HandleDaemonStopAsync(DaemonRuntime runtime, CliSessionState session, Action<string> log)
@@ -712,8 +791,8 @@ internal sealed class DaemonControlService
             var unityPsi = new ProcessStartInfo(options.UnityPath)
             {
                 UseShellExecute = false,
-                RedirectStandardOutput = false,
-                RedirectStandardError = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
                 CreateNoWindow = true
             };
 
@@ -721,7 +800,6 @@ internal sealed class DaemonControlService
             unityPsi.ArgumentList.Add(options.ProjectPath);
             unityPsi.ArgumentList.Add("-batchmode");
             unityPsi.ArgumentList.Add("-nographics");
-            unityPsi.ArgumentList.Add("-noUpm");
             unityPsi.ArgumentList.Add("-vcsMode");
             unityPsi.ArgumentList.Add("None");
             unityPsi.ArgumentList.Add("-executeMethod");
@@ -802,14 +880,116 @@ internal sealed class DaemonControlService
         return directPsi;
     }
 
-    private static async Task<bool> WaitForDaemonReadyAsync(int port, TimeSpan timeout)
+    private static void StartBackgroundOutputDrain(Process process, bool headless, Action<string>? onLine = null)
     {
-        var deadline = DateTime.UtcNow.Add(timeout);
+        if (!headless)
+        {
+            return;
+        }
+
+        if (process.StartInfo.RedirectStandardOutput)
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    while (await process.StandardOutput.ReadLineAsync() is string line)
+                    {
+                        onLine?.Invoke(line);
+                    }
+                }
+                catch
+                {
+                }
+            });
+        }
+
+        if (process.StartInfo.RedirectStandardError)
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    while (await process.StandardError.ReadLineAsync() is string line)
+                    {
+                        onLine?.Invoke(line);
+                    }
+                }
+                catch
+                {
+                }
+            });
+        }
+    }
+
+    private static void CaptureProcessOutputLine(Queue<string> tail, string line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return;
+        }
+
+        var trimmed = line.Trim();
+        if (tail.Count >= ProcessOutputTailMaxLines)
+        {
+            tail.Dequeue();
+        }
+
+        tail.Enqueue(trimmed);
+    }
+
+    private static string BuildProcessFailureSummary(Queue<string> outputTail)
+    {
+        if (outputTail.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var prioritized = outputTail
+            .Where(line => line.Contains("error", StringComparison.OrdinalIgnoreCase)
+                           || line.Contains("exception", StringComparison.OrdinalIgnoreCase)
+                           || line.Contains("failed", StringComparison.OrdinalIgnoreCase))
+            .Take(5)
+            .ToList();
+        if (prioritized.Count > 0)
+        {
+            return string.Join(" | ", prioritized);
+        }
+
+        return string.Join(" | ", outputTail.TakeLast(3));
+    }
+
+    private static List<string> ExtractCompileErrorLines(Queue<string> outputTail)
+    {
+        var lines = outputTail
+            .Where(line =>
+                line.Contains("error CS", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("Scripts have compiler errors", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("Script Compilation Error", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("Tundra build failed", StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.Ordinal)
+            .Take(30)
+            .ToList();
+        return lines;
+    }
+
+    private static async Task<bool> WaitForDaemonReadyAsync(int port, TimeSpan timeout, Action<TimeSpan>? onProgress = null)
+    {
+        var startedAt = DateTime.UtcNow;
+        var deadline = startedAt.Add(timeout);
+        var nextProgressAt = startedAt.AddSeconds(5);
         while (DateTime.UtcNow < deadline)
         {
             if (await TrySendControlAsync(port, "PING", "PONG"))
             {
                 return true;
+            }
+
+            var now = DateTime.UtcNow;
+            if (onProgress is not null && now >= nextProgressAt)
+            {
+                onProgress(now - startedAt);
+                nextProgressAt = now.AddSeconds(5);
             }
 
             await Task.Delay(180);
@@ -859,8 +1039,18 @@ internal sealed class DaemonControlService
         }
     }
 
-    private static string? ResolveDefaultUnityPath()
+    private static string? ResolveDefaultUnityPath(string projectPath)
     {
+        if (UnityEditorPathService.TryGetProjectEditorPath(projectPath, out var projectEditorPath))
+        {
+            return projectEditorPath;
+        }
+
+        if (UnityEditorPathService.TryGetDefaultEditorPath(out var defaultEditorPath))
+        {
+            return defaultEditorPath;
+        }
+
         var fromEnv = Environment.GetEnvironmentVariable("UNITY_PATH");
         if (!string.IsNullOrWhiteSpace(fromEnv))
         {
@@ -926,4 +1116,9 @@ internal sealed class DaemonControlService
 
         return tokens;
     }
+
+    internal sealed record DaemonStartupFailure(
+        bool IsCompileError,
+        string Summary,
+        IReadOnlyList<string> Lines);
 }

--- a/src/unifocl/Services/HierarchyTui.cs
+++ b/src/unifocl/Services/HierarchyTui.cs
@@ -3,7 +3,8 @@ using Spectre.Console;
 
 internal sealed class HierarchyTui
 {
-    private const int FrameWidth = 78;
+    private const int DefaultFrameWidth = 78;
+    private const int MinFrameWidth = 40;
     private const int MinTreeRows = 6;
     private const int MinCommandRows = 4;
     private const int ReservedPromptRows = 4;
@@ -333,14 +334,15 @@ internal sealed class HierarchyTui
         var delta = direction == "up" ? -amount : amount;
         if (section == "log")
         {
+            var wrappedStreamRowCount = BuildWrappedStreamRows(commandLog, Math.Max(1, ResolveFrameWidth() - 1)).Count;
             if (_followCommandScroll)
             {
-                _commandScrollOffset = Math.Max(0, commandLog.Count - 1);
+                _commandScrollOffset = Math.Max(0, wrappedStreamRowCount - 1);
             }
 
             _followCommandScroll = false;
             _commandScrollOffset += delta;
-            if (_commandScrollOffset >= commandLog.Count)
+            if (_commandScrollOffset >= wrappedStreamRowCount)
             {
                 _followCommandScroll = true;
                 _commandScrollOffset = int.MaxValue;
@@ -395,7 +397,8 @@ internal sealed class HierarchyTui
                 })
                 .ToList();
 
-            EnsureSelectedTreeVisibility(highlightedTree.Count, commandLog.Count, selectedEntryPosition + 1);
+            var wrappedStreamLineCount = BuildWrappedStreamRows(commandLog, Math.Max(1, ResolveFrameWidth() - 1)).Count;
+            EnsureSelectedTreeVisibility(highlightedTree.Count, wrappedStreamLineCount, selectedEntryPosition + 1);
             RenderFrame(port, snapshot.Scene, highlightedTree, commandLog, cwdPath, focusModeEnabled: true);
 
             var intent = KeyboardIntentReader.ReadIntent();
@@ -477,14 +480,13 @@ internal sealed class HierarchyTui
     {
         Console.Clear();
 
-        var borderTop = $"┌{new string('─', FrameWidth)}┐";
-        var borderMid = $"├{new string('─', FrameWidth)}┤";
-        var borderBottom = $"└{new string('─', FrameWidth)}┘";
+        var frameWidth = ResolveFrameWidth();
+        var borderTop = $"┌{new string('─', frameWidth)}┐";
+        var borderMid = $"├{new string('─', frameWidth)}┤";
+        var borderBottom = $"└{new string('─', frameWidth)}┘";
         var availableRows = Math.Max(MinTreeRows + MinCommandRows, Console.WindowHeight - ReservedPromptRows);
         var dynamicRows = Math.Max(MinTreeRows + MinCommandRows, availableRows - FrameOverheadRows);
-        var streamRows = commandLog
-            .Where(line => !line.StartsWith("UnityCLI:", StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        var streamRows = BuildWrappedStreamRows(commandLog, Math.Max(1, frameWidth - 1));
         var hasStreamPane = streamRows.Count > 0;
         var (treeRows, commandRows) = hasStreamPane
             ? AllocateViewportRows(dynamicRows, treeLines.Count, streamRows.Count)
@@ -499,13 +501,13 @@ internal sealed class HierarchyTui
             : $" | Focus Key: {FocusModeKey}";
 
         WriteFrameLine(borderTop);
-        WriteFrameLine(ToFrameLine($" UnityCLI v0.1 | MODE: HIERARCHY | Daemon: 127.0.0.1:{daemonPort} | Scene: {scene}{focusLabel}"));
+        WriteFrameLine(ToFrameLine($" UnityCLI v0.1 | MODE: HIERARCHY | Daemon: 127.0.0.1:{daemonPort} | Scene: {scene}{focusLabel}", frameWidth));
         WriteFrameLine(borderMid);
 
         foreach (var line in visibleTree)
         {
             var selected = focusModeEnabled && line.StartsWith("> ", StringComparison.Ordinal);
-            WriteFrameLine(ToFrameLine($" {line}"), selected);
+            WriteFrameLine(ToFrameLine($" {line}", frameWidth), selected);
         }
 
         if (hasStreamPane)
@@ -514,7 +516,7 @@ internal sealed class HierarchyTui
             for (var i = 0; i < visibleCommandLog.Count; i++)
             {
                 var line = visibleCommandLog[i];
-                WriteFrameLine(ToFrameLine($" {line}"));
+                WriteFrameLine(ToFrameLine($" {line}", frameWidth));
             }
         }
 
@@ -762,10 +764,10 @@ internal sealed class HierarchyTui
         commandLog.RemoveRange(0, commandLog.Count - maxLines);
     }
 
-    private static string ToFrameLine(string raw)
+    private static string ToFrameLine(string raw, int frameWidth)
     {
         var sanitized = raw.Replace('\t', ' ');
-        var content = sanitized.Length > FrameWidth ? sanitized[..FrameWidth] : sanitized.PadRight(FrameWidth, ' ');
+        var content = sanitized.Length > frameWidth ? sanitized[..frameWidth] : sanitized.PadRight(frameWidth, ' ');
         return $"│{content}│";
     }
 
@@ -826,5 +828,24 @@ internal sealed class HierarchyTui
         }
 
         return visible;
+    }
+
+    private static List<string> BuildWrappedStreamRows(IReadOnlyList<string> commandLog, int contentWidth)
+    {
+        return commandLog
+            .Where(line => !line.StartsWith("UnityCLI:", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(line => TuiTextWrap.WrapPlainText(line, contentWidth))
+            .ToList();
+    }
+
+    private static int ResolveFrameWidth()
+    {
+        var windowWidth = Console.WindowWidth;
+        if (windowWidth <= 2)
+        {
+            return DefaultFrameWidth;
+        }
+
+        return Math.Max(MinFrameWidth, windowWidth - 2);
     }
 }

--- a/src/unifocl/Services/InspectorModeService.cs
+++ b/src/unifocl/Services/InspectorModeService.cs
@@ -4,6 +4,8 @@ using System.Text.Json;
 
 internal sealed class InspectorModeService
 {
+    private const int DefaultInnerWidth = 78;
+    private const int MinInnerWidth = 40;
     private readonly InspectorTuiRenderer _renderer = new();
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
     private static readonly HttpClient Http = new();
@@ -660,14 +662,15 @@ internal sealed class InspectorModeService
         var delta = direction == "up" ? -amount : amount;
         if (section == "stream")
         {
+            var wrappedStreamCount = BuildWrappedStreamRows(context).Count;
             if (context.FollowStreamScroll)
             {
-                context.StreamScrollOffset = Math.Max(0, context.CommandStream.Count - 1);
+                context.StreamScrollOffset = Math.Max(0, wrappedStreamCount - 1);
             }
 
             context.FollowStreamScroll = false;
             context.StreamScrollOffset += delta;
-            if (context.StreamScrollOffset >= context.CommandStream.Count)
+            if (context.StreamScrollOffset >= wrappedStreamCount)
             {
                 context.FollowStreamScroll = true;
                 context.StreamScrollOffset = int.MaxValue;
@@ -958,6 +961,26 @@ internal sealed class InspectorModeService
         {
             AddStream(context, $"[{i}] {buffered[i]}");
         }
+    }
+
+    private static List<string> BuildWrappedStreamRows(InspectorContext context)
+    {
+        var contentWidth = Math.Max(1, ResolveInnerWidth() - 1);
+        return context.CommandStream
+            .Where(line => !line.StartsWith("UnityCLI:", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(line => TuiTextWrap.WrapPlainText(line, contentWidth))
+            .ToList();
+    }
+
+    private static int ResolveInnerWidth()
+    {
+        var windowWidth = Console.WindowWidth;
+        if (windowWidth <= 2)
+        {
+            return DefaultInnerWidth;
+        }
+
+        return Math.Max(MinInnerWidth, windowWidth - 2);
     }
 
     private sealed record InspectorBridgeRequest(

--- a/src/unifocl/Services/InspectorTuiRenderer.cs
+++ b/src/unifocl/Services/InspectorTuiRenderer.cs
@@ -2,7 +2,8 @@ using Spectre.Console;
 
 internal sealed class InspectorTuiRenderer
 {
-    private const int InnerWidth = 78;
+    private const int DefaultInnerWidth = 78;
+    private const int MinInnerWidth = 40;
     private const int MinBodyRows = 4;
     private const int MinStreamRows = 4;
     private const int ReservedPromptRows = 4;
@@ -16,11 +17,12 @@ internal sealed class InspectorTuiRenderer
         bool focusModeEnabled = false)
     {
         AnsiConsole.Clear();
+        var innerWidth = ResolveInnerWidth();
         var availableRows = Math.Max(MinBodyRows + MinStreamRows, Console.WindowHeight - ReservedPromptRows);
         var dynamicRows = Math.Max(MinBodyRows + MinStreamRows, availableRows - FrameOverheadRows);
 
-        var bodyRows = BuildBodyRows(context, highlightedComponentIndex, highlightedFieldName).ToList();
-        var streamRows = BuildStreamRows(context).ToList();
+        var bodyRows = BuildBodyRows(context, highlightedComponentIndex, highlightedFieldName, innerWidth).ToList();
+        var streamRows = BuildStreamRows(context, Math.Max(1, innerWidth - 1)).ToList();
         var hasStreamPane = streamRows.Count > 0;
         var (bodyViewportRows, streamViewportRows) = hasStreamPane
             ? AllocateViewportRows(dynamicRows, bodyRows.Count, streamRows.Count)
@@ -36,18 +38,18 @@ internal sealed class InspectorTuiRenderer
 
         var frame = new List<string>(FrameOverheadRows + visibleBody.Count + (hasStreamPane ? visibleStream.Count + 1 : 0))
         {
-            Border('┌', '┐'),
-            Line(BuildHeader(context, focusModeEnabled)),
-            Border('├', '┤')
+            Border('┌', '┐', innerWidth),
+            Line(BuildHeader(context, focusModeEnabled), innerWidth),
+            Border('├', '┤', innerWidth)
         };
 
-        frame.AddRange(visibleBody.Select(row => Line(row.Content, row.Highlight)));
+        frame.AddRange(visibleBody.Select(row => Line(row.Content, innerWidth, row.Highlight)));
         if (hasStreamPane)
         {
-            frame.Add(Border('├', '┤'));
-            frame.AddRange(visibleStream.Select(streamLine => Line(streamLine)));
+            frame.Add(Border('├', '┤', innerWidth));
+            frame.AddRange(visibleStream.Select(streamLine => Line(streamLine, innerWidth)));
         }
-        frame.Add(Border('└', '┘'));
+        frame.Add(Border('└', '┘', innerWidth));
 
         foreach (var line in frame)
         {
@@ -58,11 +60,12 @@ internal sealed class InspectorTuiRenderer
     private static IEnumerable<RenderRow> BuildBodyRows(
         InspectorContext context,
         int? highlightedComponentIndex,
-        string? highlightedFieldName)
+        string? highlightedFieldName,
+        int innerWidth)
     {
         return context.Depth == InspectorDepth.ComponentList
             ? BuildComponentRows(context, highlightedComponentIndex)
-            : BuildFieldRows(context, highlightedFieldName);
+            : BuildFieldRows(context, highlightedFieldName, innerWidth);
     }
 
     private static IEnumerable<RenderRow> BuildComponentRows(InspectorContext context, int? highlightedComponentIndex)
@@ -83,12 +86,12 @@ internal sealed class InspectorTuiRenderer
         return lines;
     }
 
-    private static IEnumerable<RenderRow> BuildFieldRows(InspectorContext context, string? highlightedFieldName)
+    private static IEnumerable<RenderRow> BuildFieldRows(InspectorContext context, string? highlightedFieldName, int innerWidth)
     {
         var lines = new List<RenderRow>
         {
             new($"{PadRight("FIELD", 20)}{PadRight("VALUE", 26)}TYPE", false),
-            new(new string('─', InnerWidth - 1), false)
+            new(new string('─', Math.Max(1, innerWidth - 1)), false)
         };
 
         foreach (var field in context.Fields)
@@ -107,10 +110,11 @@ internal sealed class InspectorTuiRenderer
         return lines;
     }
 
-    private static IEnumerable<string> BuildStreamRows(InspectorContext context)
+    private static IEnumerable<string> BuildStreamRows(InspectorContext context, int contentWidth)
     {
         var rows = context.CommandStream
             .Where(line => !line.StartsWith("UnityCLI:", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(line => TuiTextWrap.WrapPlainText(line, contentWidth))
             .ToList();
         if (rows.Count == 0)
         {
@@ -131,15 +135,15 @@ internal sealed class InspectorTuiRenderer
         return $"UnityCLI v0.1 | MODE: INSPECTOR | Target: {target}{focusLabel}";
     }
 
-    private static string Border(char left, char right)
+    private static string Border(char left, char right, int innerWidth)
     {
-        return $"{left}{new string('─', InnerWidth)}{right}";
+        return $"{left}{new string('─', innerWidth)}{right}";
     }
 
-    private static string Line(string content, bool highlight = false)
+    private static string Line(string content, int innerWidth, bool highlight = false)
     {
-        var trimmed = content.Length > InnerWidth ? content[..InnerWidth] : content;
-        var escaped = Markup.Escape(trimmed.PadRight(InnerWidth));
+        var trimmed = content.Length > innerWidth ? content[..innerWidth] : content;
+        var escaped = Markup.Escape(trimmed.PadRight(innerWidth));
         var line = $"│{escaped}│";
         return highlight ? CliTheme.CursorWrapEscaped(line) : line;
     }
@@ -245,5 +249,16 @@ internal sealed class InspectorTuiRenderer
         }
 
         return value.PadRight(width);
+    }
+
+    private static int ResolveInnerWidth()
+    {
+        var windowWidth = Console.WindowWidth;
+        if (windowWidth <= 2)
+        {
+            return DefaultInnerWidth;
+        }
+
+        return Math.Max(MinInnerWidth, windowWidth - 2);
     }
 }

--- a/src/unifocl/Services/ProjectDaemonBridge.cs
+++ b/src/unifocl/Services/ProjectDaemonBridge.cs
@@ -178,9 +178,9 @@ internal sealed class ProjectDaemonBridge
         if (extension.Equals(".unity", StringComparison.OrdinalIgnoreCase))
         {
             return new ProjectCommandResponseDto(
-                true,
-                "scene path resolved (stubbed bridge fallback; Unity scene load unavailable)",
-                "scene");
+                false,
+                $"{StubbedBridgePrefix} scene load is unavailable without Unity editor bridge: {assetPath}",
+                null);
         }
 
         if (extension.Equals(".cs", StringComparison.OrdinalIgnoreCase))

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -2,6 +2,7 @@ using Spectre.Console;
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 internal sealed class ProjectLifecycleService
 {
@@ -23,6 +24,8 @@ internal sealed class ProjectLifecycleService
             "/new" => await HandleNewAsync(input, matched, session, daemonControlService, daemonRuntime, log),
             "/clone" => await HandleCloneAsync(input, matched, session, daemonControlService, daemonRuntime, log),
             "/recent" => await HandleRecentAsync(input, matched, session, daemonControlService, daemonRuntime, log),
+            "/unity detect" => await HandleUnityDetectAsync(log),
+            "/unity set" => await HandleUnitySetAsync(input, matched, log),
             "/close" => await HandleCloseAsync(session, daemonControlService, daemonRuntime, log),
             "/init" => await HandleInitAsync(input, matched, session, log),
             "/config" => await HandleConfigAsync(input, matched, log),
@@ -113,12 +116,49 @@ internal sealed class ProjectLifecycleService
         }
 
         var projectName = args[0].Trim();
-        var unityVersion = args.Count > 1 ? args[1].Trim() : "6000.0.0f1";
         if (string.IsNullOrWhiteSpace(projectName))
         {
             log("[red]error[/]: project name cannot be empty");
             return true;
         }
+
+        var availableEditors = UnityEditorPathService.DetectInstalledEditors(out var detectedHubRoot);
+        if (availableEditors.Count == 0)
+        {
+            log("[red]error[/]: no Unity editors were detected from Unity Hub/editor environment");
+            return true;
+        }
+
+        UnityEditorPathService.UnityEditorInstallation selectedEditor;
+        if (args.Count > 1)
+        {
+            var requestedVersion = args[1].Trim();
+            selectedEditor = availableEditors.FirstOrDefault(x => x.Version.Equals(requestedVersion, StringComparison.OrdinalIgnoreCase))
+                ?? new UnityEditorPathService.UnityEditorInstallation(string.Empty, string.Empty);
+            if (string.IsNullOrWhiteSpace(selectedEditor.Version))
+            {
+                log($"[red]error[/]: requested Unity version is not installed: {Markup.Escape(requestedVersion)}");
+                return true;
+            }
+        }
+        else if (Console.IsInputRedirected)
+        {
+            selectedEditor = availableEditors[0];
+            log($"[yellow]new[/]: non-interactive input; defaulting to newest detected editor [white]{Markup.Escape(selectedEditor.Version)}[/]");
+        }
+        else
+        {
+            var hubLabel = string.IsNullOrWhiteSpace(detectedHubRoot) ? "unknown location" : detectedHubRoot;
+            log($"[grey]new[/]: detected Unity Hub editors from [white]{Markup.Escape(hubLabel)}[/]");
+            selectedEditor = AnsiConsole.Prompt(
+                new SelectionPrompt<UnityEditorPathService.UnityEditorInstallation>()
+                    .Title("Choose Unity editor version")
+                    .PageSize(Math.Min(availableEditors.Count, 12))
+                    .UseConverter(editor => $"{editor.Version} ({editor.EditorPath})")
+                    .AddChoices(availableEditors));
+        }
+
+        var unityVersion = selectedEditor.Version;
 
         var projectPath = ResolveAbsolutePath(projectName, Directory.GetCurrentDirectory());
         log($"[grey]new[/]: step 1/5 create project directory -> [white]{Markup.Escape(projectPath)}[/]");
@@ -156,6 +196,11 @@ internal sealed class ProjectLifecycleService
         {
             log($"[red]error[/]: {Markup.Escape(versionResult.Error)}");
             return true;
+        }
+
+        if (!UnityEditorPathService.TrySaveProjectEditorPath(projectPath, selectedEditor.EditorPath, out var saveEditorError))
+        {
+            log($"[yellow]new[/]: unable to persist project-editor pair ({Markup.Escape(saveEditorError ?? "unknown error")})");
         }
 
         log("[grey]new[/]: step 4/5 generate local templates and bridge config");
@@ -405,6 +450,50 @@ internal sealed class ProjectLifecycleService
             log);
     }
 
+    private Task<bool> HandleUnityDetectAsync(Action<string> log)
+    {
+        var editors = UnityEditorPathService.DetectInstalledEditors(out var hubRoot);
+        if (editors.Count == 0)
+        {
+            log("[yellow]unity[/]: no installed editors detected");
+            return Task.FromResult(true);
+        }
+
+        if (!string.IsNullOrWhiteSpace(hubRoot))
+        {
+            log($"[grey]unity[/]: Hub root [white]{Markup.Escape(hubRoot)}[/]");
+        }
+
+        log("[grey]unity[/]: detected installed editors");
+        foreach (var editor in editors)
+        {
+            log($"[grey]unity[/]: [white]{Markup.Escape(editor.Version)}[/] -> [white]{Markup.Escape(editor.EditorPath)}[/]");
+        }
+
+        return Task.FromResult(true);
+    }
+
+    private Task<bool> HandleUnitySetAsync(string input, CommandSpec matched, Action<string> log)
+    {
+        var args = ParseCommandArgs(input, matched.Trigger);
+        if (args.Count != 1)
+        {
+            log("[red]error[/]: usage /unity set <path>");
+            return Task.FromResult(true);
+        }
+
+        var unityPath = ResolveAbsolutePath(args[0], Directory.GetCurrentDirectory());
+        if (!UnityEditorPathService.TrySetDefaultEditorPath(unityPath, out var saveError))
+        {
+            log($"[red]error[/]: {Markup.Escape(saveError ?? "failed to save default Unity editor path")}");
+            return Task.FromResult(true);
+        }
+
+        Environment.SetEnvironmentVariable("UNITY_PATH", unityPath);
+        log($"[green]unity[/]: default editor set -> [white]{Markup.Escape(unityPath)}[/]");
+        return Task.FromResult(true);
+    }
+
     private Task<bool> HandleConfigAsync(
         string input,
         CommandSpec matched,
@@ -603,7 +692,7 @@ internal sealed class ProjectLifecycleService
         bool promptForInitialization,
         Action<string> log)
     {
-        log($"[grey]open[/]: step 1/4 resolve project path -> [white]{Markup.Escape(projectPath)}[/]");
+        log($"[grey]open[/]: step 1/5 resolve project path -> [white]{Markup.Escape(projectPath)}[/]");
 
         if (!Directory.Exists(projectPath))
         {
@@ -617,11 +706,18 @@ internal sealed class ProjectLifecycleService
             return false;
         }
 
-        log("[grey]open[/]: step 2/4 validate Unity project layout");
+        log("[grey]open[/]: step 2/5 validate Unity project layout");
         var bridgeResult = EnsureProjectLocalConfig(projectPath);
         if (!bridgeResult.Ok)
         {
             log($"[red]error[/]: {Markup.Escape(bridgeResult.Error)}");
+            return false;
+        }
+
+        var packageFixResult = EnsureRequiredUnityPackageReferences(projectPath);
+        if (!packageFixResult.Ok)
+        {
+            log($"[red]error[/]: {Markup.Escape(packageFixResult.Error)}");
             return false;
         }
 
@@ -650,7 +746,21 @@ internal sealed class ProjectLifecycleService
             }
         }
 
-        log("[grey]open[/]: step 3/4 route runtime by active Unity client lock");
+        if (!UnityEditorPathService.TryResolveEditorForProject(projectPath, out var resolvedEditorPath, out var resolvedEditorVersion, out var editorResolveError))
+        {
+            log($"[red]error[/]: {Markup.Escape(editorResolveError ?? "failed to resolve Unity editor for project")}");
+            return false;
+        }
+
+        if (!UnityEditorPathService.TrySetDefaultEditorPath(resolvedEditorPath, out var defaultEditorSaveError))
+        {
+            log($"[yellow]config[/]: unable to persist default editor path ({Markup.Escape(defaultEditorSaveError ?? "unknown error")})");
+        }
+
+        Environment.SetEnvironmentVariable("UNITY_PATH", resolvedEditorPath);
+        log($"[grey]open[/]: step 3/5 resolved Unity editor [white]{Markup.Escape(resolvedEditorVersion)}[/] -> [white]{Markup.Escape(resolvedEditorPath)}[/]");
+
+        log("[grey]open[/]: step 4/5 route runtime by active Unity client lock");
         var daemonPort = DaemonControlService.ComputeProjectDaemonPort(projectPath);
         if (DaemonControlService.IsUnityClientActiveForProject(projectPath))
         {
@@ -670,12 +780,18 @@ internal sealed class ProjectLifecycleService
             var started = await daemonControlService.EnsureProjectDaemonAsync(projectPath, daemonRuntime, session, log);
             if (!started)
             {
-                log("[red]daemon[/]: failed to start or attach headless daemon");
-                return false;
+                if (!HandleDaemonStartupFailure(projectPath, session, daemonControlService, log))
+                {
+                    return false;
+                }
             }
-
-            SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, true));
-            log($"[grey]daemon[/]: started headless daemon on [white]127.0.0.1:{daemonPort}[/]");
+            else
+            {
+                SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, true));
+                log($"[grey]daemon[/]: started headless daemon on [white]127.0.0.1:{daemonPort}[/]");
+                session.SafeModeEnabled = false;
+                session.LastCompileError = null;
+            }
         }
 
         session.CurrentProjectPath = projectPath;
@@ -692,9 +808,88 @@ internal sealed class ProjectLifecycleService
             log($"[yellow]recent[/]: unable to update history ({Markup.Escape(historyError ?? "unknown error")})");
         }
 
-        log("[grey]open[/]: step 4/4 load project context");
+        log("[grey]open[/]: step 5/5 load project context");
         _projectViewService.OpenInitialView(session);
         return true;
+    }
+
+    private static bool HandleDaemonStartupFailure(
+        string projectPath,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        Action<string> log)
+    {
+        if (!daemonControlService.TryGetLastStartupFailure(out var failure) || failure is null)
+        {
+            log("[red]daemon[/]: failed to start or attach headless daemon");
+            return false;
+        }
+
+        if (!failure.IsCompileError)
+        {
+            log($"[red]daemon[/]: startup failed ({Markup.Escape(failure.Summary)})");
+            return false;
+        }
+
+        session.LastCompileError = new CompileErrorState(
+            projectPath,
+            DateTimeOffset.UtcNow,
+            failure.Summary,
+            failure.Lines.ToList());
+        log("[yellow]daemon[/]: Unity script compilation errors detected during daemon startup");
+        if (!string.IsNullOrWhiteSpace(failure.Summary))
+        {
+            log($"[yellow]daemon[/]: {Markup.Escape(failure.Summary)}");
+        }
+
+        var canEnterSafeMode = CanEnterSafeMode(projectPath);
+        if (Console.IsInputRedirected)
+        {
+            log("[red]daemon[/]: redirected input cannot answer compile-error prompt; aborting open");
+            return false;
+        }
+
+        var options = new List<string>
+        {
+            "Ignore and continue",
+            "Quit open"
+        };
+        if (canEnterSafeMode)
+        {
+            options.Insert(0, "Enter Safe mode");
+        }
+
+        var selected = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Daemon startup failed due to compile errors. Choose action:")
+                .PageSize(options.Count)
+                .AddChoices(options));
+
+        if (selected.Equals("Quit open", StringComparison.Ordinal))
+        {
+            log("[yellow]open[/]: cancelled due to compile errors");
+            return false;
+        }
+
+        if (selected.Equals("Enter Safe mode", StringComparison.Ordinal))
+        {
+            session.SafeModeEnabled = true;
+            session.AttachedPort = null;
+            log("[yellow]open[/]: entered safe mode (daemon unavailable; Unity bridge commands are limited)");
+            return true;
+        }
+
+        session.SafeModeEnabled = false;
+        session.AttachedPort = null;
+        log("[yellow]open[/]: continuing without daemon attachment; Unity bridge commands may fail until compile errors are fixed");
+        return true;
+    }
+
+    private static bool CanEnterSafeMode(string projectPath)
+    {
+        return Directory.Exists(projectPath)
+               && Directory.Exists(Path.Combine(projectPath, "Assets"))
+               && Directory.Exists(Path.Combine(projectPath, "ProjectSettings"));
     }
 
     private static void SaveDaemonSession(string projectPath, DaemonSessionInfo session)
@@ -839,6 +1034,7 @@ internal sealed class ProjectLifecycleService
                         ["com.unity.ide.rider"] = "3.0.35",
                         ["com.unity.ide.visualstudio"] = "2.0.24",
                         ["com.unity.test-framework"] = "1.4.5",
+                        ["com.unity.textmeshpro"] = "3.0.6",
                         ["com.unity.timeline"] = "1.8.9",
                         ["com.unity.ugui"] = "1.0.0"
                     }
@@ -869,6 +1065,115 @@ internal sealed class ProjectLifecycleService
         {
             return OperationResult.Fail($"failed to write ProjectVersion.txt ({ex.Message})");
         }
+    }
+
+    private static OperationResult EnsureRequiredUnityPackageReferences(string projectPath)
+    {
+        try
+        {
+            var manifestPath = Path.Combine(projectPath, "Packages", "manifest.json");
+            if (!File.Exists(manifestPath))
+            {
+                return OperationResult.Fail("Packages/manifest.json is missing");
+            }
+
+            using var document = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return OperationResult.Fail("manifest.json has invalid format");
+            }
+
+            var root = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var property in document.RootElement.EnumerateObject())
+            {
+                root[property.Name] = JsonSerializer.Deserialize<object>(property.Value.GetRawText());
+            }
+
+            var dependencies = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (document.RootElement.TryGetProperty("dependencies", out var depsElement)
+                && depsElement.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var dep in depsElement.EnumerateObject())
+                {
+                    if (dep.Value.ValueKind == JsonValueKind.String)
+                    {
+                        var version = dep.Value.GetString();
+                        if (!string.IsNullOrWhiteSpace(version))
+                        {
+                            dependencies[dep.Name] = version;
+                        }
+                    }
+                }
+            }
+
+            var requiredPackages = InferRequiredUnityPackages(projectPath);
+            var changed = false;
+            foreach (var required in requiredPackages)
+            {
+                if (dependencies.ContainsKey(required.Key))
+                {
+                    continue;
+                }
+
+                dependencies[required.Key] = required.Value;
+                changed = true;
+            }
+
+            if (!changed)
+            {
+                return OperationResult.Success();
+            }
+
+            root["dependencies"] = dependencies
+                .OrderBy(x => x.Key, StringComparer.Ordinal)
+                .ToDictionary(x => x.Key, x => (object?)x.Value, StringComparer.Ordinal);
+            var updated = JsonSerializer.Serialize(root, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(manifestPath, updated + Environment.NewLine);
+            return OperationResult.Success();
+        }
+        catch (Exception ex)
+        {
+            return OperationResult.Fail($"failed to update required Unity package references ({ex.Message})");
+        }
+    }
+
+    private static Dictionary<string, string> InferRequiredUnityPackages(string projectPath)
+    {
+        var namespaceToPackage = new Dictionary<string, (string PackageId, string Version)>(StringComparer.Ordinal)
+        {
+            ["UnityEngine.UI"] = ("com.unity.ugui", "1.0.0"),
+            ["UnityEngine.EventSystems"] = ("com.unity.ugui", "1.0.0"),
+            ["TMPro"] = ("com.unity.textmeshpro", "3.0.6")
+        };
+        var required = new Dictionary<string, string>(StringComparer.Ordinal);
+        var usingPattern = new Regex(@"^\s*using\s+([A-Za-z0-9_.]+)\s*;", RegexOptions.Compiled);
+        var assetsPath = Path.Combine(projectPath, "Assets");
+        if (!Directory.Exists(assetsPath))
+        {
+            return required;
+        }
+
+        foreach (var scriptPath in Directory.EnumerateFiles(assetsPath, "*.cs", SearchOption.AllDirectories))
+        {
+            foreach (var line in File.ReadLines(scriptPath))
+            {
+                var match = usingPattern.Match(line);
+                if (!match.Success)
+                {
+                    continue;
+                }
+
+                var ns = match.Groups[1].Value;
+                if (!namespaceToPackage.TryGetValue(ns, out var package))
+                {
+                    continue;
+                }
+
+                required[package.PackageId] = package.Version;
+            }
+        }
+
+        return required;
     }
 
     private static ProcessResult RunProcess(string fileName, string arguments, string workingDirectory)

--- a/src/unifocl/Services/ProjectViewRenderer.cs
+++ b/src/unifocl/Services/ProjectViewRenderer.cs
@@ -2,12 +2,14 @@ using Spectre.Console;
 
 internal sealed class ProjectViewRenderer
 {
-    private const int FrameWidth = 78;
+    private const int DefaultFrameWidth = 78;
+    private const int MinFrameWidth = 40;
     private const int CommandRows = 8;
     private sealed record RenderLine(string Content, bool Highlight);
 
     public IReadOnlyList<string> Render(ProjectViewState state, int? highlightedEntryIndex = null, bool focusModeEnabled = false)
     {
+        var frameWidth = ResolveFrameWidth();
         var lines = new List<string>();
         var cwd = string.IsNullOrWhiteSpace(state.RelativeCwd) ? "Assets" : state.RelativeCwd;
         var db = state.DbState == ProjectDbState.LockedImporting ? "LOCKED (Importing)" : "IDLE (Safe)";
@@ -16,28 +18,32 @@ internal sealed class ProjectViewRenderer
             : " | Focus Key: F7";
         var header = $" UnityCLI v0.1 | MODE: PROJECT | DB: {db} | CWD: {cwd}{focusLabel}";
 
-        lines.Add(BorderTop());
-        lines.Add(BorderBody(header));
-        lines.Add(BorderSeparator());
+        lines.Add(BorderTop(frameWidth));
+        lines.Add(BorderBody(header, frameWidth));
+        lines.Add(BorderSeparator(frameWidth));
 
         foreach (var treeLine in BuildTreeLines(state, cwd, highlightedEntryIndex))
         {
-            lines.Add(BorderBody(treeLine.Content, treeLine.Highlight));
+            lines.Add(BorderBody(treeLine.Content, frameWidth, treeLine.Highlight));
         }
 
-        lines.Add(BorderSeparator());
-        var recent = state.CommandTranscript
-            .Skip(Math.Max(0, state.CommandTranscript.Count - CommandRows))
+        lines.Add(BorderSeparator(frameWidth));
+        var contentWidth = Math.Max(1, frameWidth - 1);
+        var wrappedTranscript = state.CommandTranscript
+            .SelectMany(line => TuiTextWrap.WrapPlainText(line, contentWidth))
+            .ToList();
+        var recent = wrappedTranscript
+            .Skip(Math.Max(0, wrappedTranscript.Count - CommandRows))
             .ToList();
         for (var i = 0; i < CommandRows; i++)
         {
             var line = i < recent.Count
                 ? recent[i]
                 : (i == recent.Count ? $"UnityCLI:{cwd} > _" : string.Empty);
-            lines.Add(BorderBody($" {line}"));
+            lines.Add(BorderBody($" {line}", frameWidth));
         }
 
-        lines.Add(BorderBottom());
+        lines.Add(BorderBottom(frameWidth));
         return lines;
     }
 
@@ -62,14 +68,14 @@ internal sealed class ProjectViewRenderer
         return string.IsNullOrWhiteSpace(name) ? $"{normalized}/" : $"{name}/";
     }
 
-    private static string BorderTop() => "┌" + new string('─', FrameWidth) + "┐";
-    private static string BorderSeparator() => "├" + new string('─', FrameWidth) + "┤";
-    private static string BorderBottom() => "└" + new string('─', FrameWidth) + "┘";
+    private static string BorderTop(int frameWidth) => "┌" + new string('─', frameWidth) + "┐";
+    private static string BorderSeparator(int frameWidth) => "├" + new string('─', frameWidth) + "┤";
+    private static string BorderBottom(int frameWidth) => "└" + new string('─', frameWidth) + "┘";
 
-    private static string BorderBody(string content, bool highlight = false)
+    private static string BorderBody(string content, int frameWidth, bool highlight = false)
     {
         var normalized = content.Replace(Environment.NewLine, " ").Replace("\n", " ");
-        var adjusted = Markup.Escape(Fit(normalized, FrameWidth));
+        var adjusted = Markup.Escape(Fit(normalized, frameWidth));
         var line = $"│{adjusted}│";
         return highlight ? CliTheme.CursorWrapEscaped(line) : line;
     }
@@ -87,5 +93,16 @@ internal sealed class ProjectViewRenderer
         }
 
         return text;
+    }
+
+    private static int ResolveFrameWidth()
+    {
+        var windowWidth = Console.WindowWidth;
+        if (windowWidth <= 2)
+        {
+            return DefaultFrameWidth;
+        }
+
+        return Math.Max(MinFrameWidth, windowWidth - 2);
     }
 }

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -64,9 +64,8 @@ internal sealed class ProjectViewService
         }
         else if (tokens.Count >= 2 && tokens[0].Equals("load", StringComparison.OrdinalIgnoreCase))
         {
-            await EnsureUnityContextAsync(session, daemonControlService, daemonRuntime);
             var selector = string.Join(' ', tokens.Skip(1));
-            handled = await HandleLoadViaBridgeAsync(selector, session, outputs);
+            handled = await HandleLoadViaBridgeAsync(selector, session, outputs, daemonControlService, daemonRuntime);
         }
         else if (tokens.Count >= 3 && tokens[0].Equals("rename", StringComparison.OrdinalIgnoreCase) && int.TryParse(tokens[1], out index))
         {
@@ -356,8 +355,7 @@ internal sealed class ProjectViewService
             return;
         }
 
-        await EnsureUnityContextAsync(session, daemonControlService, daemonRuntime);
-        await HandleLoadViaBridgeAsync(entry.Index.ToString(), session, outputs);
+        await HandleLoadViaBridgeAsync(entry.Index.ToString(), session, outputs, daemonControlService, daemonRuntime);
     }
 
     private async Task<bool> HandleMakeScriptViaBridgeAsync(
@@ -463,7 +461,12 @@ internal sealed class ProjectViewService
         }
     }
 
-    private async Task<bool> HandleLoadViaBridgeAsync(string selector, CliSessionState session, List<string> outputs)
+    private async Task<bool> HandleLoadViaBridgeAsync(
+        string selector,
+        CliSessionState session,
+        List<string> outputs,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime)
     {
         var state = session.ProjectView;
         if (string.IsNullOrWhiteSpace(selector))
@@ -485,6 +488,18 @@ internal sealed class ProjectViewService
             return true;
         }
 
+        var isSceneLoad = Path.GetExtension(target.Name).Equals(".unity", StringComparison.OrdinalIgnoreCase);
+        var unityReady = await EnsureUnityContextAsync(
+            session,
+            daemonControlService,
+            daemonRuntime,
+            requireUnityBridge: isSceneLoad);
+        if (!unityReady && isSceneLoad)
+        {
+            outputs.Add("[x] scene load failed: Unity editor bridge is unavailable; set UNITY_PATH or start Unity editor for this project");
+            return true;
+        }
+
         var response = await ExecuteProjectCommandAsync(
             session,
             new ProjectCommandRequestDto("load-asset", target.RelativePath, null, null));
@@ -502,6 +517,12 @@ internal sealed class ProjectViewService
 
         if (!response.Ok)
         {
+            if (Path.GetExtension(target.Name).Equals(".unity", StringComparison.OrdinalIgnoreCase))
+            {
+                outputs.Add($"[x] scene load failed: {response.Message ?? "unknown error"}");
+                return true;
+            }
+
             outputs.Add(FormatProjectCommandFailure("load", response.Message));
             return true;
         }
@@ -814,28 +835,38 @@ internal sealed class ProjectViewService
         state.CommandTranscript.RemoveRange(0, overflow);
     }
 
-    private static async Task EnsureUnityContextAsync(
+    private static async Task<bool> EnsureUnityContextAsync(
         CliSessionState session,
         DaemonControlService daemonControlService,
-        DaemonRuntime daemonRuntime)
+        DaemonRuntime daemonRuntime,
+        bool requireUnityBridge = false)
     {
         if (await daemonControlService.TouchAttachedDaemonAsync(session))
         {
-            return;
+            if (!requireUnityBridge)
+            {
+                return true;
+            }
         }
 
         if (string.IsNullOrWhiteSpace(session.CurrentProjectPath))
         {
-            return;
+            return false;
         }
 
-        if (DaemonControlService.IsUnityClientActiveForProject(session.CurrentProjectPath))
+        if (!requireUnityBridge
+            && DaemonControlService.IsUnityClientActiveForProject(session.CurrentProjectPath))
         {
             await daemonControlService.TryAttachProjectDaemonAsync(session.CurrentProjectPath, session);
-            return;
+            return true;
         }
 
-        await daemonControlService.EnsureProjectDaemonAsync(session.CurrentProjectPath, daemonRuntime, session, _ => { });
+        return await daemonControlService.EnsureProjectDaemonAsync(
+            session.CurrentProjectPath,
+            daemonRuntime,
+            session,
+            _ => { },
+            requireUnityBridge);
     }
 
     private static (string TemplateName, string TemplateSource, string Content) ResolveTemplate(string projectPath)

--- a/src/unifocl/Services/TuiTextWrap.cs
+++ b/src/unifocl/Services/TuiTextWrap.cs
@@ -1,0 +1,34 @@
+internal static class TuiTextWrap
+{
+    public static List<string> WrapPlainText(string? value, int width)
+    {
+        var safeWidth = Math.Max(1, width);
+        if (string.IsNullOrEmpty(value))
+        {
+            return [string.Empty];
+        }
+
+        var normalized = value
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+        var logicalLines = normalized.Split('\n');
+        var wrapped = new List<string>(logicalLines.Length);
+        foreach (var logicalLine in logicalLines)
+        {
+            var line = logicalLine.Replace('\t', ' ');
+            if (line.Length == 0)
+            {
+                wrapped.Add(string.Empty);
+                continue;
+            }
+
+            for (var offset = 0; offset < line.Length; offset += safeWidth)
+            {
+                var length = Math.Min(safeWidth, line.Length - offset);
+                wrapped.Add(line.Substring(offset, length));
+            }
+        }
+
+        return wrapped.Count == 0 ? [string.Empty] : wrapped;
+    }
+}

--- a/src/unifocl/Services/UnityEditorPathService.cs
+++ b/src/unifocl/Services/UnityEditorPathService.cs
@@ -1,0 +1,421 @@
+using System.Text.Json;
+
+internal static class UnityEditorPathService
+{
+    private sealed class UnityEditorStore
+    {
+        public string? DefaultEditorPath { get; set; }
+        public Dictionary<string, string> ProjectEditors { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal sealed record UnityEditorInstallation(string Version, string EditorPath);
+
+    public static IReadOnlyList<UnityEditorInstallation> DetectInstalledEditors(out string? hubRoot)
+    {
+        hubRoot = ResolveUnityHubRoot();
+        var discovered = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(hubRoot))
+        {
+            var editorRoot = Path.Combine(hubRoot, "Editor");
+            if (Directory.Exists(editorRoot))
+            {
+                foreach (var versionDirectory in Directory.EnumerateDirectories(editorRoot))
+                {
+                    var version = Path.GetFileName(versionDirectory);
+                    if (string.IsNullOrWhiteSpace(version))
+                    {
+                        continue;
+                    }
+
+                    var editorPath = ResolveEditorExecutablePath(versionDirectory);
+                    if (string.IsNullOrWhiteSpace(editorPath) || !File.Exists(editorPath))
+                    {
+                        continue;
+                    }
+
+                    discovered[version] = editorPath;
+                }
+            }
+        }
+
+        var fromEnv = Environment.GetEnvironmentVariable("UNITY_PATH");
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+        {
+            var normalized = Path.GetFullPath(fromEnv);
+            if (File.Exists(normalized))
+            {
+                var envVersion = TryInferVersionFromUnityPath(normalized);
+                if (!string.IsNullOrWhiteSpace(envVersion) && !discovered.ContainsKey(envVersion))
+                {
+                    discovered[envVersion] = normalized;
+                }
+            }
+        }
+
+        return discovered
+            .OrderByDescending(entry => entry.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(entry => new UnityEditorInstallation(entry.Key, entry.Value))
+            .ToList();
+    }
+
+    public static bool TryReadProjectEditorVersion(string projectPath, out string version, out string? error)
+    {
+        version = string.Empty;
+        error = null;
+        try
+        {
+            var projectVersionPath = Path.Combine(projectPath, "ProjectSettings", "ProjectVersion.txt");
+            if (!File.Exists(projectVersionPath))
+            {
+                error = "ProjectVersion.txt not found";
+                return false;
+            }
+
+            foreach (var raw in File.ReadLines(projectVersionPath))
+            {
+                var line = raw.Trim();
+                if (!line.StartsWith("m_EditorVersion:", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var parsed = line["m_EditorVersion:".Length..].Trim();
+                if (string.IsNullOrWhiteSpace(parsed))
+                {
+                    break;
+                }
+
+                version = parsed;
+                return true;
+            }
+
+            error = "m_EditorVersion not found in ProjectVersion.txt";
+            return false;
+        }
+        catch (Exception ex)
+        {
+            error = $"failed to read ProjectVersion.txt ({ex.Message})";
+            return false;
+        }
+    }
+
+    public static bool TryResolveEditorForProject(string projectPath, out string editorPath, out string version, out string? error)
+    {
+        editorPath = string.Empty;
+        version = string.Empty;
+        error = null;
+
+        if (TryReadProjectEditorVersion(projectPath, out version, out error))
+        {
+            var requiredVersion = version;
+            if (TryGetProjectEditorPath(projectPath, out var persistedPath))
+            {
+                var persistedVersion = TryInferVersionFromUnityPath(persistedPath);
+                if (string.Equals(persistedVersion, requiredVersion, StringComparison.OrdinalIgnoreCase))
+                {
+                    editorPath = persistedPath;
+                    return true;
+                }
+            }
+
+            var installed = DetectInstalledEditors(out _);
+            var exact = installed.FirstOrDefault(x => x.Version.Equals(requiredVersion, StringComparison.OrdinalIgnoreCase));
+            if (exact is not null)
+            {
+                editorPath = exact.EditorPath;
+                TrySaveProjectEditorPath(projectPath, editorPath, out _);
+                return true;
+            }
+
+            error = installed.Count == 0
+                ? $"Unity editor version {requiredVersion} is required by project, but no Unity editors were detected."
+                : $"Unity editor version {requiredVersion} is required by project, but it was not found on this machine.";
+            return false;
+        }
+
+        return false;
+    }
+
+    public static bool TryGetProjectEditorPath(string projectPath, out string editorPath)
+    {
+        editorPath = string.Empty;
+        if (!TryLoadStore(out var store, out _))
+        {
+            return false;
+        }
+
+        var normalizedProjectPath = NormalizePath(projectPath);
+        if (string.IsNullOrWhiteSpace(normalizedProjectPath))
+        {
+            return false;
+        }
+
+        if (!store.ProjectEditors.TryGetValue(normalizedProjectPath, out var saved))
+        {
+            return false;
+        }
+
+        if (!File.Exists(saved))
+        {
+            return false;
+        }
+
+        editorPath = saved;
+        return true;
+    }
+
+    public static bool TrySaveProjectEditorPath(string projectPath, string editorPath, out string? error)
+    {
+        error = null;
+        if (!File.Exists(editorPath))
+        {
+            error = $"Unity editor executable not found: {editorPath}";
+            return false;
+        }
+
+        if (!TryLoadStore(out var store, out var loadError))
+        {
+            error = loadError;
+            return false;
+        }
+
+        var normalizedProjectPath = NormalizePath(projectPath);
+        var normalizedEditorPath = NormalizePath(editorPath);
+        if (string.IsNullOrWhiteSpace(normalizedProjectPath) || string.IsNullOrWhiteSpace(normalizedEditorPath))
+        {
+            error = "invalid project/editor path";
+            return false;
+        }
+
+        store.ProjectEditors[normalizedProjectPath] = normalizedEditorPath;
+        return TrySaveStore(store, out error);
+    }
+
+    public static bool TryGetDefaultEditorPath(out string editorPath)
+    {
+        editorPath = string.Empty;
+        if (!TryLoadStore(out var store, out _))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(store.DefaultEditorPath) || !File.Exists(store.DefaultEditorPath))
+        {
+            return false;
+        }
+
+        editorPath = store.DefaultEditorPath;
+        return true;
+    }
+
+    public static bool TrySetDefaultEditorPath(string editorPath, out string? error)
+    {
+        error = null;
+        var normalized = NormalizePath(editorPath);
+        if (string.IsNullOrWhiteSpace(normalized) || !File.Exists(normalized))
+        {
+            error = $"Unity editor executable not found: {editorPath}";
+            return false;
+        }
+
+        if (!TryLoadStore(out var store, out var loadError))
+        {
+            error = loadError;
+            return false;
+        }
+
+        store.DefaultEditorPath = normalized;
+        return TrySaveStore(store, out error);
+    }
+
+    public static string? TryInferVersionFromUnityPath(string unityPath)
+    {
+        try
+        {
+            var normalized = NormalizePath(unityPath);
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                return null;
+            }
+
+            var segments = normalized.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var editorIndex = Array.FindLastIndex(segments, x => x.Equals("Editor", StringComparison.OrdinalIgnoreCase));
+            if (editorIndex > 0 && editorIndex - 1 < segments.Length)
+            {
+                var candidate = segments[editorIndex - 1];
+                if (!string.IsNullOrWhiteSpace(candidate) && char.IsDigit(candidate[0]))
+                {
+                    return candidate;
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+
+    private static string? ResolveUnityHubRoot()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable("UNITY_HUB_PATH");
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+        {
+            var normalized = Path.GetFullPath(fromEnv);
+            if (Directory.Exists(normalized))
+            {
+                if (Path.GetFileName(normalized).Equals("Editor", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Directory.GetParent(normalized)?.FullName;
+                }
+
+                if (Directory.Exists(Path.Combine(normalized, "Editor")))
+                {
+                    return normalized;
+                }
+            }
+        }
+
+        var candidates = new List<string>();
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (OperatingSystem.IsMacOS())
+        {
+            candidates.Add("/Applications/Unity/Hub");
+            if (!string.IsNullOrWhiteSpace(home))
+            {
+                candidates.Add(Path.Combine(home, "Applications", "Unity", "Hub"));
+            }
+        }
+        else if (OperatingSystem.IsWindows())
+        {
+            var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            if (!string.IsNullOrWhiteSpace(programFiles))
+            {
+                candidates.Add(Path.Combine(programFiles, "Unity", "Hub"));
+            }
+
+            var programFilesX86 = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+            if (!string.IsNullOrWhiteSpace(programFilesX86))
+            {
+                candidates.Add(Path.Combine(programFilesX86, "Unity", "Hub"));
+            }
+        }
+        else
+        {
+            if (!string.IsNullOrWhiteSpace(home))
+            {
+                candidates.Add(Path.Combine(home, "Unity", "Hub"));
+            }
+        }
+
+        foreach (var candidate in candidates.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (Directory.Exists(Path.Combine(candidate, "Editor")))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ResolveEditorExecutablePath(string versionDirectory)
+    {
+        if (OperatingSystem.IsMacOS())
+        {
+            return Path.Combine(versionDirectory, "Unity.app", "Contents", "MacOS", "Unity");
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return Path.Combine(versionDirectory, "Editor", "Unity.exe");
+        }
+
+        return Path.Combine(versionDirectory, "Editor", "Unity");
+    }
+
+    private static bool TryLoadStore(out UnityEditorStore store, out string? error)
+    {
+        store = new UnityEditorStore();
+        error = null;
+        var path = GetStorePath();
+
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return true;
+            }
+
+            var json = File.ReadAllText(path);
+            var parsed = JsonSerializer.Deserialize<UnityEditorStore>(json);
+            if (parsed is null)
+            {
+                error = "invalid unity editor store format";
+                return false;
+            }
+
+            parsed.ProjectEditors ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            store = parsed;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"failed to load unity editor store ({ex.Message})";
+            return false;
+        }
+    }
+
+    private static bool TrySaveStore(UnityEditorStore store, out string? error)
+    {
+        error = null;
+        var path = GetStorePath();
+
+        try
+        {
+            var directory = Path.GetDirectoryName(path);
+            if (string.IsNullOrWhiteSpace(directory))
+            {
+                error = "failed to resolve store directory";
+                return false;
+            }
+
+            Directory.CreateDirectory(directory);
+            var payload = JsonSerializer.Serialize(store, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(path, payload + Environment.NewLine);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"failed to save unity editor store ({ex.Message})";
+            return false;
+        }
+    }
+
+    private static string GetStorePath()
+    {
+        var explicitConfigPath = Environment.GetEnvironmentVariable("UNIFOCL_CONFIG_PATH");
+        if (!string.IsNullOrWhiteSpace(explicitConfigPath))
+        {
+            var configDirectory = Path.GetDirectoryName(Path.GetFullPath(explicitConfigPath));
+            if (!string.IsNullOrWhiteSpace(configDirectory))
+            {
+                return Path.Combine(configDirectory, "unity-editors.json");
+            }
+        }
+
+        var configRoot = Environment.GetEnvironmentVariable("UNIFOCL_CONFIG_ROOT");
+        if (!string.IsNullOrWhiteSpace(configRoot))
+        {
+            return Path.Combine(Path.GetFullPath(configRoot), "unity-editors.json");
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".unifocl", "unity-editors.json");
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return string.IsNullOrWhiteSpace(path) ? string.Empty : Path.GetFullPath(path);
+    }
+}


### PR DESCRIPTION
## Summary
- Add dynamic Unity editor resolution and persistence (project->editor mapping + default editor path).
- Improve scene-load reliability and failure handling across Unity/editor and stub bridge paths.
- Add TUI log wrapping by viewport width across project/hierarchy/inspector panes.
- Add daemon startup robustness: longer headless timeout, startup progress messages, compact failure summary, and output flood suppression.
- Add compile-error-aware startup handling with cached compile state and interactive decision flow: Enter Safe mode / Ignore and continue / Quit open.
- Add scalable package preflight by inferring required packages from project script namespaces and reconciling `Packages/manifest.json`.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `ProjectLifecycleService`, `DaemonControlService`, project open/new/clone flows
  - Unity daemon startup/attach pipeline
  - TUI renderers (`ProjectViewRenderer`, `HierarchyTui`, `InspectorTuiRenderer`)
  - Session state model (`CliSessionState`)
- Out-of-scope / intentionally not addressed:
  - Full assembly/type->package resolver via Unity package metadata indexes
  - Persistent safe-mode policy beyond current session

## How to Test
1. Run `dotnet build src/unifocl/unifocl.csproj`.
2. Open/clone a Unity project with `ProjectVersion.txt` set; verify editor path resolves automatically and persists.
3. Trigger daemon headless startup and observe step-4 progress logs every ~5s until ready.
4. In a project with compile errors, verify prompt appears with options (Safe mode / Ignore / Quit), and safe mode tag appears in prompt when selected.
5. In project/hierarchy/inspector UIs, emit long log lines and verify wrapping to current TUI width.

Expected results:
- Daemon startup is observable (no silent hang) and less noisy.
- Scene load fails fast with clear error when Unity bridge cannot load.
- Compile-error state is captured and user decision is required before continuing.
- Wrapped logs remain readable across TUI panes.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->

## Breaking Changes
- [x] This PR introduces a breaking change.

If yes, describe migration steps:
- For projects with many package dependencies, headless Unity daemon startup may still exceed timeout (currently 120s) after enabling UPM during boot. Users should either:
  - open once via GUI Unity to complete import/package resolution, then retry CLI, or
  - rerun open and choose Safe mode / Ignore when compile/import startup fails.

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No new external network endpoints or credential handling changes.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [ ] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
