### PR TITLE
Fix scene load daemon response timeout and startup limbo

### DIFF
--- a/src/unifocl.unity/EditorScripts/CLIDaemon.cs
+++ b/src/unifocl.unity/EditorScripts/CLIDaemon.cs
@@ -1,5 +1,6 @@
 #if UNITY_EDITOR
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -8,6 +9,7 @@ using System.Threading.Tasks;
 using UniFocl.SharedModels;
 using UnityEditor;
 using UnityEngine;
+using Stopwatch = System.Diagnostics.Stopwatch;
 
 namespace UniFocl.EditorBridge
 {
@@ -37,7 +39,10 @@ namespace UniFocl.EditorBridge
         private static DateTime _lastActivityUtc;
         private static bool _running;
         private static bool _autoExitEditor;
+        private static bool _isBatchMode;
         private static int _inactivityTtlSeconds;
+        private static int _mainThreadManagedThreadId;
+        private static readonly ConcurrentQueue<MainThreadWorkItem> _mainThreadWorkQueue = new();
 
         public static bool HasDaemonServiceArg()
         {
@@ -52,6 +57,7 @@ namespace UniFocl.EditorBridge
 
             while (_running)
             {
+                DrainMainThreadWorkQueue();
                 Thread.Sleep(200);
             }
         }
@@ -75,8 +81,10 @@ namespace UniFocl.EditorBridge
             }
 
             _autoExitEditor = autoExitEditorOnInactivity;
+            _isBatchMode = Application.isBatchMode;
             _inactivityTtlSeconds = Math.Max(1, options.ttlSeconds);
             _lastActivityUtc = DateTime.UtcNow;
+            _mainThreadManagedThreadId = Environment.CurrentManagedThreadId;
 
             _cts = new CancellationTokenSource();
             _listener = new HttpListener();
@@ -89,7 +97,8 @@ namespace UniFocl.EditorBridge
 
             _ = Task.Run(() => AcceptLoopAsync(_cts.Token));
 
-            Debug.Log($"[unifocl] CLIDaemon started on http://127.0.0.1:{options.port}/ (batch={Application.isBatchMode}, autoExit={_autoExitEditor})");
+            var dispatcherMode = _isBatchMode ? "batch-queue" : "delay-call";
+            Debug.Log($"[unifocl] CLIDaemon started on http://127.0.0.1:{options.port}/ (batch={_isBatchMode}, autoExit={_autoExitEditor}, dispatcher={dispatcherMode})");
         }
 
         private static async Task AcceptLoopAsync(CancellationToken cancellationToken)
@@ -157,7 +166,7 @@ namespace UniFocl.EditorBridge
                 if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/stop", StringComparison.OrdinalIgnoreCase))
                 {
                     await WriteTextResponseAsync(context.Response, "STOPPING");
-                    StopInternal(quitEditor: Application.isBatchMode);
+                    StopInternal(quitEditor: _isBatchMode);
                     return;
                 }
 
@@ -214,7 +223,12 @@ namespace UniFocl.EditorBridge
                 {
                     var payload = await ReadRequestBodyAsync(request);
                     MarkActivity();
+                    var action = TryExtractProjectAction(payload);
+                    var stopwatch = Stopwatch.StartNew();
+                    Debug.Log($"[unifocl] project command received: action={action}");
                     var response = await ExecuteOnMainThreadAsync(() => DaemonProjectService.Execute(payload));
+                    stopwatch.Stop();
+                    Debug.Log($"[unifocl] project command completed: action={action}, elapsedMs={stopwatch.ElapsedMilliseconds}");
                     await WriteJsonResponseAsync(context.Response, response);
                     return;
                 }
@@ -222,16 +236,53 @@ namespace UniFocl.EditorBridge
                 MarkActivity();
                 await WriteTextResponseAsync(context.Response, "ERR", 404);
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.LogError($"[unifocl] request failed: {request.HttpMethod} {path} -> {ex}");
                 try
                 {
-                    await WriteTextResponseAsync(context.Response, "ERR", 500);
+                    var detail = $"ERR: {ex.GetType().Name}: {ex.Message}";
+                    await WriteTextResponseAsync(context.Response, detail, 500);
                 }
                 catch
                 {
                 }
             }
+        }
+
+        private static string TryExtractProjectAction(string payload)
+        {
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                return "<empty>";
+            }
+
+            const string marker = "\"action\"";
+            var actionIndex = payload.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (actionIndex < 0)
+            {
+                return "<missing>";
+            }
+
+            var colonIndex = payload.IndexOf(':', actionIndex + marker.Length);
+            if (colonIndex < 0)
+            {
+                return "<invalid>";
+            }
+
+            var valueStart = payload.IndexOf('"', colonIndex + 1);
+            if (valueStart < 0)
+            {
+                return "<invalid>";
+            }
+
+            var valueEnd = payload.IndexOf('"', valueStart + 1);
+            if (valueEnd <= valueStart)
+            {
+                return "<invalid>";
+            }
+
+            return payload[(valueStart + 1)..valueEnd];
         }
 
         private static async Task<string> ReadRequestBodyAsync(HttpListenerRequest request)
@@ -272,6 +323,8 @@ namespace UniFocl.EditorBridge
                 return;
             }
 
+            DrainMainThreadWorkQueue();
+
             if (DateTime.UtcNow - _lastActivityUtc < TimeSpan.FromSeconds(_inactivityTtlSeconds))
             {
                 return;
@@ -308,8 +361,12 @@ namespace UniFocl.EditorBridge
             _cts?.Dispose();
             _cts = null;
             _listener = null;
+            _isBatchMode = false;
+            _mainThreadManagedThreadId = 0;
 
             EditorApplication.update -= OnEditorUpdate;
+
+            FailPendingMainThreadWork();
 
             if (quitEditor)
             {
@@ -319,7 +376,27 @@ namespace UniFocl.EditorBridge
 
         private static Task<string> ExecuteOnMainThreadAsync(Func<string> work)
         {
+            if (_mainThreadManagedThreadId != 0
+                && Environment.CurrentManagedThreadId == _mainThreadManagedThreadId)
+            {
+                try
+                {
+                    return Task.FromResult(work());
+                }
+                catch (Exception ex)
+                {
+                    return Task.FromException<string>(ex);
+                }
+            }
+
             var completion = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            if (_isBatchMode)
+            {
+                _mainThreadWorkQueue.Enqueue(new MainThreadWorkItem(work, completion));
+                return completion.Task;
+            }
+
             EditorApplication.delayCall += Execute;
             return completion.Task;
 
@@ -333,6 +410,30 @@ namespace UniFocl.EditorBridge
                 {
                     completion.TrySetException(ex);
                 }
+            }
+        }
+
+        private static void DrainMainThreadWorkQueue()
+        {
+            while (_mainThreadWorkQueue.TryDequeue(out var item))
+            {
+                try
+                {
+                    item.Completion.TrySetResult(item.Work());
+                }
+                catch (Exception ex)
+                {
+                    item.Completion.TrySetException(ex);
+                }
+            }
+        }
+
+        private static void FailPendingMainThreadWork()
+        {
+            var ex = new InvalidOperationException("CLI daemon stopped before main-thread work could execute");
+            while (_mainThreadWorkQueue.TryDequeue(out var item))
+            {
+                item.Completion.TrySetException(ex);
             }
         }
 
@@ -410,6 +511,18 @@ namespace UniFocl.EditorBridge
             }
 
             return parsed;
+        }
+
+        private readonly struct MainThreadWorkItem
+        {
+            public MainThreadWorkItem(Func<string> work, TaskCompletionSource<string> completion)
+            {
+                Work = work;
+                Completion = completion;
+            }
+
+            public Func<string> Work { get; }
+            public TaskCompletionSource<string> Completion { get; }
         }
     }
 

--- a/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
@@ -27,14 +27,26 @@ namespace UniFocl.EditorBridge
                 return JsonUtility.ToJson(new ProjectCommandResponse { ok = false, message = "missing project command payload" });
             }
 
-            return request.action switch
+            try
             {
-                "mk-script" => ExecuteCreateScript(request),
-                "rename-asset" => ExecuteRenameAsset(request),
-                "remove-asset" => ExecuteRemoveAsset(request),
-                "load-asset" => ExecuteLoadAsset(request),
-                _ => JsonUtility.ToJson(new ProjectCommandResponse { ok = false, message = $"unsupported action: {request.action}" })
-            };
+                return request.action switch
+                {
+                    "healthcheck" => JsonUtility.ToJson(new ProjectCommandResponse { ok = true, message = "project command endpoint ready", kind = "healthcheck" }),
+                    "mk-script" => ExecuteCreateScript(request),
+                    "rename-asset" => ExecuteRenameAsset(request),
+                    "remove-asset" => ExecuteRemoveAsset(request),
+                    "load-asset" => ExecuteLoadAsset(request),
+                    _ => JsonUtility.ToJson(new ProjectCommandResponse { ok = false, message = $"unsupported action: {request.action}" })
+                };
+            }
+            catch (Exception ex)
+            {
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = $"project command exception: {ex.GetType().Name}: {ex.Message}"
+                });
+            }
         }
 
         private static string ExecuteCreateScript(ProjectCommandRequest request)

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -2,7 +2,7 @@ internal static class CliVersion
 {
     public const int Major = 0;
     public const int Minor = 2;
-    public const int Patch = 1;
+    public const int Patch = 2;
     public const string Protocol = "v2";
 
     public static string SemVer => $"{Major}.{Minor}.{Patch}";

--- a/src/unifocl/Services/DaemonControlService.cs
+++ b/src/unifocl/Services/DaemonControlService.cs
@@ -11,6 +11,7 @@ internal sealed class DaemonControlService
 {
     private const int DefaultInactivityTimeoutSeconds = 600;
     private const int ProcessOutputTailMaxLines = 40;
+    private static readonly TimeSpan ProjectCommandReadyTimeout = TimeSpan.FromSeconds(30);
     private static readonly HttpClient Http = new();
     private DaemonStartupFailure? _lastStartupFailure;
 
@@ -351,12 +352,34 @@ internal sealed class DaemonControlService
         // Unity's InitializeOnLoad bridge can already be serving this port even when it's not in runtime registry.
         if (await TryAttachProjectDaemonAsync(projectPath, session, attemptCount: 1))
         {
-            var headlessSatisfied = !preferHeadless
-                                    || (existing?.Headless ?? false)
-                                    || IsUnityClientActiveForProject(projectPath);
-            if ((!requireUnityBridge || IsUnityBridgeCapable(existing)) && headlessSatisfied)
+            var projectCommandReady = await IsProjectCommandEndpointResponsiveAsync(port, TimeSpan.FromSeconds(3));
+            if (!projectCommandReady)
             {
-                return true;
+                log($"[yellow]daemon[/]: endpoint 127.0.0.1:{port} responds to ping but project commands are unresponsive; restarting bridge");
+                await TrySendControlAsync(port, "STOP", "STOPPING");
+                session.AttachedPort = null;
+                await Task.Delay(200);
+            }
+            else
+            {
+                var bridgeSatisfied = !requireUnityBridge || IsUnityBridgeCapable(existing);
+                var headlessSatisfied = !preferHeadless || (existing?.Headless ?? false);
+                var managedRuntimePresent = existing is not null;
+
+                if (managedRuntimePresent && bridgeSatisfied && headlessSatisfied)
+                {
+                    return true;
+                }
+
+                if (!preferHeadless && bridgeSatisfied)
+                {
+                    return true;
+                }
+
+                log($"[yellow]daemon[/]: endpoint 127.0.0.1:{port} is attachable but unmanaged; restarting as managed headless bridge");
+                await TrySendControlAsync(port, "STOP", "STOPPING");
+                session.AttachedPort = null;
+                await Task.Delay(200);
             }
         }
 
@@ -397,7 +420,57 @@ internal sealed class DaemonControlService
 
         session.AttachedPort = port;
         await TrySendControlAsync(port, "TOUCH", "OK");
+        var projectCommandReadyAfterStart = await WaitForProjectCommandReadyAsync(
+            port,
+            ProjectCommandReadyTimeout,
+            elapsed => log($"[grey]daemon[/]: waiting for project command endpoint... {elapsed.TotalSeconds:0}s elapsed"));
+        if (!projectCommandReadyAfterStart)
+        {
+            var probe = await ProbeProjectCommandEndpointAsync(port, TimeSpan.FromSeconds(8));
+            _lastStartupFailure = new DaemonStartupFailure(
+                IsCompileError: false,
+                Summary: $"project command endpoint is not ready on port {port} ({probe.Detail})",
+                Lines: []);
+            log($"[red]daemon[/]: project command endpoint is not ready on [white]127.0.0.1:{port}[/] ({Markup.Escape(probe.Detail)})");
+            await TrySendControlAsync(port, "STOP", "STOPPING");
+            var launched = runtime.GetByPort(port);
+            if (launched is not null)
+            {
+                var deadline = DateTime.UtcNow.AddSeconds(4);
+                while (DateTime.UtcNow < deadline && ProcessUtil.IsAlive(launched.Pid))
+                {
+                    await Task.Delay(120);
+                }
+            }
+
+            runtime.Remove(port);
+            session.AttachedPort = null;
+            return false;
+        }
+
         return true;
+    }
+
+    public async Task<bool> HasStableManagedProjectDaemonAsync(string projectPath, DaemonRuntime runtime, CliSessionState session)
+    {
+        var port = ResolveProjectDaemonPort(projectPath);
+        if (session.AttachedPort != port)
+        {
+            return false;
+        }
+
+        var instance = runtime.GetByPort(port);
+        if (instance is null || string.IsNullOrWhiteSpace(instance.UnityPath))
+        {
+            return false;
+        }
+
+        if (!await TrySendControlAsync(port, "PING", "PONG"))
+        {
+            return false;
+        }
+
+        return await WaitForProjectCommandReadyAsync(port, TimeSpan.FromSeconds(8));
     }
 
     private static bool IsUnityBridgeCapable(DaemonInstance? instance)
@@ -506,7 +579,7 @@ internal sealed class DaemonControlService
         }
         catch
         {
-            return true;
+            return false;
         }
     }
 
@@ -570,16 +643,25 @@ internal sealed class DaemonControlService
             var projectPath = startOptions.ProjectPath;
             if (IsUnityClientActiveForProject(projectPath))
             {
+                var projectPort = ResolveProjectDaemonPort(projectPath);
                 if (await TryAttachProjectDaemonAsync(projectPath, session, log, attemptCount: 2, attemptDelayMs: 250))
                 {
-                    log($"[green]daemon[/]: Unity editor is already running for project; attached bridge on [white]127.0.0.1:{ResolveProjectDaemonPort(projectPath)}[/]");
+                    var projectCommandReady = await IsProjectCommandEndpointResponsiveAsync(projectPort, TimeSpan.FromSeconds(3));
+                    if (projectCommandReady)
+                    {
+                        log($"[green]daemon[/]: Unity editor is already running for project; attached bridge on [white]127.0.0.1:{projectPort}[/]");
+                        return;
+                    }
+
+                    log($"[yellow]daemon[/]: existing bridge on port {projectPort} responds to ping but project commands are unresponsive; restarting bridge");
+                    await TrySendControlAsync(projectPort, "STOP", "STOPPING");
+                    session.AttachedPort = null;
+                    await Task.Delay(200);
                 }
                 else
                 {
-                    log("[yellow]daemon[/]: Unity editor lock detected for project; skipped starting another headless Unity instance");
+                    log("[yellow]daemon[/]: Unity lock detected, but bridge endpoint is not attachable; starting a new headless bridge");
                 }
-
-                return;
             }
         }
 
@@ -662,8 +744,10 @@ internal sealed class DaemonControlService
                     Summary: $"daemon did not respond on port {startOptions.Port} within {startupTimeout.TotalSeconds:0}s",
                     Lines: outputTail.ToList());
                 log($"[red]daemon[/]: process launched (pid {process.Id}) but not responding on port {startOptions.Port} within {startupTimeout.TotalSeconds:0}s");
+                TryTerminateSpawnedProcess(process, log);
             }
 
+            runtime.Remove(startOptions.Port);
             return false;
         }
 
@@ -711,7 +795,8 @@ internal sealed class DaemonControlService
     private async Task HandleDaemonRestartAsync(DaemonRuntime runtime, CliSessionState session, Action<string> log)
     {
         var target = ResolveTargetDaemon(runtime, session);
-        var restartPort = target?.Port ?? 8080;
+        var attachedOnlyPort = target is null ? await ResolveAttachedOnlyPortAsync(session) : null;
+        var restartPort = target?.Port ?? attachedOnlyPort ?? 8080;
         var restartHeadless = target?.Headless ?? false;
         var restartUnity = target?.UnityPath;
         var restartProject = target?.ProjectPath;
@@ -723,6 +808,22 @@ internal sealed class DaemonControlService
                 log($"[red]daemon[/]: could not stop daemon on port {target.Port}; aborting restart");
                 return;
             }
+        }
+        else if (attachedOnlyPort is int attachedPort)
+        {
+            var stopped = await TrySendControlAsync(attachedPort, "STOP", "STOPPING");
+            if (!stopped)
+            {
+                log($"[red]daemon[/]: could not stop attached endpoint on port {attachedPort}; aborting restart");
+                return;
+            }
+
+            if (session.AttachedPort == attachedPort)
+            {
+                session.AttachedPort = null;
+            }
+
+            log($"[grey]daemon[/]: stopped attached endpoint on port {attachedPort}");
         }
 
         var synthesized = $"/daemon start --port {restartPort}" +
@@ -1174,6 +1275,30 @@ internal sealed class DaemonControlService
         return lines;
     }
 
+    private static void TryTerminateSpawnedProcess(Process process, Action<string> log)
+    {
+        try
+        {
+            if (process.HasExited)
+            {
+                return;
+            }
+
+            process.Kill(entireProcessTree: true);
+            if (!process.WaitForExit(5000))
+            {
+                log($"[yellow]daemon[/]: failed to terminate stalled Unity process pid={process.Id} within 5s");
+                return;
+            }
+
+            log($"[yellow]daemon[/]: terminated stalled Unity process pid={process.Id}");
+        }
+        catch (Exception ex)
+        {
+            log($"[yellow]daemon[/]: unable to terminate stalled Unity process pid={process.Id} ({Markup.Escape(ex.Message)})");
+        }
+    }
+
     private static async Task<bool> WaitForDaemonReadyAsync(int port, TimeSpan timeout, Action<TimeSpan>? onProgress = null)
     {
         var startedAt = DateTime.UtcNow;
@@ -1276,6 +1401,82 @@ internal sealed class DaemonControlService
         {
             return false;
         }
+    }
+
+    private static async Task<bool> IsProjectCommandEndpointResponsiveAsync(int port, TimeSpan timeout)
+    {
+        var probe = await ProbeProjectCommandEndpointAsync(port, timeout);
+        return probe.Ok;
+    }
+
+    private static async Task<ProjectCommandProbeResult> ProbeProjectCommandEndpointAsync(int port, TimeSpan timeout)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            using var content = new StringContent("{\"action\":\"healthcheck\"}", Encoding.UTF8, "application/json");
+            var response = await Http.PostAsync($"http://127.0.0.1:{port}/project/command", content, cts.Token);
+            var payload = (await response.Content.ReadAsStringAsync(cts.Token)).Trim();
+            if (!response.IsSuccessStatusCode)
+            {
+                return new ProjectCommandProbeResult(false, $"HTTP {(int)response.StatusCode}: {(string.IsNullOrWhiteSpace(payload) ? "<empty>" : payload)}");
+            }
+
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                return new ProjectCommandProbeResult(false, "HTTP 200 with empty payload");
+            }
+
+            return new ProjectCommandProbeResult(true, "ok");
+        }
+        catch (OperationCanceledException)
+        {
+            return new ProjectCommandProbeResult(false, $"timeout after {(int)timeout.TotalSeconds}s");
+        }
+        catch (Exception ex)
+        {
+            return new ProjectCommandProbeResult(false, ex.Message);
+        }
+    }
+
+    private static async Task<bool> WaitForProjectCommandReadyAsync(
+        int port,
+        TimeSpan timeout,
+        Action<TimeSpan>? onProgress = null)
+    {
+        var startedAt = DateTime.UtcNow;
+        var deadline = startedAt.Add(timeout);
+        var nextProgressAt = startedAt.AddSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await IsProjectCommandEndpointResponsiveAsync(port, TimeSpan.FromSeconds(8)))
+            {
+                return true;
+            }
+
+            var now = DateTime.UtcNow;
+            if (onProgress is not null && now >= nextProgressAt)
+            {
+                onProgress(now - startedAt);
+                nextProgressAt = now.AddSeconds(5);
+            }
+
+            await Task.Delay(1000);
+        }
+
+        return false;
+    }
+
+    private readonly record struct ProjectCommandProbeResult(bool Ok, string Detail);
+
+    private static async Task<int?> ResolveAttachedOnlyPortAsync(CliSessionState session)
+    {
+        if (session.AttachedPort is not int attachedPort)
+        {
+            return null;
+        }
+
+        return await TrySendControlAsync(attachedPort, "PING", "PONG") ? attachedPort : null;
     }
 
     private static string? ResolveDefaultUnityPath(string projectPath)

--- a/src/unifocl/Services/EditorDependencyInitializerService.cs
+++ b/src/unifocl/Services/EditorDependencyInitializerService.cs
@@ -123,6 +123,20 @@ internal sealed class EditorDependencyInitializerService
             }
         }
 
+        var expectedDaemonSource = ReadEmbeddedResource(DaemonSourceResource);
+        if (string.IsNullOrWhiteSpace(expectedDaemonSource))
+        {
+            reason = "embedded daemon payload is unavailable";
+            return true;
+        }
+
+        var installedDaemonSource = File.ReadAllText(Path.Combine(packagePath, "Editor", "CLIDaemon.cs"));
+        if (!NormalizeText(installedDaemonSource).Equals(NormalizeText(expectedDaemonSource), StringComparison.Ordinal))
+        {
+            reason = "embedded daemon package is outdated; CLIDaemon.cs does not match current CLI payload";
+            return true;
+        }
+
         reason = string.Empty;
         return false;
     }
@@ -334,5 +348,11 @@ internal sealed class EditorDependencyInitializerService
             Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
             File.Copy(file, destination, overwrite: true);
         }
+    }
+
+    private static string NormalizeText(string value)
+    {
+        return value.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Trim();
     }
 }

--- a/src/unifocl/Services/HierarchyDaemonClient.cs
+++ b/src/unifocl/Services/HierarchyDaemonClient.cs
@@ -6,6 +6,11 @@ internal sealed class HierarchyDaemonClient
 {
     private static readonly HttpClient Http = new();
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan ProjectCommandTimeout = TimeSpan.FromSeconds(8);
+    private static readonly TimeSpan SceneLoadTimeout = TimeSpan.FromSeconds(90);
+    private static readonly TimeSpan SceneLoadStatusInterval = TimeSpan.FromSeconds(5);
+    private const int SceneLoadRetryCount = 1;
 
     public async Task<HierarchySnapshotDto?> GetSnapshotAsync(int port)
     {
@@ -83,30 +88,78 @@ internal sealed class HierarchyDaemonClient
         }
     }
 
-    public async Task<ProjectCommandResponseDto> ExecuteProjectCommandAsync(int port, ProjectCommandRequestDto request)
+    public async Task<ProjectCommandResponseDto> ExecuteProjectCommandAsync(int port, ProjectCommandRequestDto request, Action<string>? onStatus = null)
     {
-        var payload = await SendPostJsonAsync($"http://127.0.0.1:{port}/project/command", request);
-        if (payload is null)
+        var isSceneLoad = request.Action.Equals("load-asset", StringComparison.OrdinalIgnoreCase);
+        var timeout = isSceneLoad ? SceneLoadTimeout : ProjectCommandTimeout;
+        var maxAttempts = isSceneLoad ? SceneLoadRetryCount + 1 : 1;
+        if (isSceneLoad)
         {
-            return new ProjectCommandResponseDto(false, "daemon did not return a project response", null);
+            onStatus?.Invoke($"dispatching scene load request (timeout {timeout.TotalSeconds:0}s)");
         }
 
-        try
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            var parsed = JsonSerializer.Deserialize<ProjectCommandResponseDto>(payload, JsonOptions);
-            return parsed ?? new ProjectCommandResponseDto(false, "daemon returned empty project response", null);
+            if (isSceneLoad)
+            {
+                onStatus?.Invoke($"scene load request attempt {attempt}/{maxAttempts}");
+            }
+
+            var result = await SendPostJsonWithDiagnosticsAsync(
+                $"http://127.0.0.1:{port}/project/command",
+                request,
+                timeout,
+                onProgress: elapsed =>
+                {
+                    if (isSceneLoad)
+                    {
+                        onStatus?.Invoke($"waiting for daemon response... {elapsed.TotalSeconds:0}s elapsed");
+                    }
+                });
+            if (!string.IsNullOrWhiteSpace(result.Error))
+            {
+                var retrying = isSceneLoad && result.TimedOut && attempt < maxAttempts;
+                if (retrying)
+                {
+                    onStatus?.Invoke("scene load timed out; retrying once");
+                    continue;
+                }
+
+                return new ProjectCommandResponseDto(false, result.Error, null);
+            }
+
+            var payload = result.Payload;
+            if (string.IsNullOrWhiteSpace(payload))
+            {
+                var retrying = isSceneLoad && attempt < maxAttempts;
+                if (retrying)
+                {
+                    onStatus?.Invoke("daemon returned empty payload; retrying once");
+                    continue;
+                }
+
+                return new ProjectCommandResponseDto(false, "daemon returned an empty project response payload", null);
+            }
+
+            try
+            {
+                var parsed = JsonSerializer.Deserialize<ProjectCommandResponseDto>(payload, JsonOptions);
+                return parsed ?? new ProjectCommandResponseDto(false, "daemon returned empty project response", null);
+            }
+            catch
+            {
+                return new ProjectCommandResponseDto(false, "daemon returned invalid project response", null);
+            }
         }
-        catch
-        {
-            return new ProjectCommandResponseDto(false, "daemon returned invalid project response", null);
-        }
+
+        return new ProjectCommandResponseDto(false, "daemon did not return a project response", null);
     }
 
     private static async Task<string?> SendGetAsync(string uri)
     {
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            using var cts = new CancellationTokenSource(DefaultRequestTimeout);
             var response = await Http.GetAsync(uri, cts.Token);
             if (!response.IsSuccessStatusCode)
             {
@@ -125,7 +178,7 @@ internal sealed class HierarchyDaemonClient
     {
         try
         {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            using var cts = new CancellationTokenSource(DefaultRequestTimeout);
             var json = JsonSerializer.Serialize(payload, JsonOptions);
             using var content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await Http.PostAsync(uri, content, cts.Token);
@@ -141,4 +194,59 @@ internal sealed class HierarchyDaemonClient
             return null;
         }
     }
+
+    private static async Task<ProjectCommandTransportResult> SendPostJsonWithDiagnosticsAsync<T>(
+        string uri,
+        T payload,
+        TimeSpan timeout,
+        Action<TimeSpan>? onProgress = null)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            var json = JsonSerializer.Serialize(payload, JsonOptions);
+            using var content = new StringContent(json, Encoding.UTF8, "application/json");
+            var requestStarted = DateTime.UtcNow;
+            var responseTask = Http.PostAsync(uri, content, cts.Token);
+
+            while (!responseTask.IsCompleted)
+            {
+                await Task.Delay(SceneLoadStatusInterval, cts.Token);
+                if (responseTask.IsCompleted)
+                {
+                    break;
+                }
+
+                onProgress?.Invoke(DateTime.UtcNow - requestStarted);
+            }
+
+            var response = await responseTask;
+            var body = (await response.Content.ReadAsStringAsync(cts.Token)).Trim();
+            if (!response.IsSuccessStatusCode)
+            {
+                var statusCode = (int)response.StatusCode;
+                if (string.IsNullOrWhiteSpace(body))
+                {
+                    return new ProjectCommandTransportResult(null, $"daemon returned HTTP {statusCode} for project command", false);
+                }
+
+                return new ProjectCommandTransportResult(null, $"daemon returned HTTP {statusCode}: {body}", false);
+            }
+
+            return new ProjectCommandTransportResult(body, null, false);
+        }
+        catch (OperationCanceledException)
+        {
+            return new ProjectCommandTransportResult(null, $"daemon project command timed out after {(int)timeout.TotalSeconds}s", true);
+        }
+        catch (Exception ex)
+        {
+            return new ProjectCommandTransportResult(null, $"daemon project command request failed: {ex.Message}", false);
+        }
+    }
+
+    private readonly record struct ProjectCommandTransportResult(
+        string? Payload,
+        string? Error,
+        bool TimedOut);
 }

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -742,26 +742,23 @@ internal sealed class ProjectLifecycleService
                 }
             }
 
-            if (editorDependencyInitializerService.NeedsInitialization(projectPath, out var initReason))
+            var needsInitialization = editorDependencyInitializerService.NeedsInitialization(projectPath, out var initReason);
+            if (needsInitialization)
             {
                 log($"[yellow]init[/]: editor bridge dependency is missing or invalid ({Markup.Escape(initReason)}).");
-                if (editorDependencyInitializerService.PromptForInitialization(log))
-                {
-                    var initResult = editorDependencyInitializerService.InitializeProject(projectPath, log);
-                    if (!initResult.Ok)
-                    {
-                        log($"[red]error[/]: {Markup.Escape(initResult.Error)}");
-                        return false;
-                    }
-                }
-                else
-                {
-                    log("[yellow]init[/]: skipped; run /init to enable editor-side bridge package");
-                }
             }
             else
             {
                 log("[grey]init[/]: editor bridge dependency already installed");
+            }
+
+            // Always refresh embedded package on open to keep project-side bridge in sync with current CLI payload.
+            log("[grey]init[/]: syncing embedded editor bridge package");
+            var syncResult = editorDependencyInitializerService.InitializeProject(projectPath, log);
+            if (!syncResult.Ok)
+            {
+                log($"[red]error[/]: {Markup.Escape(syncResult.Error)}");
+                return false;
             }
         }
 
@@ -779,58 +776,42 @@ internal sealed class ProjectLifecycleService
         Environment.SetEnvironmentVariable("UNITY_PATH", resolvedEditorPath);
         log($"[grey]open[/]: step 3/5 resolved Unity editor [white]{Markup.Escape(resolvedEditorVersion)}[/] -> [white]{Markup.Escape(resolvedEditorPath)}[/]");
 
-        log("[grey]open[/]: step 4/5 route runtime by active Unity client lock");
+        log("[grey]open[/]: step 4/5 ensure managed daemon bridge");
         var daemonPort = DaemonControlService.ResolveProjectDaemonPort(projectPath);
-        if (DaemonControlService.IsUnityClientActiveForProject(projectPath))
+        if (allowUnsafe)
         {
-            log($"[grey]daemon[/]: Unity editor lock detected; waiting for bridge endpoint [white]127.0.0.1:{daemonPort}[/]");
-            var attached = await daemonControlService.TryAttachProjectDaemonAsync(
-                projectPath,
-                session,
-                log: null,
-                attemptCount: 120,
-                attemptDelayMs: 500);
-            if (attached && session.AttachedPort == daemonPort)
-            {
-                SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, false));
-                log($"[grey]daemon[/]: Unity editor lock detected; attached bridge on [white]127.0.0.1:{daemonPort}[/]");
-            }
-            else
-            {
-                log($"[red]daemon[/]: Unity editor lock detected, but bridge endpoint [white]127.0.0.1:{daemonPort}[/] is not responding");
-                log("[yellow]daemon[/]: wait for Unity editor script compilation/domain reload, then retry /open");
-                return false;
-            }
+            log("[yellow]open[/]: --allow-unsafe enabled (using -noUpm and -ignoreCompileErrors for faster headless boot)");
+        }
+
+        var started = await daemonControlService.EnsureProjectDaemonAsync(
+            projectPath,
+            daemonRuntime,
+            session,
+            log,
+            requireUnityBridge: true,
+            preferHeadless: true,
+            allowUnsafe: allowUnsafe);
+        if (!started)
+        {
+            HandleDaemonStartupFailure(projectPath, session, daemonControlService, log);
+            log("[red]open[/]: daemon is not stable; open aborted before entering project UI");
+            return false;
         }
         else
         {
-            if (allowUnsafe)
+            var stableReservation = await daemonControlService.HasStableManagedProjectDaemonAsync(projectPath, daemonRuntime, session);
+            if (!stableReservation)
             {
-                log("[yellow]open[/]: --allow-unsafe enabled (using -noUpm and -ignoreCompileErrors for faster headless boot)");
+                session.AttachedPort = null;
+                log("[red]daemon[/]: managed daemon reservation check failed (missing pid metadata, attachment, or project endpoint responsiveness)");
+                log("[red]open[/]: open aborted before entering project UI");
+                return false;
             }
 
-            var started = await daemonControlService.EnsureProjectDaemonAsync(
-                projectPath,
-                daemonRuntime,
-                session,
-                log,
-                requireUnityBridge: true,
-                preferHeadless: true,
-                allowUnsafe: allowUnsafe);
-            if (!started)
-            {
-                if (!HandleDaemonStartupFailure(projectPath, session, daemonControlService, log))
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, true));
-                log($"[grey]daemon[/]: started headless daemon on [white]127.0.0.1:{daemonPort}[/]");
-                session.SafeModeEnabled = false;
-                session.LastCompileError = null;
-            }
+            SaveDaemonSession(projectPath, new DaemonSessionInfo(daemonPort, DateTimeOffset.UtcNow, true));
+            log($"[grey]daemon[/]: managed daemon ready on [white]127.0.0.1:{daemonPort}[/]");
+            session.SafeModeEnabled = false;
+            session.LastCompileError = null;
         }
 
         session.CurrentProjectPath = projectPath;
@@ -880,55 +861,9 @@ internal sealed class ProjectLifecycleService
         {
             log($"[yellow]daemon[/]: {Markup.Escape(failure.Summary)}");
         }
-
-        var canEnterSafeMode = CanEnterSafeMode(projectPath);
-        if (Console.IsInputRedirected)
-        {
-            log("[red]daemon[/]: redirected input cannot answer compile-error prompt; aborting open");
-            return false;
-        }
-
-        var options = new List<string>
-        {
-            "Ignore and continue",
-            "Quit open"
-        };
-        if (canEnterSafeMode)
-        {
-            options.Insert(0, "Enter Safe mode");
-        }
-
-        var selected = AnsiConsole.Prompt(
-            new SelectionPrompt<string>()
-                .Title("Daemon startup failed due to compile errors. Choose action:")
-                .PageSize(ResolvePromptPageSize(options.Count, 10))
-                .AddChoices(options));
-
-        if (selected.Equals("Quit open", StringComparison.Ordinal))
-        {
-            log("[yellow]open[/]: cancelled due to compile errors");
-            return false;
-        }
-
-        if (selected.Equals("Enter Safe mode", StringComparison.Ordinal))
-        {
-            session.SafeModeEnabled = true;
-            session.AttachedPort = null;
-            log("[yellow]open[/]: entered safe mode (daemon unavailable; Unity bridge commands are limited)");
-            return true;
-        }
-
-        session.SafeModeEnabled = false;
         session.AttachedPort = null;
-        log("[yellow]open[/]: continuing without daemon attachment; Unity bridge commands may fail until compile errors are fixed");
-        return true;
-    }
-
-    private static bool CanEnterSafeMode(string projectPath)
-    {
-        return Directory.Exists(projectPath)
-               && Directory.Exists(Path.Combine(projectPath, "Assets"))
-               && Directory.Exists(Path.Combine(projectPath, "ProjectSettings"));
+        log("[yellow]open[/]: compile errors blocked daemon startup; fix errors and retry /open");
+        return false;
     }
 
     private static void SaveDaemonSession(string projectPath, DaemonSessionInfo session)

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -489,6 +489,9 @@ internal sealed class ProjectViewService
         }
 
         var isSceneLoad = Path.GetExtension(target.Name).Equals(".unity", StringComparison.OrdinalIgnoreCase);
+        EmitImmediateLoadFeedback(state, target.Name, isSceneLoad);
+        EmitLoadDiagnostic(state, $"selector '{selector}' resolved to '{target.RelativePath}'");
+        EmitLoadDiagnostic(state, "ensuring Unity bridge context");
         var unityReady = await EnsureUnityContextAsync(
             session,
             daemonControlService,
@@ -499,21 +502,30 @@ internal sealed class ProjectViewService
             outputs.Add("[x] scene load failed: Unity editor bridge is unavailable; set UNITY_PATH or start Unity editor for this project");
             return true;
         }
+        if (isSceneLoad)
+        {
+            EmitLoadDiagnostic(state, "Unity bridge context ready");
+        }
 
         var response = await ExecuteProjectCommandAsync(
             session,
-            new ProjectCommandRequestDto("load-asset", target.RelativePath, null, null));
+            new ProjectCommandRequestDto("load-asset", target.RelativePath, null, null),
+            status => EmitLoadDiagnostic(state, status));
         if (!response.Ok && IsAssetNotFoundFailure(response.Message))
         {
             var fallbackPath = await ResolveAssetFallbackPathAsync(session, target.RelativePath, allowDirectoryFallback: false);
             if (!string.IsNullOrWhiteSpace(fallbackPath)
                 && !fallbackPath.Equals(target.RelativePath, StringComparison.OrdinalIgnoreCase))
             {
+                EmitLoadDiagnostic(state, $"asset fallback path resolved: '{fallbackPath}'");
                 response = await ExecuteProjectCommandAsync(
                     session,
-                    new ProjectCommandRequestDto("load-asset", fallbackPath, null, null));
+                    new ProjectCommandRequestDto("load-asset", fallbackPath, null, null),
+                    status => EmitLoadDiagnostic(state, status));
             }
         }
+
+        EmitLoadDiagnostic(state, $"daemon result: ok={response.Ok}, kind={response.Kind ?? "null"}");
 
         if (!response.Ok)
         {
@@ -601,14 +613,17 @@ internal sealed class ProjectViewService
         }
     }
 
-    private async Task<ProjectCommandResponseDto> ExecuteProjectCommandAsync(CliSessionState session, ProjectCommandRequestDto request)
+    private async Task<ProjectCommandResponseDto> ExecuteProjectCommandAsync(
+        CliSessionState session,
+        ProjectCommandRequestDto request,
+        Action<string>? onStatus = null)
     {
         if (session.AttachedPort is not int port)
         {
             return new ProjectCommandResponseDto(false, "daemon is not attached", null);
         }
 
-        return await _daemonClient.ExecuteProjectCommandAsync(port, request);
+        return await _daemonClient.ExecuteProjectCommandAsync(port, request, onStatus);
     }
 
     private static ProjectTreeEntry? FindEntryBySelector(ProjectViewState state, string selector)
@@ -833,6 +848,19 @@ internal sealed class ProjectViewService
 
         var overflow = state.CommandTranscript.Count - MaxTranscriptEntries;
         state.CommandTranscript.RemoveRange(0, overflow);
+    }
+
+    private void EmitImmediateLoadFeedback(ProjectViewState state, string targetName, bool isSceneLoad)
+    {
+        var prefix = isSceneLoad ? "scene" : "script";
+        AppendTranscript(state, [$"[*] loading {prefix}: {targetName}"]);
+        RenderFrame(state);
+    }
+
+    private void EmitLoadDiagnostic(ProjectViewState state, string message)
+    {
+        AppendTranscript(state, [$"[grey]load[/]: {Markup.Escape(message)}"]);
+        RenderFrame(state);
     }
 
     private static async Task<bool> EnsureUnityContextAsync(


### PR DESCRIPTION
## Summary
- Stabilizes Unity daemon startup/readiness so `/open` only succeeds when a managed daemon (PID-backed) is actually usable for project commands.
- Fixes scene-load project command transport behavior and diagnostics to avoid silent hangs and provide actionable status.
- Hardens embedded bridge/package sync and startup cleanup to prevent stale processes and stale package drift.

## Related Issues
- Closes #43
- Related to #45

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
- `src/unifocl/Services/DaemonControlService.cs`
- `src/unifocl/Services/ProjectLifecycleService.cs`
- `src/unifocl/Services/HierarchyDaemonClient.cs`
- `src/unifocl/Services/ProjectViewService.cs`
- `src/unifocl/Services/EditorDependencyInitializerService.cs`
- `src/unifocl.unity/EditorScripts/CLIDaemon.cs`
- `src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs`
- `src/unifocl/Services/CliVersion.cs`

- Out-of-scope / intentionally not addressed:
- Runtime activation failure after scene open (`scene load failed: unable to activate scene ...`) is tracked separately in #45.

## How to Test
1. Run: `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Run CLI and open a Unity project with `/open <path>` (or `/recent 1`).
3. Confirm `/open` either:
   - succeeds with stable managed daemon reservation, or
   - aborts before entering project UI (no limbo attached-only state).
4. Run `/daemon ps` and verify no `PID - / unknown` limbo row after failed open.
5. Run `load <scene>` and confirm immediate load progress logs and transport diagnostics.

Expected results:
- Scene-load command path no longer fails with "daemon did not return a project response" due startup limbo.
- Stale headless Unity process is terminated on startup/readiness failure.
- Embedded package is synced on `/open`, and Unity bridge logs include dispatcher mode.

## Screenshots / Terminal Output (if applicable)
- Reproduced logs and validations captured in task conversation.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No secrets/tokens added. Changes are daemon lifecycle and diagnostics only.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
