### PR TITLE
Fix Unity daemon endpoint/attach consistency and unsafe boot flow

### DIFF
--- a/src/unifocl/Models/CommandModels.cs
+++ b/src/unifocl/Models/CommandModels.cs
@@ -1,5 +1,5 @@
 internal sealed record CommandSpec(string Signature, string Description, string Trigger);
-internal sealed record DaemonStartOptions(int Port, string? UnityPath, string? ProjectPath, bool Headless);
+internal sealed record DaemonStartOptions(int Port, string? UnityPath, string? ProjectPath, bool Headless, bool AllowUnsafe);
 internal sealed record DaemonServiceOptions(int Port, string? UnityPath, string? ProjectPath, bool Headless, int InactivityTimeoutSeconds);
 internal sealed record DaemonInstance(
     int Port,

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -18,7 +18,7 @@ if (DaemonControlService.TryParseDaemonServiceArgs(launchArgs, out var serviceOp
 var commands = new List<CommandSpec>
 {
     // System & lifecycle
-    new("/open <path>", "Open project (starts/attaches daemon, loads project)", "/open"),
+    new("/open <path> [--allow-unsafe]", "Open project (starts/attaches daemon, loads project)", "/open"),
     new("/o <path>", "Alias for /open", "/o"),
     new("/close", "Detach from current project and stop attached daemon", "/close"),
     new("/c", "Alias for /close", "/c"),
@@ -42,10 +42,10 @@ var commands = new List<CommandSpec>
     new("/i <idx|path>", "Alias for /inspect", "/i"),
 
     // Extended lifecycle (kept for compatibility)
-    new("/new <project-name> [unity-version]", "Bootstrap a new Unity project", "/new"),
-    new("/clone <git-url>", "Clone repo and set local CLI bridge config", "/clone"),
-    new("/recent [idx]", "Open recent projects (interactive or by index)", "/recent"),
-    new("/daemon start [--port 8080] [--unity <path>] [--project <path>] [--headless]", "Start always-warm daemon", "/daemon start"),
+    new("/new <project-name> [unity-version] [--allow-unsafe]", "Bootstrap a new Unity project", "/new"),
+    new("/clone <git-url> [--allow-unsafe]", "Clone repo and set local CLI bridge config", "/clone"),
+    new("/recent [idx] [--allow-unsafe]", "Open recent projects (interactive or by index)", "/recent"),
+    new("/daemon start [--port 8080] [--unity <path>] [--project <path>] [--headless] [--allow-unsafe]", "Start always-warm daemon", "/daemon start"),
     new("/daemon stop", "Stop daemon", "/daemon stop"),
     new("/daemon restart", "Restart daemon", "/daemon restart"),
     new("/daemon ps", "Show instances, ports, uptime, project", "/daemon ps"),

--- a/src/unifocl/Services/DaemonControlService.cs
+++ b/src/unifocl/Services/DaemonControlService.cs
@@ -1,4 +1,5 @@
 using Spectre.Console;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
@@ -23,7 +24,7 @@ internal sealed class DaemonControlService
         switch (trigger)
         {
             case "/daemon start":
-                await HandleDaemonStartAsync(input, runtime, log);
+                await HandleDaemonStartAsync(input, runtime, session, log);
                 break;
             case "/daemon stop":
                 await HandleDaemonStopAsync(runtime, session, log);
@@ -32,7 +33,7 @@ internal sealed class DaemonControlService
                 await HandleDaemonRestartAsync(runtime, session, log);
                 break;
             case "/daemon ps":
-                HandleDaemonPs(runtime, session, streamLog, log);
+                await HandleDaemonPsAsync(runtime, session, streamLog, log);
                 break;
             case "/daemon attach":
                 await HandleDaemonAttachAsync(input, runtime, session, log);
@@ -339,7 +340,9 @@ internal sealed class DaemonControlService
         DaemonRuntime runtime,
         CliSessionState session,
         Action<string> log,
-        bool requireUnityBridge = false)
+        bool requireUnityBridge = false,
+        bool preferHeadless = false,
+        bool allowUnsafe = false)
     {
         var port = ComputeProjectDaemonPort(projectPath);
         var existing = runtime.GetByPort(port);
@@ -347,7 +350,10 @@ internal sealed class DaemonControlService
         // Unity's InitializeOnLoad bridge can already be serving this port even when it's not in runtime registry.
         if (await TryAttachProjectDaemonAsync(projectPath, session, attemptCount: 1))
         {
-            if (!requireUnityBridge || IsUnityBridgeCapable(existing))
+            var headlessSatisfied = !preferHeadless
+                                    || (existing?.Headless ?? false)
+                                    || IsUnityClientActiveForProject(projectPath);
+            if ((!requireUnityBridge || IsUnityBridgeCapable(existing)) && headlessSatisfied)
             {
                 return true;
             }
@@ -379,7 +385,8 @@ internal sealed class DaemonControlService
             port,
             unityPath,
             projectPath,
-            Headless: true);
+            Headless: true,
+            AllowUnsafe: allowUnsafe);
 
         var started = await StartDaemonAsync(startOptions, runtime, log);
         if (!started)
@@ -504,15 +511,48 @@ internal sealed class DaemonControlService
 
     public static int ComputeProjectDaemonPort(string projectPath)
     {
-        return 18080 + Math.Abs(projectPath.GetHashCode()) % 2000;
+        var normalized = Path.GetFullPath(projectPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Replace('\\', '/');
+
+        unchecked
+        {
+            var hash = 17;
+            foreach (var ch in normalized)
+            {
+                hash = (hash * 31) + ch;
+            }
+
+            return 18080 + ((hash & 0x7fffffff) % 2000);
+        }
     }
 
-    private async Task HandleDaemonStartAsync(string input, DaemonRuntime runtime, Action<string> log)
+    private async Task HandleDaemonStartAsync(string input, DaemonRuntime runtime, CliSessionState session, Action<string> log)
     {
         if (!TryParseDaemonStartArgs(input, out var startOptions, out var parseError))
         {
             log($"[red]daemon[/]: {Markup.Escape(parseError)}");
             return;
+        }
+
+        startOptions = PromoteToHeadlessProjectStart(startOptions, session, log);
+
+        if (startOptions.Headless && !string.IsNullOrWhiteSpace(startOptions.ProjectPath))
+        {
+            var projectPath = startOptions.ProjectPath;
+            if (IsUnityClientActiveForProject(projectPath))
+            {
+                if (await TryAttachProjectDaemonAsync(projectPath, session, log, attemptCount: 2, attemptDelayMs: 250))
+                {
+                    log($"[green]daemon[/]: Unity editor is already running for project; attached bridge on [white]127.0.0.1:{ComputeProjectDaemonPort(projectPath)}[/]");
+                }
+                else
+                {
+                    log("[yellow]daemon[/]: Unity editor lock detected for project; skipped starting another headless Unity instance");
+                }
+
+                return;
+            }
         }
 
         await StartDaemonAsync(startOptions, runtime, log);
@@ -539,26 +579,40 @@ internal sealed class DaemonControlService
             log("[red]daemon[/]: failed to start daemon process");
             return false;
         }
+        var launchedAtUtc = DateTime.UtcNow;
 
         var outputTail = new Queue<string>();
+        var outputLines = new ConcurrentQueue<string>();
+        if (startOptions.Headless)
+        {
+            var mode = startOptions.AllowUnsafe ? "unsafe (UPM disabled, ignore compile errors)" : "safe (UPM enabled)";
+            log($"[grey]daemon[/]: starting Unity headless bridge on port {startOptions.Port} ({mode})");
+        }
         StartBackgroundOutputDrain(
             process,
             startOptions.Headless,
-            line => CaptureProcessOutputLine(outputTail, line));
+            line =>
+            {
+                CaptureProcessOutputLine(outputTail, line);
+                outputLines.Enqueue(line);
+            });
 
-        var startupTimeout = startOptions.Headless
-            ? TimeSpan.FromSeconds(120)
-            : TimeSpan.FromSeconds(25);
-        if (startOptions.Headless)
-        {
-            log($"[grey]daemon[/]: starting Unity headless bridge on port {startOptions.Port} (timeout {startupTimeout.TotalSeconds:0}s)");
-        }
-
-        var ready = await WaitForDaemonReadyAsync(startOptions.Port, startupTimeout, startOptions.Headless
-            ? elapsed => log($"[grey]daemon[/]: startup in progress... {elapsed.TotalSeconds:0}s elapsed")
-            : null);
+        var startupTimeout = TimeSpan.FromSeconds(25);
+        var ready = startOptions.Headless
+            ? await WaitForHeadlessDaemonReadyAsync(
+                startOptions.Port,
+                process,
+                outputLines,
+                elapsed => log($"[grey]daemon[/]: startup in progress... {elapsed.TotalSeconds:0}s elapsed"),
+                line => log($"[grey]unity[/]: {Markup.Escape(line)}"))
+            : await WaitForDaemonReadyAsync(startOptions.Port, startupTimeout);
         if (!ready)
         {
+            while (outputLines.TryDequeue(out var line))
+            {
+                log($"[grey]unity[/]: {Markup.Escape(line)}");
+            }
+
             if (process.HasExited)
             {
                 var details = BuildProcessFailureSummary(outputTail);
@@ -583,6 +637,19 @@ internal sealed class DaemonControlService
             }
 
             return false;
+        }
+
+        // Headless Unity bridge launch does not self-register in daemon runtime metadata.
+        if (startOptions.Headless)
+        {
+            runtime.Upsert(new DaemonInstance(
+                startOptions.Port,
+                process.Id,
+                launchedAtUtc,
+                startOptions.UnityPath,
+                startOptions.Headless,
+                startOptions.ProjectPath,
+                DateTime.UtcNow));
         }
 
         _lastStartupFailure = null;
@@ -634,10 +701,51 @@ internal sealed class DaemonControlService
                           (restartUnity is null ? string.Empty : $" --unity \"{restartUnity}\"") +
                           (restartProject is null ? string.Empty : $" --project \"{restartProject}\"") +
                           (restartHeadless ? " --headless" : string.Empty);
-        await HandleDaemonStartAsync(synthesized, runtime, log);
+        await HandleDaemonStartAsync(synthesized, runtime, session, log);
     }
 
-    private static void HandleDaemonPs(
+    private static DaemonStartOptions PromoteToHeadlessProjectStart(DaemonStartOptions options, CliSessionState session, Action<string> log)
+    {
+        if (options.Headless)
+        {
+            return options;
+        }
+
+        var projectPath = options.ProjectPath;
+        if (string.IsNullOrWhiteSpace(projectPath) && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+        {
+            projectPath = session.CurrentProjectPath;
+        }
+
+        if (string.IsNullOrWhiteSpace(projectPath))
+        {
+            return options;
+        }
+
+        var unityPath = options.UnityPath;
+        if (string.IsNullOrWhiteSpace(unityPath))
+        {
+            unityPath = ResolveDefaultUnityPath(projectPath);
+        }
+
+        if (string.IsNullOrWhiteSpace(unityPath))
+        {
+            log("[yellow]daemon[/]: project context found but Unity path is unresolved; starting non-headless daemon");
+            return options with { ProjectPath = projectPath };
+        }
+
+        var promotedPort = options.Port == 8080 ? ComputeProjectDaemonPort(projectPath) : options.Port;
+        log($"[grey]daemon[/]: defaulting to headless Unity bridge for project [white]{Markup.Escape(projectPath)}[/]");
+        return options with
+        {
+            Port = promotedPort,
+            ProjectPath = projectPath,
+            UnityPath = unityPath,
+            Headless = true
+        };
+    }
+
+    private async Task HandleDaemonPsAsync(
         DaemonRuntime runtime,
         CliSessionState session,
         List<string> streamLog,
@@ -645,9 +753,31 @@ internal sealed class DaemonControlService
     {
         runtime.CleanStaleEntries();
         var instances = runtime.GetAll().OrderBy(i => i.Port).ToList();
-        if (instances.Count == 0)
+        var hasLiveAttachedOnly = false;
+        if (instances.Count == 0 && session.AttachedPort is int attachedPortProbe)
+        {
+            hasLiveAttachedOnly = await TrySendControlAsync(attachedPortProbe, "PING", "PONG");
+            if (!hasLiveAttachedOnly)
+            {
+                session.AttachedPort = null;
+            }
+        }
+
+        var hasLiveProjectBridgeOnly = false;
+        var projectBridgePort = 0;
+        if (instances.Count == 0 && !hasLiveAttachedOnly && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+        {
+            projectBridgePort = ComputeProjectDaemonPort(session.CurrentProjectPath);
+            hasLiveProjectBridgeOnly = await TrySendControlAsync(projectBridgePort, "PING", "PONG");
+        }
+
+        if (instances.Count == 0 && !hasLiveAttachedOnly && !hasLiveProjectBridgeOnly)
         {
             log("[grey]daemon[/]: no running daemon instances");
+            if (!string.IsNullOrWhiteSpace(session.CurrentProjectPath) && IsUnityClientActiveForProject(session.CurrentProjectPath))
+            {
+                log("[yellow]daemon[/]: Unity editor lock exists for current project, but bridge endpoint is not responding yet");
+            }
             return;
         }
 
@@ -671,6 +801,36 @@ internal sealed class DaemonControlService
                 session.AttachedPort == instance.Port ? "yes" : "no");
         }
 
+        if (session.AttachedPort is int attachedPort && instances.All(i => i.Port != attachedPort))
+        {
+            if (await TrySendControlAsync(attachedPort, "PING", "PONG"))
+            {
+                table.AddRow(
+                    attachedPort.ToString(),
+                    "-",
+                    "-",
+                    "-",
+                    "unknown",
+                    "yes");
+            }
+            else
+            {
+                session.AttachedPort = null;
+                log($"[yellow]daemon[/]: detached stale session from port {attachedPort} (endpoint not responding)");
+            }
+        }
+
+        if (hasLiveProjectBridgeOnly && instances.All(i => i.Port != projectBridgePort))
+        {
+            table.AddRow(
+                projectBridgePort.ToString(),
+                "-",
+                "-",
+                "-",
+                IsUnityClientActiveForProject(session.CurrentProjectPath!) ? "editor-bridge" : "unknown",
+                session.AttachedPort == projectBridgePort ? "yes" : "no");
+        }
+
         AnsiConsole.Write(table);
         streamLog.Add("[grey]daemon[/]: listed active instances");
     }
@@ -684,13 +844,6 @@ internal sealed class DaemonControlService
             return;
         }
 
-        var instance = runtime.GetByPort(port);
-        if (instance is null || !ProcessUtil.IsAlive(instance.Pid))
-        {
-            log($"[red]daemon[/]: no running daemon registered on port {port}");
-            return;
-        }
-
         if (!await TrySendControlAsync(port, "PING", "PONG"))
         {
             log($"[red]daemon[/]: daemon on port {port} is not responding");
@@ -698,6 +851,13 @@ internal sealed class DaemonControlService
         }
 
         session.AttachedPort = port;
+        var known = runtime.GetByPort(port);
+        if (known is null)
+        {
+            log($"[yellow]daemon[/]: attached to live port {port} (runtime metadata not found)");
+            return;
+        }
+
         log($"[green]daemon[/]: attached to port {port}");
     }
 
@@ -734,7 +894,7 @@ internal sealed class DaemonControlService
     private static bool TryParseDaemonStartArgs(string input, out DaemonStartOptions options, out string error)
     {
         var tokens = TokenizeArgs(input);
-        options = new DaemonStartOptions(8080, null, null, false);
+        options = new DaemonStartOptions(8080, null, null, false, false);
         error = string.Empty;
 
         for (var i = 2; i < tokens.Count; i++)
@@ -775,6 +935,9 @@ internal sealed class DaemonControlService
                 case "--headless":
                     options = options with { Headless = true };
                     break;
+                case "--allow-unsafe":
+                    options = options with { AllowUnsafe = true };
+                    break;
                 default:
                     error = $"unrecognized option {token}";
                     return false;
@@ -802,8 +965,13 @@ internal sealed class DaemonControlService
             unityPsi.ArgumentList.Add("-nographics");
             unityPsi.ArgumentList.Add("-vcsMode");
             unityPsi.ArgumentList.Add("None");
+            if (options.AllowUnsafe)
+            {
+                unityPsi.ArgumentList.Add("-noUpm");
+                unityPsi.ArgumentList.Add("-ignoreCompileErrors");
+            }
             unityPsi.ArgumentList.Add("-executeMethod");
-            unityPsi.ArgumentList.Add("CLIDaemon.StartServer");
+            unityPsi.ArgumentList.Add("UniFocl.EditorBridge.CLIDaemon.StartServer");
             unityPsi.ArgumentList.Add("--daemon-service");
             unityPsi.ArgumentList.Add("--port");
             unityPsi.ArgumentList.Add(options.Port.ToString());
@@ -843,6 +1011,11 @@ internal sealed class DaemonControlService
         if (options.Headless)
         {
             daemonArgs.Add("--headless");
+        }
+
+        if (options.AllowUnsafe)
+        {
+            daemonArgs.Add("--allow-unsafe");
         }
 
         if (Path.GetFileNameWithoutExtension(processPath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
@@ -996,6 +1169,44 @@ internal sealed class DaemonControlService
         }
 
         return false;
+    }
+
+    private static async Task<bool> WaitForHeadlessDaemonReadyAsync(
+        int port,
+        Process process,
+        ConcurrentQueue<string> outputLines,
+        Action<TimeSpan>? onProgress = null,
+        Action<string>? onOutput = null)
+    {
+        var startedAt = DateTime.UtcNow;
+        var nextProgressAt = startedAt.AddSeconds(5);
+
+        while (true)
+        {
+            while (outputLines.TryDequeue(out var line))
+            {
+                onOutput?.Invoke(line);
+            }
+
+            if (await TrySendControlAsync(port, "PING", "PONG"))
+            {
+                return true;
+            }
+
+            if (process.HasExited)
+            {
+                return false;
+            }
+
+            var now = DateTime.UtcNow;
+            if (onProgress is not null && now >= nextProgressAt)
+            {
+                onProgress(now - startedAt);
+                nextProgressAt = now.AddSeconds(5);
+            }
+
+            await Task.Delay(180);
+        }
     }
 
     private static async Task<bool> TrySendControlAsync(int port, string request, string expectedResponse)

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -82,13 +82,13 @@ internal sealed class ProjectLifecycleService
         Action<string> log)
     {
         var args = ParseCommandArgs(input, matched.Trigger);
-        if (args.Count < 1)
+        if (!TryParseOpenArgs(args, out var openPath, out var allowUnsafe, out var openParseError))
         {
-            log("[red]error[/]: usage /open <path>");
+            log($"[red]error[/]: {Markup.Escape(openParseError)}");
             return true;
         }
 
-        var projectPath = ResolveAbsolutePath(args[0], Directory.GetCurrentDirectory());
+        var projectPath = ResolveAbsolutePath(openPath, Directory.GetCurrentDirectory());
         await TryOpenProjectAsync(
             projectPath,
             session,
@@ -96,7 +96,8 @@ internal sealed class ProjectLifecycleService
             daemonRuntime,
             _editorDependencyInitializerService,
             promptForInitialization: true,
-            log);
+            allowUnsafe: allowUnsafe,
+            log: log);
         return true;
     }
 
@@ -109,16 +110,9 @@ internal sealed class ProjectLifecycleService
         Action<string> log)
     {
         var args = ParseCommandArgs(input, matched.Trigger);
-        if (args.Count < 1)
+        if (!TryParseNewArgs(args, out var projectName, out var requestedVersion, out var allowUnsafe, out var parseError))
         {
-            log("[red]error[/]: usage /new <project-name> <unity-version?>");
-            return true;
-        }
-
-        var projectName = args[0].Trim();
-        if (string.IsNullOrWhiteSpace(projectName))
-        {
-            log("[red]error[/]: project name cannot be empty");
+            log($"[red]error[/]: {Markup.Escape(parseError)}");
             return true;
         }
 
@@ -130,9 +124,8 @@ internal sealed class ProjectLifecycleService
         }
 
         UnityEditorPathService.UnityEditorInstallation selectedEditor;
-        if (args.Count > 1)
+        if (!string.IsNullOrWhiteSpace(requestedVersion))
         {
-            var requestedVersion = args[1].Trim();
             selectedEditor = availableEditors.FirstOrDefault(x => x.Version.Equals(requestedVersion, StringComparison.OrdinalIgnoreCase))
                 ?? new UnityEditorPathService.UnityEditorInstallation(string.Empty, string.Empty);
             if (string.IsNullOrWhiteSpace(selectedEditor.Version))
@@ -219,7 +212,8 @@ internal sealed class ProjectLifecycleService
                 daemonRuntime,
                 _editorDependencyInitializerService,
                 promptForInitialization: true,
-                log))
+                allowUnsafe: allowUnsafe,
+                log: log))
         {
             log("[green]new[/]: Unity project scaffold ready");
         }
@@ -240,16 +234,9 @@ internal sealed class ProjectLifecycleService
         Action<string> log)
     {
         var args = ParseCommandArgs(input, matched.Trigger);
-        if (args.Count < 1)
+        if (!TryParseCloneArgs(args, out var gitUrl, out var allowUnsafe, out var parseError))
         {
-            log("[red]error[/]: usage /clone <git-url>");
-            return true;
-        }
-
-        var gitUrl = args[0].Trim();
-        if (string.IsNullOrWhiteSpace(gitUrl))
-        {
-            log("[red]error[/]: git url cannot be empty");
+            log($"[red]error[/]: {Markup.Escape(parseError)}");
             return true;
         }
 
@@ -294,7 +281,8 @@ internal sealed class ProjectLifecycleService
                 daemonRuntime,
                 _editorDependencyInitializerService,
                 promptForInitialization: true,
-                log))
+                allowUnsafe: allowUnsafe,
+                log: log))
         {
             log("[green]clone[/]: repository cloned and prepared");
         }
@@ -355,9 +343,9 @@ internal sealed class ProjectLifecycleService
         Action<string> log)
     {
         var args = ParseCommandArgs(input, matched.Trigger);
-        if (args.Count > 1)
+        if (!TryParseRecentArgs(args, out var indexRaw, out var allowUnsafe, out var parseError))
         {
-            log("[red]error[/]: usage /recent <idx?>");
+            log($"[red]error[/]: {Markup.Escape(parseError)}");
             return Task.FromResult(true);
         }
 
@@ -375,9 +363,9 @@ internal sealed class ProjectLifecycleService
 
         LogRecentEntries(entries, log);
 
-        if (args.Count == 1)
+        if (!string.IsNullOrWhiteSpace(indexRaw))
         {
-            if (!int.TryParse(args[0], out var idx) || idx <= 0)
+            if (!int.TryParse(indexRaw, out var idx) || idx <= 0)
             {
                 log("[red]error[/]: idx must be a positive integer");
                 return Task.FromResult(true);
@@ -397,7 +385,7 @@ internal sealed class ProjectLifecycleService
                 return Task.FromResult(true);
             }
 
-            return OpenRecentSelectionAsync(selectedEntry, session, daemonControlService, daemonRuntime, log);
+            return OpenRecentSelectionAsync(selectedEntry, session, daemonControlService, daemonRuntime, allowUnsafe, log);
         }
 
         if (Console.IsInputRedirected)
@@ -418,7 +406,7 @@ internal sealed class ProjectLifecycleService
                 })
                 .AddChoices(entries));
 
-        return OpenRecentSelectionAsync(selected, session, daemonControlService, daemonRuntime, log);
+        return OpenRecentSelectionAsync(selected, session, daemonControlService, daemonRuntime, allowUnsafe, log);
     }
 
     private static void LogRecentEntries(IReadOnlyList<RecentProjectEntry> entries, Action<string> log)
@@ -437,6 +425,7 @@ internal sealed class ProjectLifecycleService
         CliSessionState session,
         DaemonControlService daemonControlService,
         DaemonRuntime daemonRuntime,
+        bool allowUnsafe,
         Action<string> log)
     {
         log($"[grey]recent[/]: opening [white]{Markup.Escape(selectedEntry.ProjectPath)}[/]");
@@ -447,7 +436,8 @@ internal sealed class ProjectLifecycleService
             daemonRuntime,
             _editorDependencyInitializerService,
             promptForInitialization: true,
-            log);
+            allowUnsafe: allowUnsafe,
+            log: log);
     }
 
     private Task<bool> HandleUnityDetectAsync(Action<string> log)
@@ -690,6 +680,7 @@ internal sealed class ProjectLifecycleService
         DaemonRuntime daemonRuntime,
         EditorDependencyInitializerService editorDependencyInitializerService,
         bool promptForInitialization,
+        bool allowUnsafe,
         Action<string> log)
     {
         log($"[grey]open[/]: step 1/5 resolve project path -> [white]{Markup.Escape(projectPath)}[/]");
@@ -764,20 +755,39 @@ internal sealed class ProjectLifecycleService
         var daemonPort = DaemonControlService.ComputeProjectDaemonPort(projectPath);
         if (DaemonControlService.IsUnityClientActiveForProject(projectPath))
         {
-            await daemonControlService.TryAttachProjectDaemonAsync(projectPath, session, log);
-            SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, false));
-            if (session.AttachedPort == daemonPort)
+            var attached = await daemonControlService.TryAttachProjectDaemonAsync(
+                projectPath,
+                session,
+                log: null,
+                attemptCount: 32,
+                attemptDelayMs: 250);
+            if (attached && session.AttachedPort == daemonPort)
             {
+                SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, false));
                 log($"[grey]daemon[/]: Unity editor lock detected; attached bridge on [white]127.0.0.1:{daemonPort}[/]");
             }
             else
             {
-                log("[grey]daemon[/]: Unity editor lock detected; routing operations via InitializeOnLoad bridge");
+                log($"[red]daemon[/]: Unity editor lock detected, but bridge endpoint [white]127.0.0.1:{daemonPort}[/] is not responding");
+                log("[yellow]daemon[/]: wait for Unity editor script compilation/domain reload, then retry /open");
+                return false;
             }
         }
         else
         {
-            var started = await daemonControlService.EnsureProjectDaemonAsync(projectPath, daemonRuntime, session, log);
+            if (allowUnsafe)
+            {
+                log("[yellow]open[/]: --allow-unsafe enabled (using -noUpm and -ignoreCompileErrors for faster headless boot)");
+            }
+
+            var started = await daemonControlService.EnsureProjectDaemonAsync(
+                projectPath,
+                daemonRuntime,
+                session,
+                log,
+                requireUnityBridge: true,
+                preferHeadless: true,
+                allowUnsafe: allowUnsafe);
             if (!started)
             {
                 if (!HandleDaemonStartupFailure(projectPath, session, daemonControlService, log))
@@ -953,6 +963,183 @@ internal sealed class ProjectLifecycleService
         return tokens;
     }
 
+    private static bool TryParseOpenArgs(
+        IReadOnlyList<string> args,
+        out string projectPath,
+        out bool allowUnsafe,
+        out string error)
+    {
+        projectPath = string.Empty;
+        allowUnsafe = false;
+        error = string.Empty;
+
+        foreach (var arg in args)
+        {
+            if (arg.Equals("--allow-unsafe", StringComparison.Ordinal))
+            {
+                allowUnsafe = true;
+                continue;
+            }
+
+            if (arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                error = $"unrecognized option {arg}; usage /open <path> [--allow-unsafe]";
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(projectPath))
+            {
+                error = "too many positional arguments; usage /open <path> [--allow-unsafe]";
+                return false;
+            }
+
+            projectPath = arg;
+        }
+
+        if (string.IsNullOrWhiteSpace(projectPath))
+        {
+            error = "usage /open <path> [--allow-unsafe]";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryParseNewArgs(
+        IReadOnlyList<string> args,
+        out string projectName,
+        out string? unityVersion,
+        out bool allowUnsafe,
+        out string error)
+    {
+        projectName = string.Empty;
+        unityVersion = null;
+        allowUnsafe = false;
+        error = string.Empty;
+
+        foreach (var arg in args)
+        {
+            if (IsAllowUnsafeFlag(arg))
+            {
+                allowUnsafe = true;
+                continue;
+            }
+
+            if (arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                error = $"unrecognized option {arg}; usage /new <project-name> [unity-version] [--allow-unsafe]";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(projectName))
+            {
+                projectName = arg.Trim();
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(unityVersion))
+            {
+                unityVersion = arg.Trim();
+                continue;
+            }
+
+            error = "too many positional arguments; usage /new <project-name> [unity-version] [--allow-unsafe]";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(projectName))
+        {
+            error = "usage /new <project-name> [unity-version] [--allow-unsafe]";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryParseCloneArgs(
+        IReadOnlyList<string> args,
+        out string gitUrl,
+        out bool allowUnsafe,
+        out string error)
+    {
+        gitUrl = string.Empty;
+        allowUnsafe = false;
+        error = string.Empty;
+
+        foreach (var arg in args)
+        {
+            if (IsAllowUnsafeFlag(arg))
+            {
+                allowUnsafe = true;
+                continue;
+            }
+
+            if (arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                error = $"unrecognized option {arg}; usage /clone <git-url> [--allow-unsafe]";
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(gitUrl))
+            {
+                error = "too many positional arguments; usage /clone <git-url> [--allow-unsafe]";
+                return false;
+            }
+
+            gitUrl = arg.Trim();
+        }
+
+        if (string.IsNullOrWhiteSpace(gitUrl))
+        {
+            error = "usage /clone <git-url> [--allow-unsafe]";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryParseRecentArgs(
+        IReadOnlyList<string> args,
+        out string? indexRaw,
+        out bool allowUnsafe,
+        out string error)
+    {
+        indexRaw = null;
+        allowUnsafe = false;
+        error = string.Empty;
+
+        foreach (var arg in args)
+        {
+            if (IsAllowUnsafeFlag(arg))
+            {
+                allowUnsafe = true;
+                continue;
+            }
+
+            if (arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                error = $"unrecognized option {arg}; usage /recent [idx] [--allow-unsafe]";
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(indexRaw))
+            {
+                error = "too many positional arguments; usage /recent [idx] [--allow-unsafe]";
+                return false;
+            }
+
+            indexRaw = arg.Trim();
+        }
+
+        return true;
+    }
+
+    private static bool IsAllowUnsafeFlag(string arg)
+    {
+        return arg.Equals("--allow-unsafe", StringComparison.Ordinal)
+               || arg.Equals("--alow-unsafe", StringComparison.Ordinal);
+    }
+
     private static string ResolveAbsolutePath(string path, string baseDirectory)
     {
         if (string.IsNullOrWhiteSpace(path))
@@ -999,17 +1186,14 @@ internal sealed class ProjectLifecycleService
             Directory.CreateDirectory(bridgeDir);
 
             var bridgePath = Path.Combine(bridgeDir, "bridge.json");
-            if (!File.Exists(bridgePath))
+            var bridge = JsonSerializer.Serialize(new
             {
-                var bridge = JsonSerializer.Serialize(new
-                {
-                    projectPath,
-                    daemon = new { host = "127.0.0.1", port = 18080 },
-                    protocol = "v1",
-                    updatedAtUtc = DateTimeOffset.UtcNow
-                }, new JsonSerializerOptions { WriteIndented = true });
-                File.WriteAllText(bridgePath, bridge + Environment.NewLine);
-            }
+                projectPath,
+                daemon = new { host = "127.0.0.1", port = DaemonControlService.ComputeProjectDaemonPort(projectPath) },
+                protocol = "v1",
+                updatedAtUtc = DateTimeOffset.UtcNow
+            }, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(bridgePath, bridge + Environment.NewLine);
 
             return OperationResult.Success();
         }


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Fixes Unity daemon endpoint consistency between CLI and Unity editor bridge.
  - Replaces non-deterministic project port hashing with deterministic hashing.
  - Ensures `.unifocl/bridge.json` is always updated to the computed project port.
  - Fixes `-executeMethod` to use fully-qualified `UniFocl.EditorBridge.CLIDaemon.StartServer`.
  - Improves headless startup diagnostics by streaming Unity boot logs and removing hard headless startup timeout.
  - Adds `--allow-unsafe` support to `/open`, `/new`, `/clone`, `/recent`, and `/daemon start` to pass `-noUpm` and `-ignoreCompileErrors`.
  - Stabilizes attachment lifecycle so open/start paths attach to responding endpoints and `/daemon ps` reflects live bridge state.
- Why is this change needed?
  - Users could observe Unity lock with no responding endpoint due to port mismatch (`bridge.json` vs CLI-computed port), causing inconsistent attach behavior and conflicting diagnostics.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - Daemon lifecycle and attach logic (`DaemonControlService`)
  - Project open/new/clone/recent lifecycle (`ProjectLifecycleService`)
  - Command option models/help signatures (`CommandModels`, `Program`)
- Out-of-scope / intentionally not addressed:
  - New automated integration tests for Unity process/bridge behavior (manual verification only in this PR)

## How to Test
1. Build CLI: `dotnet build src/unifocl/unifocl.csproj -v minimal`
2. Open a Unity project with editor already running: `/open <projectPath>`
3. Confirm attach succeeds only when endpoint responds; if not responding, open fails with explicit bridge message.
4. Run `/daemon ps` and confirm it reports live project bridge/attachment consistently.
5. Test unsafe mode:
   - `/open <projectPath> --allow-unsafe`
   - `/new <name> [version] --allow-unsafe`
   - `/clone <url> --allow-unsafe`
   - `/recent <idx> --allow-unsafe`
   - `/daemon start --allow-unsafe`

Expected results:
- Project port is consistent and deterministic.
- `.unifocl/bridge.json` daemon port matches CLI computed project port.
- No duplicate headless launch when Unity lock is already active.
- `/daemon ps` no longer reports misleading “no running daemon instances” when live bridge state exists.

## Screenshots / Terminal Output (if applicable)
- Local validation command:
  - `dotnet build src/unifocl/unifocl.csproj -v minimal` -> success (0 errors, 0 warnings)

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Changes are local daemon lifecycle/control flow and logging improvements.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
