### PR TITLE
Improve UPM list UX and bridge payload handling

### DIFF
--- a/src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs
+++ b/src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs
@@ -177,6 +177,34 @@ namespace UniFocl.EditorBridge
         public bool ok;
         public string message = string.Empty;
         public string kind = string.Empty;
+        public string content = string.Empty;
+    }
+
+    [Serializable]
+    internal sealed class UpmListRequestOptions
+    {
+        public bool includeOutdated;
+        public bool includeBuiltin;
+        public bool includeGit;
+    }
+
+    [Serializable]
+    internal sealed class UpmPackageEntry
+    {
+        public string packageId = string.Empty;
+        public string displayName = string.Empty;
+        public string version = string.Empty;
+        public string source = string.Empty;
+        public string latestCompatibleVersion = string.Empty;
+        public bool isOutdated;
+        public bool isDeprecated;
+        public bool isPreview;
+    }
+
+    [Serializable]
+    internal sealed class UpmListResponse
+    {
+        public UpmPackageEntry[] packages = Array.Empty<UpmPackageEntry>();
     }
 }
 #endif

--- a/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
@@ -220,6 +220,9 @@ namespace UniFocl.EditorBridge
                 var isOutdated = !string.IsNullOrWhiteSpace(latestCompatible)
                                  && !string.IsNullOrWhiteSpace(installedVersion)
                                  && !installedVersion.Equals(latestCompatible, StringComparison.OrdinalIgnoreCase);
+                var isDeprecated = package.isDeprecated;
+                var isPreview = installedVersion.Contains("preview", StringComparison.OrdinalIgnoreCase)
+                                || latestCompatible.Contains("preview", StringComparison.OrdinalIgnoreCase);
 
                 if (!options.includeBuiltin && isBuiltIn)
                 {
@@ -243,7 +246,9 @@ namespace UniFocl.EditorBridge
                     version = installedVersion,
                     source = source,
                     latestCompatibleVersion = latestCompatible,
-                    isOutdated = isOutdated
+                    isOutdated = isOutdated,
+                    isDeprecated = isDeprecated,
+                    isPreview = isPreview
                 });
             }
 

--- a/src/unifocl/Models/CliSessionState.cs
+++ b/src/unifocl/Models/CliSessionState.cs
@@ -50,6 +50,7 @@ internal sealed class CliSessionState
         ProjectView.AssetIndexRevision = 0;
         ProjectView.AssetPathByInstanceId.Clear();
         ProjectView.LastFuzzyMatches.Clear();
+        ProjectView.LastUpmPackages.Clear();
         UnityLogPane.Clear();
         RecentProjectEntries.Clear();
         RecentSelectionAllowUnsafe = false;

--- a/src/unifocl/Models/ProjectBridgeModels.cs
+++ b/src/unifocl/Models/ProjectBridgeModels.cs
@@ -7,4 +7,5 @@ internal sealed record ProjectCommandRequestDto(
 internal sealed record ProjectCommandResponseDto(
     bool Ok,
     string Message,
-    string? Kind);
+    string? Kind,
+    string? Content);

--- a/src/unifocl/Models/ProjectViewModels.cs
+++ b/src/unifocl/Models/ProjectViewModels.cs
@@ -16,6 +16,7 @@ internal sealed class ProjectViewState
     public int AssetIndexRevision { get; set; }
     public Dictionary<int, string> AssetPathByInstanceId { get; } = [];
     public List<ProjectFuzzyMatch> LastFuzzyMatches { get; } = [];
+    public List<UpmPackageEntry> LastUpmPackages { get; } = [];
 }
 
 internal sealed record ProjectTreeEntry(
@@ -24,3 +25,14 @@ internal sealed record ProjectTreeEntry(
     string Name,
     string RelativePath,
     bool IsDirectory);
+
+internal sealed record UpmPackageEntry(
+    int Index,
+    string PackageId,
+    string DisplayName,
+    string Version,
+    string Source,
+    string? LatestCompatibleVersion,
+    bool IsOutdated,
+    bool IsDeprecated,
+    bool IsPreview);

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -67,7 +67,10 @@ var commands = new List<CommandSpec>
     new("/shortcuts", "Alias for keybinds", "/shortcuts"),
     new("/update", "Check for CLI updates", "/update"),
     new("/version", "Show CLI and protocol version", "/version"),
-    new("/protocol", "Show supported JSON schema capabilities", "/protocol")
+    new("/protocol", "Show supported JSON schema capabilities", "/protocol"),
+    new("/upm list [--outdated] [--builtin] [--git]", "List installed Unity packages (UPM)", "/upm list"),
+    new("/upm ls [--outdated] [--builtin] [--git]", "Alias for /upm list", "/upm ls"),
+    new("/upm", "Unity Package Manager commands", "/upm")
 };
 
 var projectCommands = new List<CommandSpec>
@@ -92,7 +95,9 @@ var projectCommands = new List<CommandSpec>
     new("f <query>", "Fuzzy find in active mode", "f"),
     new("ff <query>", "Alias for fuzzy find", "ff"),
     new("move <...>", "Move/reorder item in active mode", "move"),
-    new("mv <...>", "Alias for move", "mv")
+    new("mv <...>", "Alias for move", "mv"),
+    new("upm list [--outdated] [--builtin] [--git]", "List installed Unity packages (UPM)", "upm list"),
+    new("upm ls [--outdated] [--builtin] [--git]", "Alias for upm list", "upm ls")
 };
 
 var streamLog = new List<string>();
@@ -270,6 +275,31 @@ while (true)
             {
                 session.ContextMode = CliContextMode.Inspector;
             }
+            continue;
+        }
+
+        if (matched.Trigger.StartsWith("/upm", StringComparison.Ordinal))
+        {
+            if (session.Mode != CliMode.Project || string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+            {
+                AppendLog(streamLog, "[yellow]mode[/]: open a project first with /open");
+                continue;
+            }
+
+            var upmInput = input.Length > "/upm".Length
+                ? $"upm {input["/upm".Length..].Trim()}"
+                : "upm";
+            var handled = await projectCommandRouterService.TryHandleProjectCommandAsync(
+                upmInput,
+                session,
+                daemonControlService,
+                daemonRuntime,
+                line => AppendLog(streamLog, line));
+            if (!handled)
+            {
+                AppendLog(streamLog, "[yellow]upm[/]: unsupported /upm command");
+            }
+
             continue;
         }
 
@@ -812,6 +842,12 @@ static bool TryGetComposerIntellisenseCandidates(
         return true;
     }
 
+    if (TryGetUpmComposerCandidates(input, session, out var upmCandidates))
+    {
+        candidates = upmCandidates;
+        return true;
+    }
+
     if (input.StartsWith('/'))
     {
         candidates = GetSuggestionMatches(input, commands)
@@ -829,6 +865,74 @@ static bool TryGetComposerIntellisenseCandidates(
     }
 
     return false;
+}
+
+static bool TryGetUpmComposerCandidates(
+    string input,
+    CliSessionState session,
+    out List<(string Label, string? CommitCommand)> candidates)
+{
+    candidates = [];
+    var trimmed = input.TrimStart();
+    var isSlash = trimmed.StartsWith("/upm", StringComparison.OrdinalIgnoreCase);
+    var isProjectCommand = trimmed.StartsWith("upm", StringComparison.OrdinalIgnoreCase);
+    if (!isSlash && !isProjectCommand)
+    {
+        return false;
+    }
+
+    var prefix = isSlash ? "/upm" : "upm";
+    var suffix = trimmed.Length > prefix.Length
+        ? trimmed[prefix.Length..].TrimStart()
+        : string.Empty;
+
+    if (string.IsNullOrWhiteSpace(suffix))
+    {
+        candidates.Add((isSlash
+            ? "/upm list [--outdated] [--builtin] [--git]"
+            : "upm list [--outdated] [--builtin] [--git]", isSlash ? "/upm list" : "upm list"));
+        candidates.Add((isSlash ? "/upm ls" : "upm ls", isSlash ? "/upm ls" : "upm ls"));
+        return true;
+    }
+
+    var upmSuggestions = new List<(string Label, string? CommitCommand)>
+    {
+        (isSlash ? "/upm list [--outdated] [--builtin] [--git]" : "upm list [--outdated] [--builtin] [--git]", isSlash ? "/upm list" : "upm list"),
+        (isSlash ? "/upm ls [--outdated] [--builtin] [--git]" : "upm ls [--outdated] [--builtin] [--git]", isSlash ? "/upm ls" : "upm ls")
+    };
+
+    var suffixLower = suffix.ToLowerInvariant();
+    candidates = upmSuggestions
+        .Where(candidate => candidate.Label.Contains(suffixLower, StringComparison.OrdinalIgnoreCase)
+                            || candidate.CommitCommand?.Contains(suffixLower, StringComparison.OrdinalIgnoreCase) == true)
+        .Take(10)
+        .ToList();
+
+    if (suffixLower.StartsWith("list", StringComparison.OrdinalIgnoreCase)
+        || suffixLower.StartsWith("ls", StringComparison.OrdinalIgnoreCase))
+    {
+        var commandHead = isSlash
+            ? (suffixLower.StartsWith("ls", StringComparison.OrdinalIgnoreCase) ? "/upm ls" : "/upm list")
+            : (suffixLower.StartsWith("ls", StringComparison.OrdinalIgnoreCase) ? "upm ls" : "upm list");
+        var flags = new[] { "--outdated", "--builtin", "--git" };
+        foreach (var flag in flags)
+        {
+            candidates.Add(($"{commandHead} {flag}", $"{commandHead} {flag}"));
+        }
+    }
+
+    var packageRefs = session.ProjectView.LastUpmPackages.Take(5).ToList();
+    if (packageRefs.Count > 0)
+    {
+        foreach (var package in packageRefs)
+        {
+            var label = $"[{package.Index}] {package.DisplayName} ({package.PackageId})";
+            candidates.Add((label, null));
+        }
+    }
+
+    candidates = candidates.DistinctBy(x => x.Label).Take(10).ToList();
+    return true;
 }
 
 static IEnumerable<string> GetSuggestionLines(string query, List<CommandSpec> commands, int selectedSuggestionIndex)

--- a/src/unifocl/Services/HierarchyDaemonClient.cs
+++ b/src/unifocl/Services/HierarchyDaemonClient.cs
@@ -125,7 +125,7 @@ internal sealed class HierarchyDaemonClient
                     continue;
                 }
 
-                return new ProjectCommandResponseDto(false, result.Error, null);
+                return new ProjectCommandResponseDto(false, result.Error, null, null);
             }
 
             var payload = result.Payload;
@@ -138,21 +138,21 @@ internal sealed class HierarchyDaemonClient
                     continue;
                 }
 
-                return new ProjectCommandResponseDto(false, "daemon returned an empty project response payload", null);
+                return new ProjectCommandResponseDto(false, "daemon returned an empty project response payload", null, null);
             }
 
             try
             {
                 var parsed = JsonSerializer.Deserialize<ProjectCommandResponseDto>(payload, JsonOptions);
-                return parsed ?? new ProjectCommandResponseDto(false, "daemon returned empty project response", null);
+                return parsed ?? new ProjectCommandResponseDto(false, "daemon returned empty project response", null, null);
             }
             catch
             {
-                return new ProjectCommandResponseDto(false, "daemon returned invalid project response", null);
+                return new ProjectCommandResponseDto(false, "daemon returned invalid project response", null, null);
             }
         }
 
-        return new ProjectCommandResponseDto(false, "daemon did not return a project response", null);
+        return new ProjectCommandResponseDto(false, "daemon did not return a project response", null, null);
     }
 
     private static async Task<string?> SendGetAsync(string uri)

--- a/src/unifocl/Services/ProjectCommandRouterService.cs
+++ b/src/unifocl/Services/ProjectCommandRouterService.cs
@@ -151,6 +151,15 @@ internal sealed class ProjectCommandRouterService
             _ => tokens[0]
         };
 
+        if (tokens[0].Equals("upm", StringComparison.OrdinalIgnoreCase) && tokens.Count >= 2)
+        {
+            tokens[1] = tokens[1].ToLowerInvariant() switch
+            {
+                "list" => "ls",
+                _ => tokens[1]
+            };
+        }
+
         if (tokens[0].Equals("up", StringComparison.OrdinalIgnoreCase))
         {
             tokens[0] = mode == CliContextMode.Inspector ? ":i" : "up";

--- a/src/unifocl/Services/ProjectDaemonBridge.cs
+++ b/src/unifocl/Services/ProjectDaemonBridge.cs
@@ -46,7 +46,7 @@ internal sealed class ProjectDaemonBridge
             "rename-asset" => HandleRenameAsset(request),
             "remove-asset" => HandleRemoveAsset(request),
             "load-asset" => HandleLoadAsset(request),
-            _ => new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} unsupported action: {request.Action}", null)
+            _ => new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} unsupported action: {request.Action}", null, null)
         };
         response = JsonSerializer.Serialize(result, _jsonOptions);
         return true;
@@ -56,13 +56,13 @@ internal sealed class ProjectDaemonBridge
     {
         if (!IsValidAssetPath(request.AssetPath) || string.IsNullOrWhiteSpace(request.Content))
         {
-            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} mk-script requires assetPath and content", null);
+            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} mk-script requires assetPath and content", null, null);
         }
 
         var absolutePath = ResolveAssetPath(request.AssetPath!);
         if (File.Exists(absolutePath))
         {
-            return new ProjectCommandResponseDto(false, $"asset already exists: {request.AssetPath}", null);
+            return new ProjectCommandResponseDto(false, $"asset already exists: {request.AssetPath}", null, null);
         }
 
         try
@@ -74,11 +74,11 @@ internal sealed class ProjectDaemonBridge
             }
 
             File.WriteAllText(absolutePath, request.Content);
-            return new ProjectCommandResponseDto(true, "script created (stubbed bridge fallback)", "script");
+            return new ProjectCommandResponseDto(true, "script created (stubbed bridge fallback)", "script", null);
         }
         catch (Exception ex)
         {
-            return new ProjectCommandResponseDto(false, $"failed to create script: {ex.Message}", null);
+            return new ProjectCommandResponseDto(false, $"failed to create script: {ex.Message}", null, null);
         }
     }
 
@@ -86,19 +86,19 @@ internal sealed class ProjectDaemonBridge
     {
         if (!IsValidAssetPath(request.AssetPath) || !IsValidAssetPath(request.NewAssetPath))
         {
-            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} rename-asset requires assetPath and newAssetPath", null);
+            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} rename-asset requires assetPath and newAssetPath", null, null);
         }
 
         var sourcePath = ResolveAssetPath(request.AssetPath!);
         var targetPath = ResolveAssetPath(request.NewAssetPath!);
         if (!File.Exists(sourcePath) && !Directory.Exists(sourcePath))
         {
-            return new ProjectCommandResponseDto(false, $"asset not found: {request.AssetPath}", null);
+            return new ProjectCommandResponseDto(false, $"asset not found: {request.AssetPath}", null, null);
         }
 
         if (File.Exists(targetPath) || Directory.Exists(targetPath))
         {
-            return new ProjectCommandResponseDto(false, $"target already exists: {request.NewAssetPath}", null);
+            return new ProjectCommandResponseDto(false, $"target already exists: {request.NewAssetPath}", null, null);
         }
 
         try
@@ -119,11 +119,11 @@ internal sealed class ProjectDaemonBridge
             }
 
             MoveMetaIfPresent(sourcePath, targetPath);
-            return new ProjectCommandResponseDto(true, "asset renamed (stubbed bridge fallback)", null);
+            return new ProjectCommandResponseDto(true, "asset renamed (stubbed bridge fallback)", null, null);
         }
         catch (Exception ex)
         {
-            return new ProjectCommandResponseDto(false, $"failed to rename asset: {ex.Message}", null);
+            return new ProjectCommandResponseDto(false, $"failed to rename asset: {ex.Message}", null, null);
         }
     }
 
@@ -131,13 +131,13 @@ internal sealed class ProjectDaemonBridge
     {
         if (!IsValidAssetPath(request.AssetPath))
         {
-            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} remove-asset requires assetPath", null);
+            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} remove-asset requires assetPath", null, null);
         }
 
         var absolutePath = ResolveAssetPath(request.AssetPath!);
         if (!File.Exists(absolutePath) && !Directory.Exists(absolutePath))
         {
-            return new ProjectCommandResponseDto(false, $"asset not found: {request.AssetPath}", null);
+            return new ProjectCommandResponseDto(false, $"asset not found: {request.AssetPath}", null, null);
         }
 
         try
@@ -152,11 +152,11 @@ internal sealed class ProjectDaemonBridge
             }
 
             DeleteMetaIfPresent(absolutePath);
-            return new ProjectCommandResponseDto(true, "asset removed (stubbed bridge fallback)", null);
+            return new ProjectCommandResponseDto(true, "asset removed (stubbed bridge fallback)", null, null);
         }
         catch (Exception ex)
         {
-            return new ProjectCommandResponseDto(false, $"failed to remove asset: {ex.Message}", null);
+            return new ProjectCommandResponseDto(false, $"failed to remove asset: {ex.Message}", null, null);
         }
     }
 
@@ -164,14 +164,14 @@ internal sealed class ProjectDaemonBridge
     {
         if (!IsValidAssetPath(request.AssetPath))
         {
-            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} load-asset requires assetPath", null);
+            return new ProjectCommandResponseDto(false, $"{StubbedBridgePrefix} load-asset requires assetPath", null, null);
         }
 
         var assetPath = request.AssetPath!;
         var absolutePath = ResolveAssetPath(assetPath);
         if (!File.Exists(absolutePath))
         {
-            return new ProjectCommandResponseDto(false, $"asset not found: {request.AssetPath}", null);
+            return new ProjectCommandResponseDto(false, $"asset not found: {request.AssetPath}", null, null);
         }
 
         var extension = Path.GetExtension(assetPath);
@@ -180,6 +180,7 @@ internal sealed class ProjectDaemonBridge
             return new ProjectCommandResponseDto(
                 false,
                 $"{StubbedBridgePrefix} scene load is unavailable without Unity editor bridge: {assetPath}",
+                null,
                 null);
         }
 
@@ -188,12 +189,14 @@ internal sealed class ProjectDaemonBridge
             return new ProjectCommandResponseDto(
                 true,
                 "script path resolved (stubbed bridge fallback; Unity script open unavailable)",
-                "script");
+                "script",
+                null);
         }
 
         return new ProjectCommandResponseDto(
             false,
             $"unsupported asset type: {extension} (supported: .unity, .cs)",
+            null,
             null);
     }
 
@@ -237,6 +240,6 @@ internal sealed class ProjectDaemonBridge
 
     private string SerializeError(string message)
     {
-        return JsonSerializer.Serialize(new ProjectCommandResponseDto(false, message, null), _jsonOptions);
+        return JsonSerializer.Serialize(new ProjectCommandResponseDto(false, message, null, null), _jsonOptions);
     }
 }

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -100,6 +100,10 @@ internal sealed class ProjectViewService
         {
             handled = await HandleFuzzyFindAsync(session, tokens, outputs);
         }
+        else if (tokens[0].Equals("upm", StringComparison.OrdinalIgnoreCase))
+        {
+            handled = await HandleUpmCommandAsync(session, tokens, outputs, daemonControlService, daemonRuntime);
+        }
 
         if (!handled)
         {
@@ -259,6 +263,7 @@ internal sealed class ProjectViewService
         state.AssetIndexRevision = 0;
         state.AssetPathByInstanceId.Clear();
         state.LastFuzzyMatches.Clear();
+        state.LastUpmPackages.Clear();
         RefreshTree(projectPath, state);
     }
 
@@ -686,7 +691,7 @@ internal sealed class ProjectViewService
     {
         if (session.AttachedPort is not int port)
         {
-            return new ProjectCommandResponseDto(false, "daemon is not attached", null);
+            return new ProjectCommandResponseDto(false, "daemon is not attached", null, null);
         }
 
         return await _daemonClient.ExecuteProjectCommandAsync(port, request, onStatus);
@@ -827,6 +832,61 @@ internal sealed class ProjectViewService
                && message.Contains("asset not found", StringComparison.OrdinalIgnoreCase);
     }
 
+    private static string ResolvePackageDisplayName(string? displayName, string packageId)
+    {
+        if (!string.IsNullOrWhiteSpace(displayName))
+        {
+            return displayName.Trim();
+        }
+
+        var tail = packageId.Split('.', StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? packageId;
+        return string.Join(' ', tail
+            .Split('-', StringSplitOptions.RemoveEmptyEntries)
+            .Select(token => token.Length == 0
+                ? token
+                : char.ToUpperInvariant(token[0]) + token[1..]));
+    }
+
+    private static string ResolveUpmStatusColor(UpmPackageEntry package)
+    {
+        if (package.IsDeprecated)
+        {
+            return CliTheme.Error;
+        }
+
+        if (package.IsOutdated)
+        {
+            return CliTheme.Warning;
+        }
+
+        if (package.IsPreview)
+        {
+            return CliTheme.Info;
+        }
+
+        return CliTheme.Success;
+    }
+
+    private static string ResolveUpmStatusLabel(UpmPackageEntry package)
+    {
+        if (package.IsDeprecated)
+        {
+            return "deprecated";
+        }
+
+        if (package.IsOutdated)
+        {
+            return "update available";
+        }
+
+        if (package.IsPreview)
+        {
+            return "preview";
+        }
+
+        return "stable";
+    }
+
     private async Task<bool> HandleFuzzyFindAsync(CliSessionState session, IReadOnlyList<string> tokens, List<string> outputs)
     {
         if (tokens.Count < 2)
@@ -886,6 +946,138 @@ internal sealed class ProjectViewService
             outputs.Add($"[{match.Index}] {match.Path}");
         }
 
+        return true;
+    }
+
+    private async Task<bool> HandleUpmCommandAsync(
+        CliSessionState session,
+        IReadOnlyList<string> tokens,
+        List<string> outputs,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime)
+    {
+        if (tokens.Count < 2)
+        {
+            outputs.Add("[x] usage: upm <list|ls> [--outdated] [--builtin] [--git]");
+            return true;
+        }
+
+        var subcommand = tokens[1];
+        if (!subcommand.Equals("list", StringComparison.OrdinalIgnoreCase)
+            && !subcommand.Equals("ls", StringComparison.OrdinalIgnoreCase))
+        {
+            outputs.Add($"[x] unsupported upm subcommand: {subcommand}");
+            outputs.Add("supported: upm list (alias: upm ls)");
+            return true;
+        }
+
+        var includeOutdatedOnly = false;
+        var includeBuiltin = false;
+        var includeGitOnly = false;
+        for (var i = 2; i < tokens.Count; i++)
+        {
+            var option = tokens[i];
+            if (option.Equals("--outdated", StringComparison.OrdinalIgnoreCase))
+            {
+                includeOutdatedOnly = true;
+                continue;
+            }
+
+            if (option.Equals("--builtin", StringComparison.OrdinalIgnoreCase))
+            {
+                includeBuiltin = true;
+                continue;
+            }
+
+            if (option.Equals("--git", StringComparison.OrdinalIgnoreCase))
+            {
+                includeGitOnly = true;
+                continue;
+            }
+
+            outputs.Add($"[x] unsupported flag: {option}");
+            outputs.Add("supported flags: --outdated --builtin --git");
+            return true;
+        }
+
+        AppendTranscript(session.ProjectView, [$"[{CliTheme.Info}]loading package information...[/]"]);
+        RenderFrame(session.ProjectView);
+
+        var unityReady = await EnsureUnityContextAsync(session, daemonControlService, daemonRuntime, requireUnityBridge: true);
+        if (!unityReady)
+        {
+            outputs.Add("[x] upm list failed: Unity editor bridge is unavailable; set UNITY_PATH or open Unity editor for this project");
+            return true;
+        }
+
+        var payload = JsonSerializer.Serialize(
+            new UpmListRequestPayload(includeOutdatedOnly, includeBuiltin, includeGitOnly),
+            new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var response = await ExecuteProjectCommandAsync(
+            session,
+            new ProjectCommandRequestDto("upm-list", null, null, payload));
+
+        if (!response.Ok)
+        {
+            outputs.Add(FormatProjectCommandFailure("upm list", response.Message));
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(response.Content))
+        {
+            outputs.Add("[x] upm list failed: daemon returned empty package payload");
+            return true;
+        }
+
+        UpmListResponsePayload? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<UpmListResponsePayload>(
+                response.Content,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch (Exception ex)
+        {
+            outputs.Add($"[x] upm list failed: invalid package payload ({ex.Message})");
+            return true;
+        }
+
+        var indexedPackages = (parsed?.Packages ?? [])
+            .Where(p => !string.IsNullOrWhiteSpace(p.PackageId))
+            .OrderBy(p => ResolvePackageDisplayName(p.DisplayName, p.PackageId!), StringComparer.OrdinalIgnoreCase)
+            .ThenBy(p => p.PackageId, StringComparer.OrdinalIgnoreCase)
+            .Select((package, index) => new UpmPackageEntry(
+                index,
+                package.PackageId!,
+                ResolvePackageDisplayName(package.DisplayName, package.PackageId!),
+                string.IsNullOrWhiteSpace(package.Version) ? "-" : package.Version!,
+                string.IsNullOrWhiteSpace(package.Source) ? "unknown" : package.Source!,
+                string.IsNullOrWhiteSpace(package.LatestCompatibleVersion) ? null : package.LatestCompatibleVersion,
+                package.IsOutdated,
+                package.IsDeprecated,
+                package.IsPreview))
+            .ToList();
+
+        session.ProjectView.LastUpmPackages.Clear();
+        session.ProjectView.LastUpmPackages.AddRange(indexedPackages);
+
+        outputs.Add($"{indexedPackages.Count} package(s)");
+        if (indexedPackages.Count == 0)
+        {
+            outputs.Add("no packages matched the selected filters");
+            return true;
+        }
+
+        foreach (var package in indexedPackages)
+        {
+            var statusColor = ResolveUpmStatusColor(package);
+            var statusLabel = ResolveUpmStatusLabel(package);
+            var updateSuffix = package.IsOutdated && !string.IsNullOrWhiteSpace(package.LatestCompatibleVersion)
+                ? $" -> {package.LatestCompatibleVersion}"
+                : string.Empty;
+            outputs.Add(
+                $"[{package.Index}] {Markup.Escape(package.DisplayName)} ({Markup.Escape(package.PackageId)}) v{Markup.Escape(package.Version)}{Markup.Escape(updateSuffix)} [{CliTheme.TextSecondary}]{Markup.Escape(package.Source)}[/] [{statusColor}]{Markup.Escape(statusLabel)}[/]");
+        }
         return true;
     }
 
@@ -1174,4 +1366,22 @@ $"using UnityEngine;{Environment.NewLine}{Environment.NewLine}public class #NAME
 
         return tokens;
     }
+
+    private sealed record UpmListRequestPayload(
+        bool IncludeOutdated,
+        bool IncludeBuiltin,
+        bool IncludeGit);
+
+    private sealed record UpmListResponsePayload(
+        List<UpmListPackagePayload>? Packages);
+
+    private sealed record UpmListPackagePayload(
+        string? PackageId,
+        string? DisplayName,
+        string? Version,
+        string? Source,
+        string? LatestCompatibleVersion,
+        bool IsOutdated,
+        bool IsDeprecated,
+        bool IsPreview);
 }


### PR DESCRIPTION
## Summary
- Add `/upm list` command wiring from CLI to Unity bridge using UPM API package data.
- Add immediate loading feedback while package info is fetched to avoid a frozen-looking screen.
- Simplify `/upm list` output by removing noisy labels and status clutter.
- Add status-aware package labels (`deprecated`, `update available`, `preview`, `stable`) with theme-aligned colors.
- Extend project command response payload to carry optional structured content from Unity bridge.
- Fix `PackageInfo` ambiguity by explicitly aliasing `UnityEditor.PackageManager.PackageInfo`.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Program.cs`
  - `src/unifocl/Services/ProjectViewService.cs`
  - `src/unifocl/Services/ProjectCommandRouterService.cs`
  - `src/unifocl/Services/HierarchyDaemonClient.cs`
  - `src/unifocl/Services/ProjectDaemonBridge.cs`
  - `src/unifocl/Models/ProjectBridgeModels.cs`
  - `src/unifocl/Models/ProjectViewModels.cs`
  - `src/unifocl/Models/CliSessionState.cs`
  - `src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs`
  - `src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs`
- Out-of-scope / intentionally not addressed:
  - `/upm install`, `/upm remove`, `/upm update`, `/upm resolve`, `/upm reimport`

## How to Test
1. Run `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`.
2. Open a Unity project through the CLI and run `upm list`.
3. Run `upm list --outdated`, `upm list --builtin`, and `upm list --git`.
4. Confirm package rows are indexed, human-readable, and status-colored.

Expected results:
- Build succeeds.
- CLI shows immediate loading feedback while fetching package info.
- Output is concise and status-based without noisy `[i]` labels.

## Screenshots / Terminal Output (if applicable)
- Build: success (`0 errors`, NU1900 feed warnings only).

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No credentials, tokens, or secrets added. Changes are limited to CLI/bridge command handling and formatting.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
