### PR TITLE
Unify focus keybind on F7 and persist TUI focus cursors

### DIFF
--- a/src/unifocl/Models/CliSessionState.cs
+++ b/src/unifocl/Models/CliSessionState.cs
@@ -46,6 +46,7 @@ internal sealed class CliSessionState
         ProjectView.ExpandedDirectories.Clear();
         ProjectView.CommandTranscript.Clear();
         ProjectView.DbState = ProjectDbState.IdleSafe;
+        ProjectView.FocusHighlightedEntryIndex = null;
         ProjectView.AssetIndexRevision = 0;
         ProjectView.AssetPathByInstanceId.Clear();
         ProjectView.LastFuzzyMatches.Clear();

--- a/src/unifocl/Models/InspectorModels.cs
+++ b/src/unifocl/Models/InspectorModels.cs
@@ -8,6 +8,8 @@ internal sealed class InspectorContext
 {
     public string TargetPath { get; set; } = "/Player";
     public InspectorDepth Depth { get; set; } = InspectorDepth.ComponentList;
+    public int? FocusHighlightedComponentIndex { get; set; }
+    public string? FocusHighlightedFieldName { get; set; }
     public List<InspectorComponentEntry> Components { get; } = [];
     public List<InspectorFieldEntry> Fields { get; } = [];
     public int? SelectedComponentIndex { get; set; }

--- a/src/unifocl/Models/KeyboardIntentModels.cs
+++ b/src/unifocl/Models/KeyboardIntentModels.cs
@@ -6,7 +6,6 @@ internal enum KeyboardIntent
     Tab,
     ShiftTab,
     Escape,
-    FocusHierarchy,
     FocusProject,
     FocusInspector
 }

--- a/src/unifocl/Models/ProjectViewModels.cs
+++ b/src/unifocl/Models/ProjectViewModels.cs
@@ -8,6 +8,7 @@ internal sealed class ProjectViewState
 {
     public bool Initialized { get; set; }
     public string RelativeCwd { get; set; } = string.Empty;
+    public int? FocusHighlightedEntryIndex { get; set; }
     public List<ProjectTreeEntry> VisibleEntries { get; } = [];
     public HashSet<string> ExpandedDirectories { get; } = new(StringComparer.OrdinalIgnoreCase);
     public List<string> CommandTranscript { get; } = [];

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -750,7 +750,7 @@ static void WriteKeybindsHelp(List<string> streamLog, CliSessionState session)
 {
     AppendLog(streamLog, "[bold deepskyblue1]unifocl[/] [grey]>[/] [white]/keybinds[/]");
     AppendLog(streamLog, "[grey]keybinds[/]: global");
-    AppendLog(streamLog, "[grey]keybinds[/]: [white]F6[/] enter/exit hierarchy focus mode (inside /hierarchy)");
+    AppendLog(streamLog, "[grey]keybinds[/]: [white]F7[/] enter/exit hierarchy focus mode (inside /hierarchy)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F7[/] enter/exit project focus mode (project context), or recent selection mode after /recent");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F8[/] enter/exit inspector focus mode (inspector context)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]Esc[/] dismiss intellisense (or clear input if already dismissed)");
@@ -761,7 +761,7 @@ static void WriteKeybindsHelp(List<string> streamLog, CliSessionState session)
     AppendLog(streamLog, "[grey]keybinds[/]: [white]↑/↓[/] move highlighted GameObject");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]Tab[/] expand selected node");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]Shift+Tab[/] collapse selected node");
-    AppendLog(streamLog, "[grey]keybinds[/]: [white]Esc/F6[/] exit focus mode");
+    AppendLog(streamLog, "[grey]keybinds[/]: [white]Esc/F7[/] exit focus mode");
 
     AppendLog(streamLog, "[grey]keybinds[/]: project focus");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]↑/↓[/] move highlighted file/folder");
@@ -785,7 +785,7 @@ static void WriteKeybindsHelp(List<string> streamLog, CliSessionState session)
     }
     else if (session.ContextMode == CliContextMode.Hierarchy)
     {
-        AppendLog(streamLog, "[grey]keybinds[/]: current context -> hierarchy (F6 available now)");
+        AppendLog(streamLog, "[grey]keybinds[/]: current context -> hierarchy (F7 available now)");
     }
     else
     {

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -2,7 +2,7 @@ internal static class CliVersion
 {
     public const int Major = 0;
     public const int Minor = 2;
-    public const int Patch = 4;
+    public const int Patch = 5;
     public const string Protocol = "v2";
 
     public static string SemVer => $"{Major}.{Minor}.{Patch}";

--- a/src/unifocl/Services/HierarchyTui.cs
+++ b/src/unifocl/Services/HierarchyTui.cs
@@ -9,7 +9,7 @@ internal sealed class HierarchyTui
     private const int MinCommandRows = 4;
     private const int ReservedPromptRows = 4;
     private const int FrameOverheadRows = 5;
-    private const ConsoleKey FocusModeKey = ConsoleKey.F6;
+    private const ConsoleKey FocusModeKey = ConsoleKey.F7;
 
     private readonly HierarchyDaemonClient _daemonClient = new();
     private int _treeScrollOffset;
@@ -17,7 +17,7 @@ internal sealed class HierarchyTui
     private bool _followCommandScroll = true;
 
     private sealed record HierarchyTreeLine(int? EntryIndex, int? NodeId, bool HasChildren, string Text);
-    private sealed record FocusTreeEntry(int EntryIndex, int NodeId, bool HasChildren);
+    private sealed record FocusTreeEntry(int EntryIndex, int NodeId, int Depth, bool HasChildren);
 
     public async Task RunAsync(
         CliSessionState session,
@@ -65,9 +65,10 @@ internal sealed class HierarchyTui
             Console.Write($"UnityCLI:{cwdPath} > ");
             var firstKey = Console.ReadKey(intercept: true);
             var firstIntent = KeyboardIntentReader.FromConsoleKey(firstKey);
-            if (firstIntent == KeyboardIntent.FocusHierarchy || firstKey.Key == FocusModeKey)
+            if (firstIntent == KeyboardIntent.FocusProject
+                || firstKey.Key == FocusModeKey)
             {
-                commandLog.Add("[i] hierarchy focus mode enabled (up/down select, tab expand, shift+tab collapse, esc exit)");
+                commandLog.Add("[i] hierarchy focus mode enabled (up/down select, tab expand, shift+tab collapse, esc/F7 exit)");
                 await RunKeyboardFocusModeAsync(port, snapshot, cwdId, commandLog, updatedSnapshot =>
                 {
                     snapshot = updatedSnapshot;
@@ -80,27 +81,7 @@ internal sealed class HierarchyTui
                 continue;
             }
 
-            string input;
-            if (firstKey.Key == ConsoleKey.Enter)
-            {
-                Console.WriteLine();
-                input = string.Empty;
-            }
-            else
-            {
-                var firstChar = firstKey.KeyChar;
-                if (!char.IsControl(firstChar))
-                {
-                    Console.Write(firstChar);
-                    var tail = Console.ReadLine() ?? string.Empty;
-                    input = (firstChar + tail).Trim();
-                }
-                else
-                {
-                    Console.WriteLine();
-                    input = string.Empty;
-                }
-            }
+            var input = ReadPromptInputFromFirstKey(firstKey);
 
             if (string.IsNullOrWhiteSpace(input))
             {
@@ -233,7 +214,7 @@ internal sealed class HierarchyTui
 
             if (!response.Ok)
             {
-                commandLog.Add($"[!] {response.Message}");
+                commandLog.Add($"[!] {FormatHierarchyCommandFailure(response.Message)}");
                 return true;
             }
 
@@ -255,7 +236,7 @@ internal sealed class HierarchyTui
                 new HierarchyCommandRequestDto("toggle", null, targetId, null, false));
             if (!response.Ok)
             {
-                commandLog.Add($"[!] {response.Message}");
+                commandLog.Add($"[!] {FormatHierarchyCommandFailure(response.Message)}");
                 return true;
             }
 
@@ -271,7 +252,7 @@ internal sealed class HierarchyTui
             var response = await _daemonClient.SearchAsync(port, new HierarchySearchRequestDto(query, 20, cwdId));
             if (response?.Ok != true)
             {
-                commandLog.Add($"[!] {(response?.Message ?? "hierarchy fuzzy search failed")}");
+                commandLog.Add($"[!] {FormatHierarchyCommandFailure(response?.Message, "hierarchy fuzzy search failed")}");
                 return true;
             }
 
@@ -366,6 +347,8 @@ internal sealed class HierarchyTui
     {
         var collapsedNodeIds = BuildDefaultCollapsedNodeSet(snapshot.Root, cwdId);
         var selectedEntryPosition = 0;
+        int? highlightedNodeId = null;
+        int? pendingExpandedNodeId = null;
 
         while (true)
         {
@@ -383,8 +366,24 @@ internal sealed class HierarchyTui
                 return;
             }
 
+            if (pendingExpandedNodeId is int expandedNodeId)
+            {
+                highlightedNodeId = ResolveExpandedSelectionNodeId(visibleEntries, expandedNodeId);
+                pendingExpandedNodeId = null;
+            }
+
+            if (highlightedNodeId is int selectedNodeId)
+            {
+                var highlightedPosition = visibleEntries.FindIndex(entry => entry.NodeId == selectedNodeId);
+                if (highlightedPosition >= 0)
+                {
+                    selectedEntryPosition = highlightedPosition;
+                }
+            }
+
             selectedEntryPosition = Math.Clamp(selectedEntryPosition, 0, visibleEntries.Count - 1);
             var selectedEntry = visibleEntries[selectedEntryPosition];
+            highlightedNodeId = selectedEntry.NodeId;
             var highlightedTree = treeLines
                 .Select(line =>
                 {
@@ -408,11 +407,13 @@ internal sealed class HierarchyTui
                     selectedEntryPosition = selectedEntryPosition <= 0
                         ? visibleEntries.Count - 1
                         : selectedEntryPosition - 1;
+                    highlightedNodeId = visibleEntries[selectedEntryPosition].NodeId;
                     break;
                 case KeyboardIntent.Down:
                     selectedEntryPosition = selectedEntryPosition >= visibleEntries.Count - 1
                         ? 0
                         : selectedEntryPosition + 1;
+                    highlightedNodeId = visibleEntries[selectedEntryPosition].NodeId;
                     break;
                 case KeyboardIntent.Tab:
                     selectedEntry = visibleEntries[selectedEntryPosition];
@@ -424,6 +425,7 @@ internal sealed class HierarchyTui
 
                     if (collapsedNodeIds.Remove(selectedEntry.NodeId))
                     {
+                        pendingExpandedNodeId = selectedEntry.NodeId;
                         commandLog.Add($"[*] expanded [{selectedEntry.EntryIndex}]");
                         break;
                     }
@@ -447,7 +449,7 @@ internal sealed class HierarchyTui
                     commandLog.Add($"[i] already collapsed [{selectedEntry.EntryIndex}]");
                     break;
                 case KeyboardIntent.Escape:
-                case KeyboardIntent.FocusHierarchy:
+                case KeyboardIntent.FocusProject:
                     commandLog.Add("[i] hierarchy focus mode disabled");
                     return;
                 default:
@@ -543,7 +545,7 @@ internal sealed class HierarchyTui
         {
             var child = cwdNode.Children[i];
             var isLast = i == cwdNode.Children.Count - 1;
-            Traverse(child, string.Empty, isLast, lines, indexMap, visibleEntries, ref index, collapsedNodeIds);
+            Traverse(child, string.Empty, isLast, depth: 0, lines, indexMap, visibleEntries, ref index, collapsedNodeIds);
         }
 
         return lines;
@@ -553,6 +555,7 @@ internal sealed class HierarchyTui
         HierarchyNodeDto node,
         string prefix,
         bool isLast,
+        int depth,
         List<HierarchyTreeLine> lines,
         Dictionary<int, int> indexMap,
         List<FocusTreeEntry> visibleEntries,
@@ -565,7 +568,7 @@ internal sealed class HierarchyTui
         var collapsedMarker = hasChildren && collapsedNodeIds?.Contains(node.Id) == true ? " [+]" : string.Empty;
         lines.Add(new HierarchyTreeLine(index, node.Id, hasChildren, $"{prefix}{branch} [{index}] {label}{collapsedMarker}"));
         indexMap[index] = node.Id;
-        visibleEntries.Add(new FocusTreeEntry(index, node.Id, hasChildren));
+        visibleEntries.Add(new FocusTreeEntry(index, node.Id, depth, hasChildren));
         index++;
 
         if (hasChildren && collapsedNodeIds?.Contains(node.Id) == true)
@@ -578,8 +581,30 @@ internal sealed class HierarchyTui
         {
             var child = node.Children[i];
             var childLast = i == node.Children.Count - 1;
-            Traverse(child, nextPrefix, childLast, lines, indexMap, visibleEntries, ref index, collapsedNodeIds);
+            Traverse(child, nextPrefix, childLast, depth + 1, lines, indexMap, visibleEntries, ref index, collapsedNodeIds);
         }
+    }
+
+    private static int ResolveExpandedSelectionNodeId(List<FocusTreeEntry> visibleEntries, int expandedNodeId)
+    {
+        var expandedPosition = visibleEntries.FindIndex(entry => entry.NodeId == expandedNodeId);
+        if (expandedPosition < 0)
+        {
+            return expandedNodeId;
+        }
+
+        var expandedEntry = visibleEntries[expandedPosition];
+        var firstChildPosition = expandedPosition + 1;
+        if (firstChildPosition < visibleEntries.Count)
+        {
+            var firstChild = visibleEntries[firstChildPosition];
+            if (firstChild.Depth == expandedEntry.Depth + 1)
+            {
+                return firstChild.NodeId;
+            }
+        }
+
+        return expandedNodeId;
     }
 
     private static HashSet<int> BuildDefaultCollapsedNodeSet(HierarchyNodeDto root, int cwdId)
@@ -715,6 +740,88 @@ internal sealed class HierarchyTui
         }
 
         return null;
+    }
+
+    private static string ReadPromptInputFromFirstKey(ConsoleKeyInfo firstKey)
+    {
+        if (firstKey.Key == ConsoleKey.Enter)
+        {
+            Console.WriteLine();
+            return string.Empty;
+        }
+
+        if (firstKey.Key == ConsoleKey.Escape)
+        {
+            Console.WriteLine();
+            return string.Empty;
+        }
+
+        var input = new StringBuilder();
+        if (!TryAppendInputCharacter(firstKey, input))
+        {
+            Console.WriteLine();
+            return string.Empty;
+        }
+
+        while (true)
+        {
+            var key = Console.ReadKey(intercept: true);
+            if (key.Key == ConsoleKey.Enter)
+            {
+                Console.WriteLine();
+                return input.ToString().Trim();
+            }
+
+            if (key.Key == ConsoleKey.Backspace)
+            {
+                if (input.Length == 0)
+                {
+                    continue;
+                }
+
+                input.Length--;
+                Console.Write("\b \b");
+                continue;
+            }
+
+            if (key.Key == ConsoleKey.Escape)
+            {
+                Console.WriteLine();
+                return string.Empty;
+            }
+
+            TryAppendInputCharacter(key, input);
+        }
+    }
+
+    private static bool TryAppendInputCharacter(ConsoleKeyInfo key, StringBuilder input)
+    {
+        if (char.IsControl(key.KeyChar))
+        {
+            return false;
+        }
+
+        input.Append(key.KeyChar);
+        Console.Write(key.KeyChar);
+        return true;
+    }
+
+    private static string FormatHierarchyCommandFailure(string? message, string fallback = "hierarchy command failed")
+    {
+        var normalized = string.IsNullOrWhiteSpace(message) ? fallback : message!;
+        if (IsHierarchyStubbedMessage(normalized))
+        {
+            return $"hierarchy command is stubbed without Unity editor bridge: {normalized}";
+        }
+
+        return normalized;
+    }
+
+    private static bool IsHierarchyStubbedMessage(string message)
+    {
+        return message.Contains("require Unity editor bridge", StringComparison.OrdinalIgnoreCase)
+               || message.Contains("stubbed bridge", StringComparison.OrdinalIgnoreCase)
+               || message.Contains("stubbed", StringComparison.OrdinalIgnoreCase);
     }
 
     private static List<string> Tokenize(string input)

--- a/src/unifocl/Services/InspectorModeService.cs
+++ b/src/unifocl/Services/InspectorModeService.cs
@@ -152,12 +152,23 @@ internal sealed class InspectorModeService
                 var components = context.Components.OrderBy(component => component.Index).ToList();
                 if (components.Count == 0)
                 {
+                    context.FocusHighlightedComponentIndex = null;
                     _renderer.Render(context, null, null, focusModeEnabled: true);
                 }
                 else
                 {
+                    if (context.FocusHighlightedComponentIndex is int highlightedComponentIndex)
+                    {
+                        var highlightedPosition = components.FindIndex(component => component.Index == highlightedComponentIndex);
+                        if (highlightedPosition >= 0)
+                        {
+                            selectedComponentPosition = highlightedPosition;
+                        }
+                    }
+
                     selectedComponentPosition = Math.Clamp(selectedComponentPosition, 0, components.Count - 1);
                     var selectedComponent = components[selectedComponentPosition];
+                    context.FocusHighlightedComponentIndex = selectedComponent.Index;
                     _renderer.Render(context, selectedComponent.Index, null, focusModeEnabled: true);
                 }
             }
@@ -166,12 +177,24 @@ internal sealed class InspectorModeService
                 var fields = context.Fields;
                 if (fields.Count == 0)
                 {
+                    context.FocusHighlightedFieldName = null;
                     _renderer.Render(context, null, null, focusModeEnabled: true);
                 }
                 else
                 {
+                    if (!string.IsNullOrWhiteSpace(context.FocusHighlightedFieldName))
+                    {
+                        var highlightedPosition = fields.FindIndex(field =>
+                            field.Name.Equals(context.FocusHighlightedFieldName, StringComparison.OrdinalIgnoreCase));
+                        if (highlightedPosition >= 0)
+                        {
+                            selectedFieldPosition = highlightedPosition;
+                        }
+                    }
+
                     selectedFieldPosition = Math.Clamp(selectedFieldPosition, 0, fields.Count - 1);
-                    _renderer.Render(context, null, fields[selectedFieldPosition].Name, focusModeEnabled: true);
+                    context.FocusHighlightedFieldName = fields[selectedFieldPosition].Name;
+                    _renderer.Render(context, null, context.FocusHighlightedFieldName, focusModeEnabled: true);
                 }
             }
 
@@ -181,29 +204,35 @@ internal sealed class InspectorModeService
                 case KeyboardIntent.Up:
                     if (context.Depth == InspectorDepth.ComponentList && context.Components.Count > 0)
                     {
+                        var orderedComponentsForUp = context.Components.OrderBy(component => component.Index).ToList();
                         selectedComponentPosition = selectedComponentPosition <= 0
-                            ? context.Components.Count - 1
+                            ? orderedComponentsForUp.Count - 1
                             : selectedComponentPosition - 1;
+                        context.FocusHighlightedComponentIndex = orderedComponentsForUp[selectedComponentPosition].Index;
                     }
                     else if (context.Depth == InspectorDepth.ComponentFields && context.Fields.Count > 0)
                     {
                         selectedFieldPosition = selectedFieldPosition <= 0
                             ? context.Fields.Count - 1
                             : selectedFieldPosition - 1;
+                        context.FocusHighlightedFieldName = context.Fields[selectedFieldPosition].Name;
                     }
                     break;
                 case KeyboardIntent.Down:
                     if (context.Depth == InspectorDepth.ComponentList && context.Components.Count > 0)
                     {
-                        selectedComponentPosition = selectedComponentPosition >= context.Components.Count - 1
+                        var orderedComponentsForDown = context.Components.OrderBy(component => component.Index).ToList();
+                        selectedComponentPosition = selectedComponentPosition >= orderedComponentsForDown.Count - 1
                             ? 0
                             : selectedComponentPosition + 1;
+                        context.FocusHighlightedComponentIndex = orderedComponentsForDown[selectedComponentPosition].Index;
                     }
                     else if (context.Depth == InspectorDepth.ComponentFields && context.Fields.Count > 0)
                     {
                         selectedFieldPosition = selectedFieldPosition >= context.Fields.Count - 1
                             ? 0
                             : selectedFieldPosition + 1;
+                        context.FocusHighlightedFieldName = context.Fields[selectedFieldPosition].Name;
                     }
                     break;
                 case KeyboardIntent.Tab:
@@ -220,10 +249,13 @@ internal sealed class InspectorModeService
                         orderedComponents[selectedComponentPosition].Index,
                         $"inspect {orderedComponents[selectedComponentPosition].Index}");
                     selectedFieldPosition = 0;
+                    context.FocusHighlightedFieldName = null;
                     break;
                 case KeyboardIntent.ShiftTab:
                     if (context.Depth == InspectorDepth.ComponentFields)
                     {
+                        context.FocusHighlightedComponentIndex = context.SelectedComponentIndex;
+                        context.FocusHighlightedFieldName = null;
                         context.Depth = InspectorDepth.ComponentList;
                         context.Fields.Clear();
                         context.SelectedComponentIndex = null;
@@ -242,6 +274,8 @@ internal sealed class InspectorModeService
                 case KeyboardIntent.Escape:
                 case KeyboardIntent.FocusInspector:
                     AddStream(context, "[i] inspector focus mode disabled");
+                    context.FocusHighlightedFieldName = null;
+                    context.FocusHighlightedComponentIndex = null;
                     _renderer.Render(context);
                     return;
                 default:
@@ -696,6 +730,8 @@ internal sealed class InspectorModeService
 
         if (context.Depth == InspectorDepth.ComponentFields)
         {
+            context.FocusHighlightedComponentIndex = context.SelectedComponentIndex;
+            context.FocusHighlightedFieldName = null;
             context.Depth = InspectorDepth.ComponentList;
             context.Fields.Clear();
             context.SelectedComponentIndex = null;
@@ -722,6 +758,8 @@ internal sealed class InspectorModeService
     {
         context.TargetPath = targetPath;
         context.Depth = InspectorDepth.ComponentList;
+        context.FocusHighlightedComponentIndex = null;
+        context.FocusHighlightedFieldName = null;
         context.Fields.Clear();
         context.SelectedComponentIndex = null;
         context.SelectedComponentName = null;
@@ -759,6 +797,8 @@ internal sealed class InspectorModeService
         context.Depth = InspectorDepth.ComponentFields;
         context.SelectedComponentIndex = componentIndex;
         context.SelectedComponentName = component.Name;
+        context.FocusHighlightedComponentIndex = componentIndex;
+        context.FocusHighlightedFieldName = null;
         context.BodyScrollOffset = 0;
         context.FollowStreamScroll = true;
         context.StreamScrollOffset = int.MaxValue;

--- a/src/unifocl/Services/KeyboardIntentReader.cs
+++ b/src/unifocl/Services/KeyboardIntentReader.cs
@@ -33,11 +33,6 @@ internal static class KeyboardIntentReader
             return KeyboardIntent.Escape;
         }
 
-        if (key.Key == ConsoleKey.F6)
-        {
-            return KeyboardIntent.FocusHierarchy;
-        }
-
         if (key.Key == ConsoleKey.F7)
         {
             return KeyboardIntent.FocusProject;

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -7,6 +7,12 @@ internal sealed class ProjectViewService
     private const int MaxTranscriptEntries = 80;
     private readonly ProjectViewRenderer _renderer = new();
     private readonly HierarchyDaemonClient _daemonClient = new();
+    private enum ProjectFocusTabResult
+    {
+        ExpandedDirectory,
+        NestedDirectory,
+        OpenedAsset
+    }
 
     public void OpenInitialView(CliSessionState session)
     {
@@ -130,11 +136,22 @@ internal sealed class ProjectViewService
             var entries = session.ProjectView.VisibleEntries;
             if (entries.Count == 0)
             {
+                session.ProjectView.FocusHighlightedEntryIndex = null;
                 RenderFrame(session.ProjectView, null, focusModeEnabled: true);
             }
             else
             {
+                if (session.ProjectView.FocusHighlightedEntryIndex is int highlightedIndex)
+                {
+                    var highlightedPosition = entries.FindIndex(entry => entry.Index == highlightedIndex);
+                    if (highlightedPosition >= 0)
+                    {
+                        selectedEntryPosition = highlightedPosition;
+                    }
+                }
+
                 selectedEntryPosition = Math.Clamp(selectedEntryPosition, 0, entries.Count - 1);
+                session.ProjectView.FocusHighlightedEntryIndex = entries[selectedEntryPosition].Index;
                 RenderFrame(session.ProjectView, entries[selectedEntryPosition].Index, focusModeEnabled: true);
             }
 
@@ -147,6 +164,7 @@ internal sealed class ProjectViewService
                         selectedEntryPosition = selectedEntryPosition <= 0
                             ? entries.Count - 1
                             : selectedEntryPosition - 1;
+                        session.ProjectView.FocusHighlightedEntryIndex = entries[selectedEntryPosition].Index;
                     }
                     break;
                 case KeyboardIntent.Down:
@@ -155,6 +173,7 @@ internal sealed class ProjectViewService
                         selectedEntryPosition = selectedEntryPosition >= entries.Count - 1
                             ? 0
                             : selectedEntryPosition + 1;
+                        session.ProjectView.FocusHighlightedEntryIndex = entries[selectedEntryPosition].Index;
                     }
                     break;
                 case KeyboardIntent.Tab:
@@ -163,7 +182,8 @@ internal sealed class ProjectViewService
                         break;
                     }
 
-                    await HandleProjectFocusTabAsync(entries[selectedEntryPosition], session, daemonControlService, daemonRuntime, outputs);
+                    var selectedEntry = entries[selectedEntryPosition];
+                    var tabResult = await HandleProjectFocusTabAsync(selectedEntry, session, daemonControlService, daemonRuntime, outputs);
                     if (session.ContextMode != CliContextMode.Project)
                     {
                         AppendTranscript(session.ProjectView, outputs);
@@ -171,15 +191,28 @@ internal sealed class ProjectViewService
                         return;
                     }
 
-                    selectedEntryPosition = 0;
+                    if (tabResult == ProjectFocusTabResult.ExpandedDirectory)
+                    {
+                        session.ProjectView.FocusHighlightedEntryIndex = ResolveExpandedSelectionIndex(
+                            session.CurrentProjectPath,
+                            session.ProjectView,
+                            selectedEntry.RelativePath);
+                    }
+                    else
+                    {
+                        selectedEntryPosition = 0;
+                        session.ProjectView.FocusHighlightedEntryIndex = null;
+                    }
                     break;
                 case KeyboardIntent.ShiftTab:
                     HandleUp(session.ProjectView, outputs);
                     selectedEntryPosition = 0;
+                    session.ProjectView.FocusHighlightedEntryIndex = null;
                     break;
                 case KeyboardIntent.Escape:
                 case KeyboardIntent.FocusProject:
                     outputs.Add("[i] project focus mode disabled");
+                    session.ProjectView.FocusHighlightedEntryIndex = null;
                     AppendTranscript(session.ProjectView, outputs);
                     RenderFrame(session.ProjectView);
                     return;
@@ -222,6 +255,7 @@ internal sealed class ProjectViewService
         state.CommandTranscript.Add("[i] project view ready");
         state.DbState = ProjectDbState.IdleSafe;
         state.Initialized = true;
+        state.FocusHighlightedEntryIndex = null;
         state.AssetIndexRevision = 0;
         state.AssetPathByInstanceId.Clear();
         state.LastFuzzyMatches.Clear();
@@ -336,7 +370,7 @@ internal sealed class ProjectViewService
         return state.ExpandedDirectories.Contains(entry.RelativePath);
     }
 
-    private async Task HandleProjectFocusTabAsync(
+    private async Task<ProjectFocusTabResult> HandleProjectFocusTabAsync(
         ProjectTreeEntry entry,
         CliSessionState session,
         DaemonControlService daemonControlService,
@@ -348,14 +382,46 @@ internal sealed class ProjectViewService
             if (!IsExpandedDirectory(session.ProjectView, entry))
             {
                 HandleExpand(entry.Index, session.ProjectView, outputs);
-                return;
+                return ProjectFocusTabResult.ExpandedDirectory;
             }
 
             HandleNest(entry.Index, session.ProjectView, outputs);
-            return;
+            return ProjectFocusTabResult.NestedDirectory;
         }
 
         await HandleLoadViaBridgeAsync(entry.Index.ToString(), session, outputs, daemonControlService, daemonRuntime);
+        return ProjectFocusTabResult.OpenedAsset;
+    }
+
+    private static int? ResolveExpandedSelectionIndex(string projectPath, ProjectViewState state, string expandedRelativePath)
+    {
+        RefreshTree(projectPath, state);
+        var entries = state.VisibleEntries;
+        if (entries.Count == 0)
+        {
+            return null;
+        }
+
+        var expandedIndex = entries.FindIndex(entry =>
+            entry.RelativePath.Equals(expandedRelativePath, StringComparison.OrdinalIgnoreCase));
+        if (expandedIndex < 0)
+        {
+            return null;
+        }
+
+        var expandedEntry = entries[expandedIndex];
+        var firstChildIndex = expandedIndex + 1;
+        if (firstChildIndex < entries.Count)
+        {
+            var firstChild = entries[firstChildIndex];
+            if (firstChild.Depth == expandedEntry.Depth + 1
+                && firstChild.RelativePath.StartsWith(expandedEntry.RelativePath + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                return firstChild.Index;
+            }
+        }
+
+        return expandedEntry.Index;
     }
 
     private async Task<bool> HandleMakeScriptViaBridgeAsync(


### PR DESCRIPTION
## Summary
- Persist highlight cursor state across rerenders in project, hierarchy, and inspector focus modes.
- Fix hierarchy expansion behavior: move highlight to the first child when expanded, or keep it on the directory/node when empty.
- Fix hierarchy prompt input handling so the first typed character can be deleted via backspace.
- Standardize focus keybind policy to `F7` (drop `F6` mapping/mentions).
- Clarify hierarchy stubbed behavior by emitting explicit "hierarchy command is stubbed without Unity editor bridge" errors.
- Bump CLI patch version from `0.2.4` to `0.2.5`.

## Related Issues
- Closes #N/A
- Related to #N/A

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `ProjectViewService`, `ProjectViewModels`
  - `HierarchyTui`
  - `InspectorModeService`, `InspectorModels`
  - `KeyboardIntentReader`, `KeyboardIntentModels`
  - `Program` keybind help text
  - `CliVersion`
- Out-of-scope / intentionally not addressed:
  - Functional changes to focus keybinds in inspector (`F8`) and recent selection behavior.

## How to Test
1. Enter project mode and use focus mode (`F7`), expand directories with `Tab`, and verify highlight moves to first child when present or stays on expanded directory when empty.
2. Enter hierarchy mode (`/hierarchy`) and press `F7` to enter/exit focus mode; verify `F6` no longer toggles focus.
3. In hierarchy prompt input, type one character then press backspace; verify it is deleted correctly.
4. Run hierarchy command paths without Unity bridge and verify explicit stubbed message is shown.
5. Run `dotnet build -v minimal`.

Expected results:
- Cursor highlight is stable across rerenders in all focus modes.
- Focus keybind policy is consistently `F7` where applicable.
- Hierarchy stubbed paths are explicitly labeled.
- Build succeeds.

## Screenshots / Terminal Output (if applicable)
- `dotnet build -v minimal` succeeded locally (0 errors; existing NU1900 network warnings unchanged).

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- This change only affects local TUI interaction/state handling and user-facing messaging.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
