### PR TITLE
Fix UPM list rendering consistency and output format

### DIFF
--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -2,7 +2,7 @@ internal static class CliVersion
 {
     public const int Major = 0;
     public const int Minor = 2;
-    public const int Patch = 5;
+    public const int Patch = 8;
     public const string Protocol = "v2";
 
     public static string SemVer => $"{Major}.{Minor}.{Patch}";

--- a/src/unifocl/Services/ProjectViewRenderer.cs
+++ b/src/unifocl/Services/ProjectViewRenderer.cs
@@ -1,4 +1,5 @@
 using Spectre.Console;
+using System.Text;
 
 internal sealed class ProjectViewRenderer
 {
@@ -30,7 +31,7 @@ internal sealed class ProjectViewRenderer
         lines.Add(BorderSeparator(frameWidth));
         var contentWidth = Math.Max(1, frameWidth - 1);
         var wrappedTranscript = state.CommandTranscript
-            .SelectMany(line => TuiTextWrap.WrapPlainText(line, contentWidth))
+            .SelectMany(line => WrapTranscriptLine(line, contentWidth))
             .ToList();
         var recent = wrappedTranscript
             .Skip(Math.Max(0, wrappedTranscript.Count - CommandRows))
@@ -119,6 +120,144 @@ internal sealed class ProjectViewRenderer
         {
             return Markup.Escape(Fit(markup, width));
         }
+    }
+
+    private static IReadOnlyList<string> WrapTranscriptLine(string line, int width)
+    {
+        if (string.IsNullOrEmpty(line))
+        {
+            return [string.Empty];
+        }
+
+        var safeWidth = Math.Max(1, width);
+        var normalized = line
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+        var logicalLines = normalized.Split('\n');
+        var wrapped = new List<string>();
+        foreach (var logicalLine in logicalLines)
+        {
+            wrapped.AddRange(WrapMarkupLine(logicalLine, safeWidth));
+        }
+
+        return wrapped.Count == 0 ? [string.Empty] : wrapped;
+    }
+
+    private static IReadOnlyList<string> WrapMarkupLine(string markup, int width)
+    {
+        if (string.IsNullOrEmpty(markup))
+        {
+            return [string.Empty];
+        }
+
+        var lines = new List<string>();
+        var current = new StringBuilder();
+        var activeTags = new List<string>();
+        var currentPlainLength = 0;
+
+        void StartNewLine()
+        {
+            var next = new StringBuilder();
+            foreach (var tag in activeTags)
+            {
+                next.Append('[').Append(tag).Append(']');
+            }
+
+            current = next;
+            currentPlainLength = 0;
+        }
+
+        void FlushLineAndContinue()
+        {
+            for (var i = activeTags.Count - 1; i >= 0; i--)
+            {
+                current.Append("[/]");
+            }
+
+            lines.Add(current.ToString());
+            StartNewLine();
+        }
+
+        void AppendLiteral(char ch)
+        {
+            if (currentPlainLength >= width)
+            {
+                FlushLineAndContinue();
+            }
+
+            if (ch == '[')
+            {
+                current.Append("[[");
+            }
+            else if (ch == ']')
+            {
+                current.Append("]]");
+            }
+            else
+            {
+                current.Append(ch);
+            }
+
+            currentPlainLength++;
+        }
+
+        for (var i = 0; i < markup.Length; i++)
+        {
+            var ch = markup[i];
+            if (ch != '[')
+            {
+                AppendLiteral(ch);
+                continue;
+            }
+
+            if (i + 1 < markup.Length && markup[i + 1] == '[')
+            {
+                AppendLiteral('[');
+                i++;
+                continue;
+            }
+
+            var close = markup.IndexOf(']', i + 1);
+            if (close < 0)
+            {
+                AppendLiteral('[');
+                continue;
+            }
+
+            var token = markup.Substring(i + 1, close - i - 1);
+            if (token == "/")
+            {
+                if (activeTags.Count > 0)
+                {
+                    activeTags.RemoveAt(activeTags.Count - 1);
+                }
+
+                current.Append("[/]");
+                i = close;
+                continue;
+            }
+
+            if (token.Length == 0)
+            {
+                AppendLiteral('[');
+                continue;
+            }
+
+            activeTags.Add(token);
+            current.Append('[').Append(token).Append(']');
+            i = close;
+        }
+
+        if (current.Length == 0)
+        {
+            lines.Add(string.Empty);
+        }
+        else
+        {
+            lines.Add(current.ToString());
+        }
+
+        return lines;
     }
 
     private static int ResolveFrameWidth()

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -1072,11 +1072,8 @@ internal sealed class ProjectViewService
         {
             var statusColor = ResolveUpmStatusColor(package);
             var statusLabel = ResolveUpmStatusLabel(package);
-            var updateSuffix = package.IsOutdated && !string.IsNullOrWhiteSpace(package.LatestCompatibleVersion)
-                ? $" -> {package.LatestCompatibleVersion}"
-                : string.Empty;
             outputs.Add(
-                $"[{package.Index}] {Markup.Escape(package.DisplayName)} ({Markup.Escape(package.PackageId)}) v{Markup.Escape(package.Version)}{Markup.Escape(updateSuffix)} [{CliTheme.TextSecondary}]{Markup.Escape(package.Source)}[/] [{statusColor}]{Markup.Escape(statusLabel)}[/]");
+                $"[{CliTheme.TextSecondary}]{package.Index}.[/] {Markup.Escape(package.DisplayName)} ({Markup.Escape(package.PackageId)}) v{Markup.Escape(package.Version)} [{CliTheme.TextSecondary}]{Markup.Escape(package.Source)}[/] [{statusColor}]{Markup.Escape(statusLabel)}[/]");
         }
         return true;
     }


### PR DESCRIPTION
## Summary
- Fix inconsistent `/upm list` transcript rendering in the project TUI by introducing markup-aware line wrapping that preserves Spectre styles across wrapped lines.
- Prevent literal markup/tag artifacts in package list rows and keep visual styling stable in narrow terminal widths.
- Simplify package output for outdated packages to show only current version plus update state label, without printing target update version.
- Bump CLI patch version to `0.2.8`.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
- `src/unifocl/Services/ProjectViewRenderer.cs`
- `src/unifocl/Services/ProjectViewService.cs`
- `src/unifocl/Services/CliVersion.cs`
- Out-of-scope / intentionally not addressed:
- No changes to Unity-side bridge payload or protocol contracts.

## How to Test
1. Build CLI: `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Open a project and run `upm list` in project mode.
3. Resize terminal to narrow width and confirm list rows wrap cleanly while keeping status/source coloring.

Expected results:
- `/upm list` rows wrap by width without style loss or literal tag artifacts.
- Outdated packages show state (for example `update available`) but do not include `-> <latest-version>`.
- CLI reports version `0.2.8`.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Changes are limited to local TUI rendering and CLI output formatting.

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [x] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
