### PR TITLE
Improve /recent inline F7 selection flow and bump to 0.2.4

### DIFF
--- a/src/unifocl/Models/CliSessionState.cs
+++ b/src/unifocl/Models/CliSessionState.cs
@@ -24,6 +24,8 @@ internal sealed class CliSessionState
     public bool AutoEnterHierarchyRequested { get; set; }
     public ProjectViewState ProjectView { get; } = new();
     public List<string> UnityLogPane { get; } = [];
+    public List<RecentProjectEntry> RecentProjectEntries { get; } = [];
+    public bool RecentSelectionAllowUnsafe { get; set; }
     public bool SafeModeEnabled { get; set; }
     public CompileErrorState? LastCompileError { get; set; }
 
@@ -48,6 +50,8 @@ internal sealed class CliSessionState
         ProjectView.AssetPathByInstanceId.Clear();
         ProjectView.LastFuzzyMatches.Clear();
         UnityLogPane.Clear();
+        RecentProjectEntries.Clear();
+        RecentSelectionAllowUnsafe = false;
         SafeModeEnabled = false;
         LastCompileError = null;
     }

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -44,7 +44,7 @@ var commands = new List<CommandSpec>
     // Extended lifecycle (kept for compatibility)
     new("/new <project-name> [unity-version] [--allow-unsafe]", "Bootstrap a new Unity project", "/new"),
     new("/clone <git-url> [--allow-unsafe]", "Clone repo and set local CLI bridge config", "/clone"),
-    new("/recent [idx] [--allow-unsafe]", "Open recent projects (interactive or by index)", "/recent"),
+    new("/recent [idx] [--allow-unsafe]", "List recent projects (or open by index)", "/recent"),
     new("/daemon start [--port 8080] [--unity <path>] [--project <path>] [--headless] [--allow-unsafe]", "Start always-warm daemon", "/daemon start"),
     new("/daemon stop", "Stop daemon", "/daemon stop"),
     new("/daemon restart", "Restart daemon", "/daemon restart"),
@@ -143,6 +143,16 @@ while (true)
         var input = rawInput.Trim();
         if (string.IsNullOrWhiteSpace(input))
         {
+            continue;
+        }
+
+        if (input.Equals(":focus-recent", StringComparison.OrdinalIgnoreCase))
+        {
+            await projectLifecycleService.TryHandleRecentSelectionToggleAsync(
+                session,
+                daemonControlService,
+                daemonRuntime,
+                line => AppendLog(streamLog, line));
             continue;
         }
 
@@ -454,6 +464,14 @@ static string? ReadInteractiveInput(
                     Console.WriteLine();
                     return ":focus-project";
                 }
+
+                if (input.Length == 0
+                    && (session.Mode != CliMode.Project || string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+                    && session.RecentProjectEntries.Count > 0)
+                {
+                    Console.WriteLine();
+                    return ":focus-recent";
+                }
                 break;
             case ConsoleKey.F8:
                 if (input.Length == 0
@@ -733,7 +751,7 @@ static void WriteKeybindsHelp(List<string> streamLog, CliSessionState session)
     AppendLog(streamLog, "[bold deepskyblue1]unifocl[/] [grey]>[/] [white]/keybinds[/]");
     AppendLog(streamLog, "[grey]keybinds[/]: global");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F6[/] enter/exit hierarchy focus mode (inside /hierarchy)");
-    AppendLog(streamLog, "[grey]keybinds[/]: [white]F7[/] enter/exit project focus mode (project context)");
+    AppendLog(streamLog, "[grey]keybinds[/]: [white]F7[/] enter/exit project focus mode (project context), or recent selection mode after /recent");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F8[/] enter/exit inspector focus mode (inspector context)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]Esc[/] dismiss intellisense (or clear input if already dismissed)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]↑/↓[/] fuzzy candidate selection in composer");

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -2,7 +2,7 @@ internal static class CliVersion
 {
     public const int Major = 0;
     public const int Minor = 2;
-    public const int Patch = 2;
+    public const int Patch = 4;
     public const string Protocol = "v2";
 
     public static string SemVer => $"{Major}.{Minor}.{Patch}";

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -33,6 +33,28 @@ internal sealed class ProjectLifecycleService
         };
     }
 
+    public async Task<bool> TryHandleRecentSelectionToggleAsync(
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        if (Console.IsInputRedirected)
+        {
+            log("[yellow]recent[/]: selection mode requires a TTY terminal");
+            return true;
+        }
+
+        if (session.RecentProjectEntries.Count == 0)
+        {
+            log("[yellow]recent[/]: no cached recent list; run /recent first");
+            return true;
+        }
+
+        await RunRecentSelectionModeAsync(session, daemonControlService, daemonRuntime, log);
+        return true;
+    }
+
     public async Task PerformSafeExitCleanupAsync(
         CliSessionState session,
         DaemonControlService daemonControlService,
@@ -371,11 +393,16 @@ internal sealed class ProjectLifecycleService
 
         if (entries.Count == 0)
         {
+            session.RecentProjectEntries.Clear();
+            session.RecentSelectionAllowUnsafe = false;
             log("[grey]recent[/]: no recent projects found");
             return Task.FromResult(true);
         }
 
         LogRecentEntries(entries, log);
+        session.RecentProjectEntries.Clear();
+        session.RecentProjectEntries.AddRange(entries);
+        session.RecentSelectionAllowUnsafe = allowUnsafe;
 
         if (!string.IsNullOrWhiteSpace(indexRaw))
         {
@@ -402,25 +429,8 @@ internal sealed class ProjectLifecycleService
             return OpenRecentSelectionAsync(selectedEntry, session, daemonControlService, daemonRuntime, allowUnsafe, log);
         }
 
-        if (Console.IsInputRedirected)
-        {
-            log("[yellow]recent[/]: interactive selection requires a TTY; use /recent <idx> to open a project");
-            return Task.FromResult(true);
-        }
-
-        var selected = AnsiConsole.Prompt(
-            new SelectionPrompt<RecentProjectEntry>()
-                .Title("Select a recent project to open")
-                .PageSize(ResolvePromptPageSize(entries.Count, 10))
-                .UseConverter(entry =>
-                {
-                    var index = entries.IndexOf(entry) + 1;
-                    var opened = entry.LastOpenedUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz");
-                    return $"{index}. {entry.ProjectPath} ({opened})";
-                })
-                .AddChoices(entries));
-
-        return OpenRecentSelectionAsync(selected, session, daemonControlService, daemonRuntime, allowUnsafe, log);
+        log("[grey]recent[/]: press [white]F7[/] to enter selection mode ([white]↑/↓[/] move, [white]Enter[/] open, [white]F7[/] exit)");
+        return Task.FromResult(true);
     }
 
     private static void LogRecentEntries(IReadOnlyList<RecentProjectEntry> entries, Action<string> log)
@@ -452,6 +462,99 @@ internal sealed class ProjectLifecycleService
             promptForInitialization: true,
             allowUnsafe: allowUnsafe,
             log: log);
+    }
+
+    private async Task RunRecentSelectionModeAsync(
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        var entries = session.RecentProjectEntries;
+        if (entries.Count == 0)
+        {
+            log("[yellow]recent[/]: no recent entries are available");
+            return;
+        }
+
+        var selectedIndex = 0;
+        var lastRenderedSelectedIndex = -1;
+        log("[i] recent selection mode enabled ([white]↑/↓[/] move, [white]Enter[/] open, [white]F7[/] exit)");
+        LogRecentSelectionIfChanged(entries, selectedIndex, ref lastRenderedSelectedIndex, log);
+
+        while (true)
+        {
+            var key = Console.ReadKey(intercept: true);
+            if (key.Key == ConsoleKey.UpArrow)
+            {
+                var nextSelectedIndex = selectedIndex <= 0 ? entries.Count - 1 : selectedIndex - 1;
+                LogRecentSelectionIfChanged(entries, nextSelectedIndex, ref lastRenderedSelectedIndex, log);
+                selectedIndex = nextSelectedIndex;
+                continue;
+            }
+
+            if (key.Key == ConsoleKey.DownArrow)
+            {
+                var nextSelectedIndex = selectedIndex >= entries.Count - 1 ? 0 : selectedIndex + 1;
+                LogRecentSelectionIfChanged(entries, nextSelectedIndex, ref lastRenderedSelectedIndex, log);
+                selectedIndex = nextSelectedIndex;
+                continue;
+            }
+
+            if (key.Key is ConsoleKey.F7 or ConsoleKey.Escape)
+            {
+                log("[i] recent selection mode disabled");
+                return;
+            }
+
+            if (key.Key != ConsoleKey.Enter)
+            {
+                continue;
+            }
+
+            var selectedEntry = entries[selectedIndex];
+            await OpenRecentSelectionAsync(
+                selectedEntry,
+                session,
+                daemonControlService,
+                daemonRuntime,
+                session.RecentSelectionAllowUnsafe,
+                log);
+            return;
+        }
+    }
+
+    private static void LogRecentSelectionIfChanged(
+        IReadOnlyList<RecentProjectEntry> entries,
+        int selectedIndex,
+        ref int lastRenderedSelectedIndex,
+        Action<string> log)
+    {
+        if (selectedIndex == lastRenderedSelectedIndex)
+        {
+            return;
+        }
+
+        lastRenderedSelectedIndex = selectedIndex;
+        LogRecentSelectionList(entries, selectedIndex, log);
+    }
+
+    private static void LogRecentSelectionList(IReadOnlyList<RecentProjectEntry> entries, int selectedIndex, Action<string> log)
+    {
+        log("[grey]recent[/]: selection");
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var entry = entries[i];
+            var opened = entry.LastOpenedUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz");
+            var plain = $"recent: {i + 1}. {entry.ProjectPath} ({opened})";
+            if (i == selectedIndex)
+            {
+                log(CliTheme.CursorWrapEscaped(Markup.Escape($"> {plain}")));
+                continue;
+            }
+
+            log($"[grey]{Markup.Escape(plain)}[/]");
+        }
     }
 
     private Task<bool> HandleUnityDetectAsync(Action<string> log)


### PR DESCRIPTION
## Summary
- Change `/recent` default behavior to list recents without forcing immediate open selection.
- Add F7-driven inline recent selection mode (no dedicated window) with highlighted selected row, `↑/↓` navigation, `Enter` open, and `F7/Esc` exit.
- Cache last rendered selection and skip re-logging when selection does not change.
- Bump CLI patch version from `0.2.2` to `0.2.4`.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [x] Chore

## Scope
- Affected areas/components:
- `src/unifocl/Services/ProjectLifecycleService.cs`
- `src/unifocl/Program.cs`
- `src/unifocl/Models/CliSessionState.cs`
- `src/unifocl/Services/CliVersion.cs`
- Out-of-scope / intentionally not addressed:
- Dedicated full-screen recent selector UI
- Other keybind/modal behavior outside `/recent`

## How to Test
1. Run `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`.
2. Launch CLI, run `/recent`, verify it lists projects and does not force a prompt.
3. Press `F7` and verify inline selection appears with highlighted row; use `↑/↓`, then `F7` to exit.
4. Press `F7` again, move selection and press `Enter` to open selected project.
5. With one recent entry, press `↑/↓` repeatedly and verify duplicate selection logs are skipped.

Expected results:
- `/recent` lists only by default.
- F7 toggles inline recent selection mode and selected row highlight is visible.
- Selection opens on `Enter` and exits on `F7/Esc`.
- No redundant selection re-logs when selected row is unchanged.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Changes are limited to local CLI interaction flow and version constants.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
