### PR TITLE
Fix daemon bridge attach reliability and bump protocol to v2

### DIFF
--- a/src/unifocl.unity/SharedModels/BridgeModels.cs
+++ b/src/unifocl.unity/SharedModels/BridgeModels.cs
@@ -7,7 +7,7 @@ namespace UniFocl.SharedModels
     {
         public string projectPath = string.Empty;
         public DaemonEndpoint daemon = new();
-        public string protocol = "v1";
+        public string protocol = "v2";
         public string updatedAtUtc = string.Empty;
     }
 

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -2,8 +2,8 @@ internal static class CliVersion
 {
     public const int Major = 0;
     public const int Minor = 2;
-    public const int Patch = 0;
-    public const string Protocol = "v1";
+    public const int Patch = 1;
+    public const string Protocol = "v2";
 
     public static string SemVer => $"{Major}.{Minor}.{Patch}";
 }

--- a/src/unifocl/Services/DaemonControlService.cs
+++ b/src/unifocl/Services/DaemonControlService.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
 
 internal sealed class DaemonControlService
 {
@@ -344,7 +345,7 @@ internal sealed class DaemonControlService
         bool preferHeadless = false,
         bool allowUnsafe = false)
     {
-        var port = ComputeProjectDaemonPort(projectPath);
+        var port = ResolveProjectDaemonPort(projectPath);
         var existing = runtime.GetByPort(port);
 
         // Unity's InitializeOnLoad bridge can already be serving this port even when it's not in runtime registry.
@@ -417,7 +418,7 @@ internal sealed class DaemonControlService
         int attemptCount = 8,
         int attemptDelayMs = 250)
     {
-        var port = ComputeProjectDaemonPort(projectPath);
+        var port = ResolveProjectDaemonPort(projectPath);
         var normalizedAttemptCount = Math.Max(1, attemptCount);
         var normalizedDelayMs = Math.Max(50, attemptDelayMs);
 
@@ -527,6 +528,33 @@ internal sealed class DaemonControlService
         }
     }
 
+    public static int ResolveProjectDaemonPort(string projectPath)
+    {
+        var bridgePath = Path.Combine(projectPath, ".unifocl", "bridge.json");
+        try
+        {
+            if (File.Exists(bridgePath))
+            {
+                using var document = JsonDocument.Parse(File.ReadAllText(bridgePath));
+                if (document.RootElement.ValueKind == JsonValueKind.Object
+                    && document.RootElement.TryGetProperty("daemon", out var daemonElement)
+                    && daemonElement.ValueKind == JsonValueKind.Object
+                    && daemonElement.TryGetProperty("port", out var portElement)
+                    && portElement.TryGetInt32(out var configuredPort)
+                    && configuredPort is > 0 and <= 65535)
+                {
+                    return configuredPort;
+                }
+            }
+        }
+        catch
+        {
+            // Ignore malformed local bridge config and fall back to deterministic port.
+        }
+
+        return ComputeProjectDaemonPort(projectPath);
+    }
+
     private async Task HandleDaemonStartAsync(string input, DaemonRuntime runtime, CliSessionState session, Action<string> log)
     {
         if (!TryParseDaemonStartArgs(input, out var startOptions, out var parseError))
@@ -544,7 +572,7 @@ internal sealed class DaemonControlService
             {
                 if (await TryAttachProjectDaemonAsync(projectPath, session, log, attemptCount: 2, attemptDelayMs: 250))
                 {
-                    log($"[green]daemon[/]: Unity editor is already running for project; attached bridge on [white]127.0.0.1:{ComputeProjectDaemonPort(projectPath)}[/]");
+                    log($"[green]daemon[/]: Unity editor is already running for project; attached bridge on [white]127.0.0.1:{ResolveProjectDaemonPort(projectPath)}[/]");
                 }
                 else
                 {
@@ -734,7 +762,7 @@ internal sealed class DaemonControlService
             return options with { ProjectPath = projectPath };
         }
 
-        var promotedPort = options.Port == 8080 ? ComputeProjectDaemonPort(projectPath) : options.Port;
+        var promotedPort = options.Port == 8080 ? ResolveProjectDaemonPort(projectPath) : options.Port;
         log($"[grey]daemon[/]: defaulting to headless Unity bridge for project [white]{Markup.Escape(projectPath)}[/]");
         return options with
         {
@@ -767,7 +795,7 @@ internal sealed class DaemonControlService
         var projectBridgePort = 0;
         if (instances.Count == 0 && !hasLiveAttachedOnly && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
         {
-            projectBridgePort = ComputeProjectDaemonPort(session.CurrentProjectPath);
+            projectBridgePort = ResolveProjectDaemonPort(session.CurrentProjectPath);
             hasLiveProjectBridgeOnly = await TrySendControlAsync(projectBridgePort, "PING", "PONG");
         }
 

--- a/src/unifocl/Services/HierarchyTui.cs
+++ b/src/unifocl/Services/HierarchyTui.cs
@@ -501,7 +501,7 @@ internal sealed class HierarchyTui
             : $" | Focus Key: {FocusModeKey}";
 
         WriteFrameLine(borderTop);
-        WriteFrameLine(ToFrameLine($" UnityCLI v0.1 | MODE: HIERARCHY | Daemon: 127.0.0.1:{daemonPort} | Scene: {scene}{focusLabel}", frameWidth));
+        WriteFrameLine(ToFrameLine($" UnityCLI v{CliVersion.SemVer} | MODE: HIERARCHY | Daemon: 127.0.0.1:{daemonPort} | Scene: {scene}{focusLabel}", frameWidth));
         WriteFrameLine(borderMid);
 
         foreach (var line in visibleTree)

--- a/src/unifocl/Services/InspectorTuiRenderer.cs
+++ b/src/unifocl/Services/InspectorTuiRenderer.cs
@@ -132,7 +132,7 @@ internal sealed class InspectorTuiRenderer
         var focusLabel = focusModeEnabled
             ? " | FOCUS: ON (up/down, tab, shift+tab, esc)"
             : " | Focus Key: F8";
-        return $"UnityCLI v0.1 | MODE: INSPECTOR | Target: {target}{focusLabel}";
+        return $"UnityCLI v{CliVersion.SemVer} | MODE: INSPECTOR | Target: {target}{focusLabel}";
     }
 
     private static string Border(char left, char right, int innerWidth)

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -146,7 +146,7 @@ internal sealed class ProjectLifecycleService
             selectedEditor = AnsiConsole.Prompt(
                 new SelectionPrompt<UnityEditorPathService.UnityEditorInstallation>()
                     .Title("Choose Unity editor version")
-                    .PageSize(Math.Min(availableEditors.Count, 12))
+                    .PageSize(ResolvePromptPageSize(availableEditors.Count, 12))
                     .UseConverter(editor => $"{editor.Version} ({editor.EditorPath})")
                     .AddChoices(availableEditors));
         }
@@ -411,7 +411,7 @@ internal sealed class ProjectLifecycleService
         var selected = AnsiConsole.Prompt(
             new SelectionPrompt<RecentProjectEntry>()
                 .Title("Select a recent project to open")
-                .PageSize(Math.Min(entries.Count, 10))
+                .PageSize(ResolvePromptPageSize(entries.Count, 10))
                 .UseConverter(entry =>
                 {
                     var index = entries.IndexOf(entry) + 1;
@@ -657,7 +657,7 @@ internal sealed class ProjectLifecycleService
 
         if (!string.IsNullOrWhiteSpace(session.CurrentProjectPath))
         {
-            candidatePorts.Add(DaemonControlService.ComputeProjectDaemonPort(session.CurrentProjectPath));
+            candidatePorts.Add(DaemonControlService.ResolveProjectDaemonPort(session.CurrentProjectPath));
         }
 
         var hadDaemonTarget = candidatePorts.Count > 0;
@@ -711,6 +711,9 @@ internal sealed class ProjectLifecycleService
             return false;
         }
 
+        var hasProtocolMismatch = TryGetProjectBridgeProtocol(projectPath, out var configuredProtocol)
+                                  && !string.Equals(configuredProtocol, CliVersion.Protocol, StringComparison.Ordinal);
+
         log("[grey]open[/]: step 2/5 validate Unity project layout");
         var bridgeResult = EnsureProjectLocalConfig(projectPath);
         if (!bridgeResult.Ok)
@@ -728,6 +731,17 @@ internal sealed class ProjectLifecycleService
 
         if (promptForInitialization)
         {
+            if (hasProtocolMismatch)
+            {
+                log($"[yellow]init[/]: bridge protocol mismatch detected (project: [white]{Markup.Escape(configuredProtocol!)}[/], cli: [white]{Markup.Escape(CliVersion.Protocol)}[/]); reinitializing editor dependencies");
+                var initResult = editorDependencyInitializerService.InitializeProject(projectPath, log);
+                if (!initResult.Ok)
+                {
+                    log($"[red]error[/]: {Markup.Escape(initResult.Error)}");
+                    return false;
+                }
+            }
+
             if (editorDependencyInitializerService.NeedsInitialization(projectPath, out var initReason))
             {
                 log($"[yellow]init[/]: editor bridge dependency is missing or invalid ({Markup.Escape(initReason)}).");
@@ -766,15 +780,16 @@ internal sealed class ProjectLifecycleService
         log($"[grey]open[/]: step 3/5 resolved Unity editor [white]{Markup.Escape(resolvedEditorVersion)}[/] -> [white]{Markup.Escape(resolvedEditorPath)}[/]");
 
         log("[grey]open[/]: step 4/5 route runtime by active Unity client lock");
-        var daemonPort = DaemonControlService.ComputeProjectDaemonPort(projectPath);
+        var daemonPort = DaemonControlService.ResolveProjectDaemonPort(projectPath);
         if (DaemonControlService.IsUnityClientActiveForProject(projectPath))
         {
+            log($"[grey]daemon[/]: Unity editor lock detected; waiting for bridge endpoint [white]127.0.0.1:{daemonPort}[/]");
             var attached = await daemonControlService.TryAttachProjectDaemonAsync(
                 projectPath,
                 session,
                 log: null,
-                attemptCount: 32,
-                attemptDelayMs: 250);
+                attemptCount: 120,
+                attemptDelayMs: 500);
             if (attached && session.AttachedPort == daemonPort)
             {
                 SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, false));
@@ -886,7 +901,7 @@ internal sealed class ProjectLifecycleService
         var selected = AnsiConsole.Prompt(
             new SelectionPrompt<string>()
                 .Title("Daemon startup failed due to compile errors. Choose action:")
-                .PageSize(options.Count)
+                .PageSize(ResolvePromptPageSize(options.Count, 10))
                 .AddChoices(options));
 
         if (selected.Equals("Quit open", StringComparison.Ordinal))
@@ -1154,6 +1169,16 @@ internal sealed class ProjectLifecycleService
                || arg.Equals("--alow-unsafe", StringComparison.Ordinal);
     }
 
+    private static int ResolvePromptPageSize(int itemCount, int maxPageSize)
+    {
+        if (itemCount <= 0)
+        {
+            return 3;
+        }
+
+        return Math.Max(3, Math.Min(itemCount, maxPageSize));
+    }
+
     private static string ResolveAbsolutePath(string path, string baseDirectory)
     {
         if (string.IsNullOrWhiteSpace(path))
@@ -1175,6 +1200,42 @@ internal sealed class ProjectLifecycleService
     {
         return Directory.Exists(Path.Combine(projectPath, "Assets"))
                && Directory.Exists(Path.Combine(projectPath, "ProjectSettings"));
+    }
+
+    private static bool TryGetProjectBridgeProtocol(string projectPath, out string? protocol)
+    {
+        protocol = null;
+        var bridgePath = Path.Combine(projectPath, ".unifocl", "bridge.json");
+        if (!File.Exists(bridgePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(bridgePath));
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            if (!document.RootElement.TryGetProperty("protocol", out var protocolElement))
+            {
+                return false;
+            }
+
+            if (protocolElement.ValueKind != JsonValueKind.String)
+            {
+                return false;
+            }
+
+            protocol = protocolElement.GetString();
+            return !string.IsNullOrWhiteSpace(protocol);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static OperationResult EnsureProjectLocalConfig(string projectPath)
@@ -1203,7 +1264,7 @@ internal sealed class ProjectLifecycleService
             var bridge = JsonSerializer.Serialize(new
             {
                 projectPath,
-                daemon = new { host = "127.0.0.1", port = DaemonControlService.ComputeProjectDaemonPort(projectPath) },
+                daemon = new { host = "127.0.0.1", port = DaemonControlService.ResolveProjectDaemonPort(projectPath) },
                 protocol = CliVersion.Protocol,
                 updatedAtUtc = DateTimeOffset.UtcNow
             }, new JsonSerializerOptions { WriteIndented = true });

--- a/src/unifocl/Services/ProjectViewRenderer.cs
+++ b/src/unifocl/Services/ProjectViewRenderer.cs
@@ -16,7 +16,7 @@ internal sealed class ProjectViewRenderer
         var focusLabel = focusModeEnabled
             ? " | FOCUS: ON (up/down, tab, shift+tab, esc)"
             : " | Focus Key: F7";
-        var header = $" UnityCLI v0.1 | MODE: PROJECT | DB: {db} | CWD: {cwd}{focusLabel}";
+        var header = $" UnityCLI v{CliVersion.SemVer} | MODE: PROJECT | DB: {db} | CWD: {cwd}{focusLabel}";
 
         lines.Add(BorderTop(frameWidth));
         lines.Add(BorderBody(header, frameWidth));


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Fixes daemon attach reliability by resolving the project daemon port from `.unifocl/bridge.json` first and using that consistently in open/attach/close/ps flows.
  - Extends `/open` lock-attach wait to handle Unity compile/domain-reload startup windows.
  - Bumps CLI version to `0.2.1` and protocol to `v2`.
  - Adds protocol mismatch detection during `/open` and automatically re-initializes editor dependencies when project protocol differs.
  - Fixes Spectre selection prompt page-size handling to prevent `Page size must be greater or equal to 3` exceptions.
- Why is this change needed?
  - The CLI could fail attaching to a live Unity bridge despite proper initialization due to port mismatch and short readiness windows.
  - Protocol drift between project-local bridge config and current CLI protocol needed explicit recovery.

## Related Issues
- Related to #43

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Services/DaemonControlService.cs`
  - `src/unifocl/Services/ProjectLifecycleService.cs`
  - `src/unifocl/Services/CliVersion.cs`
  - `src/unifocl/Services/ProjectViewRenderer.cs`
  - `src/unifocl/Services/HierarchyTui.cs`
  - `src/unifocl/Services/InspectorTuiRenderer.cs`
  - `src/unifocl.unity/SharedModels/BridgeModels.cs`
- Out-of-scope / intentionally not addressed:
  - The scene load transport failure `scene load failed: daemon did not return a project response` (tracked in #43).

## How to Test
1. Run `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`.
2. In a Unity project with existing `.unifocl/bridge.json`, run `/open <path>` while Unity is already running; confirm attach succeeds on configured bridge port.
3. Change project bridge protocol to `v1` and run `/open <path>`; confirm automatic re-initialization occurs and protocol is updated to `v2`.
4. Run `/recent` with a short list and verify no page-size exception occurs.

Expected results:
- `/open` reliably attaches/starts daemon bridge with correct port resolution.
- Protocol mismatch triggers automatic initialization recovery.
- CLI reports version `0.2.1` and protocol `v2`.
- No Spectre page-size crash.

## Screenshots / Terminal Output (if applicable)
- Build passed locally:
  - `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal` (0 warnings, 0 errors)

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Changes are limited to local daemon/bridge control flow and protocol compatibility handling.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
