### PR TITLE
Fix /init bridge config generation and add CLI-wide version 0.2.0

### DIFF
--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -51,7 +51,7 @@ var commands = new List<CommandSpec>
     new("/daemon ps", "Show instances, ports, uptime, project", "/daemon ps"),
     new("/daemon attach <port>", "Attach CLI to existing daemon", "/daemon attach"),
     new("/daemon detach", "Detach CLI and keep daemon alive", "/daemon detach"),
-    new("/init [path-to-project]", "Install editor-side CLI bridge dependencies", "/init"),
+    new("/init [path-to-project]", "Generate local bridge config and install editor-side CLI bridge dependencies", "/init"),
     new("/clear", "Clear and redraw boot screen", "/clear"),
 
     // Legacy compatibility commands (not all implemented yet)
@@ -266,6 +266,20 @@ while (true)
         if (matched.Trigger is "/keybinds" or "/shortcuts")
         {
             WriteKeybindsHelp(streamLog, session);
+            continue;
+        }
+
+        if (matched.Trigger == "/version")
+        {
+            var processPath = Environment.ProcessPath ?? AppContext.BaseDirectory;
+            AppendLog(streamLog, $"[grey]version[/]: cli [white]{Markup.Escape(CliVersion.SemVer)}[/], protocol [white]{Markup.Escape(CliVersion.Protocol)}[/]");
+            AppendLog(streamLog, $"[grey]binary[/]: [white]{Markup.Escape(processPath)}[/]");
+            continue;
+        }
+
+        if (matched.Trigger == "/protocol")
+        {
+            AppendLog(streamLog, $"[grey]protocol[/]: [white]{Markup.Escape(CliVersion.Protocol)}[/]");
             continue;
         }
 
@@ -623,6 +637,7 @@ static void SeedBootLog(List<string> streamLog)
 
     streamLog.Add("[bold deepskyblue1]unifocl[/]");
     streamLog.Add("[bold green]Welcome to unifocl[/]");
+    streamLog.Add($"[grey]cli[/]: [white]{Markup.Escape(CliVersion.SemVer)}[/] ([white]{Markup.Escape(CliVersion.Protocol)}[/])");
     streamLog.Add(string.Empty);
 
     var logo = """

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -1,0 +1,9 @@
+internal static class CliVersion
+{
+    public const int Major = 0;
+    public const int Minor = 2;
+    public const int Patch = 0;
+    public const string Protocol = "v1";
+
+    public static string SemVer => $"{Major}.{Minor}.{Patch}";
+}

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -323,6 +323,20 @@ internal sealed class ProjectLifecycleService
             return Task.FromResult(true);
         }
 
+        var configResult = EnsureProjectLocalConfig(targetPath);
+        if (!configResult.Ok)
+        {
+            log($"[red]error[/]: {Markup.Escape(configResult.Error)}");
+            return Task.FromResult(true);
+        }
+
+        var packageFixResult = EnsureRequiredUnityPackageReferences(targetPath);
+        if (!packageFixResult.Ok)
+        {
+            log($"[red]error[/]: {Markup.Escape(packageFixResult.Error)}");
+            return Task.FromResult(true);
+        }
+
         var initResult = _editorDependencyInitializerService.InitializeProject(targetPath, log);
         if (!initResult.Ok)
         {
@@ -1190,7 +1204,7 @@ internal sealed class ProjectLifecycleService
             {
                 projectPath,
                 daemon = new { host = "127.0.0.1", port = DaemonControlService.ComputeProjectDaemonPort(projectPath) },
-                protocol = "v1",
+                protocol = CliVersion.Protocol,
                 updatedAtUtc = DateTimeOffset.UtcNow
             }, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(bridgePath, bridge + Environment.NewLine);


### PR DESCRIPTION
## Summary
- Fixes `/init` so it now generates local project bridge config (`.unifocl/bridge.json`) and normalizes required Unity package references before installing editor bridge dependencies.
- Adds a CLI-wide semantic version source (`major.minor.patch`) via `CliVersion` and sets current version to `0.2.0`.
- Wires `/version` and `/protocol` to shared version/protocol constants and shows version on startup banner for immediate binary identification.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Services/ProjectLifecycleService.cs`
  - `src/unifocl/Program.cs`
  - `src/unifocl/Services/CliVersion.cs` (new)
- Out-of-scope / intentionally not addressed:
  - Unity editor bridge runtime behavior outside local bridge/protocol config wiring.

## How to Test
1. Run: `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. In CLI, run `/init <unity-project-path>` and verify `<unity-project-path>/.unifocl/bridge.json` exists.
3. In CLI, run `/version` and confirm it reports `0.2.0`; run `/protocol` and confirm protocol output.

Expected results:
- Build succeeds with zero errors.
- `/init` writes/refreshes local bridge config.
- Version/protocol output is consistent and sourced from shared constants.

## Screenshots / Terminal Output (if applicable)
- `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal` completed successfully (0 warnings, 0 errors).

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No credentials or secret material introduced. Changes are limited to local config/version handling.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
