### PR TITLE
Build UX hardening for v0.3.0 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## 0.3.0 - 2026-03-06
+
+### Added
+- New `/build` command suite and aliases:
+  - `/build run [target] [--dev] [--debug] [--clean] [--path <output-path>]`
+  - `/build exec <Method>`
+  - `/build scenes`
+  - `/build addressables [--clean] [--update]`
+  - `/build cancel`
+  - `/build targets`
+  - `/build logs`
+  - Aliases: `/b`, `/bx`, `/ba`
+- Interactive build-target selection when target is omitted.
+- Target install-then-build flow for missing modules.
+- Build target caching (refresh on explicit install flow).
+- In-terminal live build monitor with pinned status/log header.
+- Restartable build log tail and cancelled-build log snapshot view.
+- Build diagnostics expansion:
+  - heartbeat and stall hints
+  - last diagnostic / last exception reporting
+  - log file path shown in monitor and summary
+
+### Changed
+- Build cancellation now performs daemon teardown and returns to Project mode after keypress.
+- Build output routing now supports explicit `--path`.
+- Default build outputs are isolated in timestamped folders to avoid artifact collisions.
+- Main-thread dispatch safety improved for build execution and daemon stop paths.
+- Added spinner/status UX for heavy build-related steps.
+
+### Fixed
+- Resolved Unity main-thread violation during daemon stop (`EditorApplication.Exit` off main thread).
+- Improved resilience for detach/reattach with ongoing builds.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ These commands manage your session, project loading, and CLI configuration. They
 | `/recent [idx]` | | List recent projects or open one by index. |
 | `/config <get/set/list/reset>`| `/cfg` | Manage CLI preferences (e.g., themes). |
 | `/status` | `/st` | Show daemon, mode, editor, project, and session status summary. |
+| `/build run [target] [--dev] [--debug] [--clean] [--path <output-path>]` | `/b` | Trigger a Unity player build. If target is omitted, choose from an interactive target selector. |
+| `/build exec <Method>` | `/bx` | Execute a static build method (e.g., `CI.Builder.BuildAndroidProd`). |
+| `/build scenes` | | Open an interactive TUI to view, toggle, and reorder build scenes. |
+| `/build addressables [--clean] [--update]` | `/ba` | Trigger an Addressables content build (full or update mode). |
+| `/build cancel` | | Request cancellation for the active build process via daemon. |
+| `/build targets` | | List platform build support currently available in this Unity Editor. |
+| `/build logs` | | Reopen live build log tail (restartable, with error filtering). |
 | `/init [path]` | | Generate bridge-mode config and install editor-side dependencies. |
 | `/clear` | | Clear and redraw the boot screen and log. |
 | `/help [topic]` | `/?` | Show help by topic. |

--- a/src/unifocl.unity/EditorScripts/CLIDaemon.cs
+++ b/src/unifocl.unity/EditorScripts/CLIDaemon.cs
@@ -43,6 +43,7 @@ namespace UniFocl.EditorBridge
         private static int _inactivityTtlSeconds;
         private static int _mainThreadManagedThreadId;
         private static readonly ConcurrentQueue<MainThreadWorkItem> _mainThreadWorkQueue = new();
+        private static readonly ConcurrentQueue<Action> _mainThreadActionQueue = new();
 
         public static bool HasDaemonServiceArg()
         {
@@ -166,7 +167,19 @@ namespace UniFocl.EditorBridge
                 if (request.HttpMethod.Equals("POST", StringComparison.OrdinalIgnoreCase) && path.Equals("/stop", StringComparison.OrdinalIgnoreCase))
                 {
                     await WriteTextResponseAsync(context.Response, "STOPPING");
-                    StopInternal(quitEditor: _isBatchMode);
+                    if (_isBatchMode
+                        && (_mainThreadManagedThreadId == 0 || Environment.CurrentManagedThreadId != _mainThreadManagedThreadId))
+                    {
+                        _ = await ExecuteOnMainThreadAsync(() =>
+                        {
+                            StopInternal(quitEditor: true);
+                            return "OK";
+                        });
+                    }
+                    else
+                    {
+                        StopInternal(quitEditor: _isBatchMode);
+                    }
                     return;
                 }
 
@@ -230,6 +243,24 @@ namespace UniFocl.EditorBridge
                     stopwatch.Stop();
                     Debug.Log($"[unifocl] project command completed: action={action}, elapsedMs={stopwatch.ElapsedMilliseconds}");
                     await WriteJsonResponseAsync(context.Response, response);
+                    return;
+                }
+
+                if (request.HttpMethod.Equals("GET", StringComparison.OrdinalIgnoreCase) && path.Equals("/build/status", StringComparison.OrdinalIgnoreCase))
+                {
+                    await WriteJsonResponseAsync(context.Response, DaemonProjectService.GetBuildStatusPayload());
+                    return;
+                }
+
+                if (request.HttpMethod.Equals("GET", StringComparison.OrdinalIgnoreCase) && path.Equals("/build/log", StringComparison.OrdinalIgnoreCase))
+                {
+                    var offsetRaw = request.QueryString["offset"];
+                    var limitRaw = request.QueryString["limit"];
+                    var errorsOnlyRaw = request.QueryString["errorsOnly"];
+                    _ = long.TryParse(offsetRaw, out var offset);
+                    _ = int.TryParse(limitRaw, out var limit);
+                    _ = bool.TryParse(errorsOnlyRaw, out var errorsOnly);
+                    await WriteJsonResponseAsync(context.Response, DaemonProjectService.ReadBuildLogPayload(offset, limit, errorsOnly));
                     return;
                 }
 
@@ -341,6 +372,10 @@ namespace UniFocl.EditorBridge
                 return;
             }
 
+            var wasBatchMode = _isBatchMode;
+            var isMainThread = _mainThreadManagedThreadId != 0
+                && Environment.CurrentManagedThreadId == _mainThreadManagedThreadId;
+
             _running = false;
             try
             {
@@ -361,8 +396,6 @@ namespace UniFocl.EditorBridge
             _cts?.Dispose();
             _cts = null;
             _listener = null;
-            _isBatchMode = false;
-            _mainThreadManagedThreadId = 0;
 
             EditorApplication.update -= OnEditorUpdate;
 
@@ -370,8 +403,28 @@ namespace UniFocl.EditorBridge
 
             if (quitEditor)
             {
-                EditorApplication.Exit(0);
+                RequestEditorExit(wasBatchMode, isMainThread);
             }
+
+            _isBatchMode = false;
+            _mainThreadManagedThreadId = 0;
+        }
+
+        private static void RequestEditorExit(bool wasBatchMode, bool isMainThread)
+        {
+            if (isMainThread)
+            {
+                EditorApplication.Exit(0);
+                return;
+            }
+
+            if (wasBatchMode)
+            {
+                Environment.Exit(0);
+                return;
+            }
+
+            EditorApplication.delayCall += () => EditorApplication.Exit(0);
         }
 
         private static Task<string> ExecuteOnMainThreadAsync(Func<string> work)
@@ -415,6 +468,18 @@ namespace UniFocl.EditorBridge
 
         private static void DrainMainThreadWorkQueue()
         {
+            while (_mainThreadActionQueue.TryDequeue(out var action))
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"[unifocl] main-thread action failed: {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+
             while (_mainThreadWorkQueue.TryDequeue(out var item))
             {
                 try
@@ -431,10 +496,48 @@ namespace UniFocl.EditorBridge
         private static void FailPendingMainThreadWork()
         {
             var ex = new InvalidOperationException("CLI daemon stopped before main-thread work could execute");
+            while (_mainThreadActionQueue.TryDequeue(out _))
+            {
+            }
+
             while (_mainThreadWorkQueue.TryDequeue(out var item))
             {
                 item.Completion.TrySetException(ex);
             }
+        }
+
+        internal static void DispatchOnMainThread(Action action)
+        {
+            if (action is null)
+            {
+                return;
+            }
+
+            var isMainThread = _mainThreadManagedThreadId != 0
+                && Environment.CurrentManagedThreadId == _mainThreadManagedThreadId;
+            if (isMainThread)
+            {
+                action();
+                return;
+            }
+
+            if (_isBatchMode)
+            {
+                _mainThreadActionQueue.Enqueue(action);
+                return;
+            }
+
+            EditorApplication.delayCall += () =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"[unifocl] delayed main-thread action failed: {ex.GetType().Name}: {ex.Message}");
+                }
+            };
         }
 
         internal static void MarkAssetIndexDirty() => DaemonAssetIndexService.MarkDirty();

--- a/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
@@ -3,7 +3,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
 using UnityEditor;
+using UnityEditor.Build.Reporting;
 using UnityEditor.PackageManager;
 using UnityEditor.SceneManagement;
 using UnityEngine;
@@ -14,8 +18,21 @@ namespace UniFocl.EditorBridge
 {
     internal static class DaemonProjectService
     {
+        private static readonly object BuildStateLock = new();
+        private static readonly Regex PercentRegex = new(@"(?<!\d)(\d{1,3})\s*%", RegexOptions.Compiled);
+        private static BuildRuntimeState _buildState = new();
+        private static int _unityMainThreadId;
+        private static bool _buildInProgress;
+        private static bool _cancelRequested;
+        private static string _activeBuildAction = string.Empty;
+
         public static string Execute(string payload)
         {
+            if (_unityMainThreadId == 0)
+            {
+                _unityMainThreadId = Environment.CurrentManagedThreadId;
+            }
+
             ProjectCommandRequest? request;
             try
             {
@@ -41,6 +58,13 @@ namespace UniFocl.EditorBridge
                     "remove-asset" => ExecuteRemoveAsset(request),
                     "load-asset" => ExecuteLoadAsset(request),
                     "upm-list" => ExecuteUpmList(request),
+                    "build-run" => ExecuteBuildRun(request),
+                    "build-exec" => ExecuteBuildExec(request),
+                    "build-scenes-get" => ExecuteBuildScenesGet(),
+                    "build-scenes-set" => ExecuteBuildScenesSet(request),
+                    "build-addressables" => ExecuteBuildAddressables(request),
+                    "build-cancel" => ExecuteBuildCancel(),
+                    "build-targets" => ExecuteBuildTargets(),
                     _ => JsonUtility.ToJson(new ProjectCommandResponse { ok = false, message = $"unsupported action: {request.action}" })
                 };
             }
@@ -52,6 +76,87 @@ namespace UniFocl.EditorBridge
                     message = $"project command exception: {ex.GetType().Name}: {ex.Message}"
                 });
             }
+        }
+
+        public static string GetBuildStatusPayload()
+        {
+            lock (BuildStateLock)
+            {
+                return JsonUtility.ToJson(new BuildStatusResponse
+                {
+                    running = _buildState.running,
+                    cancelRequested = _buildState.cancelRequested,
+                    progress01 = _buildState.progress01,
+                    step = _buildState.step,
+                    kind = _buildState.kind,
+                    logPath = _buildState.logPath,
+                    outputPath = _buildState.outputPath,
+                    startedAtUtc = _buildState.startedAtUtc,
+                    finishedAtUtc = _buildState.finishedAtUtc,
+                    success = _buildState.success,
+                    message = _buildState.message,
+                    lastHeartbeatUtc = _buildState.lastHeartbeatUtc,
+                    lastDiagnostic = _buildState.lastDiagnostic,
+                    lastException = _buildState.lastException
+                });
+            }
+        }
+
+        public static string ReadBuildLogPayload(long offset, int limit, bool errorsOnly)
+        {
+            string? logPath;
+            lock (BuildStateLock)
+            {
+                logPath = _buildState.logPath;
+            }
+
+            if (string.IsNullOrWhiteSpace(logPath) || !File.Exists(logPath))
+            {
+                return JsonUtility.ToJson(new BuildLogChunkResponse
+                {
+                    nextOffset = Math.Max(0, offset),
+                    lines = Array.Empty<BuildLogLine>()
+                });
+            }
+
+            var safeOffset = Math.Max(0, offset);
+            var safeLimit = Math.Clamp(limit, 1, 400);
+            var lines = new List<BuildLogLine>(safeLimit);
+            long nextOffset = safeOffset;
+            using (var stream = new FileStream(logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                if (safeOffset > stream.Length)
+                {
+                    safeOffset = stream.Length;
+                }
+
+                stream.Seek(safeOffset, SeekOrigin.Begin);
+                using var reader = new StreamReader(stream, Encoding.UTF8);
+                while (!reader.EndOfStream && lines.Count < safeLimit)
+                {
+                    var line = reader.ReadLine();
+                    if (line is null)
+                    {
+                        continue;
+                    }
+
+                    var parsed = ParseLogLine(line);
+                    if (errorsOnly && !parsed.level.Equals("error", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    lines.Add(parsed);
+                }
+
+                nextOffset = stream.Position;
+            }
+
+            return JsonUtility.ToJson(new BuildLogChunkResponse
+            {
+                nextOffset = nextOffset,
+                lines = lines.ToArray()
+            });
         }
 
         private static string ExecuteCreateScript(ProjectCommandRequest request)
@@ -268,6 +373,1182 @@ namespace UniFocl.EditorBridge
                 kind = "upm-list",
                 content = payload
             });
+        }
+
+        private static string ExecuteBuildRun(ProjectCommandRequest request)
+        {
+            if (_buildInProgress)
+            {
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = $"build is already running: {_activeBuildAction}"
+                });
+            }
+
+            BuildRunRequestOptions? options;
+            try
+            {
+                options = JsonUtility.FromJson<BuildRunRequestOptions>(request.content);
+            }
+            catch
+            {
+                options = null;
+            }
+
+            if (options is null || string.IsNullOrWhiteSpace(options.target))
+            {
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = "build-run requires target"
+                });
+            }
+
+            if (!TryParseBuildTarget(options.target, out var buildTarget))
+            {
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = $"unsupported build target: {options.target}"
+                });
+            }
+
+            StartBackgroundBuild("run", () => RunBuildRun(buildTarget, options));
+            return JsonUtility.ToJson(new ProjectCommandResponse
+            {
+                ok = true,
+                message = $"build queued for {buildTarget}",
+                kind = "build-run",
+                content = JsonUtility.ToJson(new BuildOperationContent
+                {
+                    summary = "background build started",
+                    details = Array.Empty<string>()
+                })
+            });
+        }
+
+        private static string ExecuteBuildExec(ProjectCommandRequest request)
+        {
+            if (_buildInProgress)
+            {
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = $"build is already running: {_activeBuildAction}"
+                });
+            }
+
+            BuildExecRequestOptions? options;
+            try
+            {
+                options = JsonUtility.FromJson<BuildExecRequestOptions>(request.content);
+            }
+            catch
+            {
+                options = null;
+            }
+
+            if (options is null || string.IsNullOrWhiteSpace(options.method))
+            {
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = "build-exec requires method"
+                });
+            }
+
+            StartBackgroundBuild("exec", () =>
+            {
+                var signature = options.method.Trim();
+                var separator = signature.LastIndexOf('.');
+                if (separator <= 0 || separator >= signature.Length - 1)
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = "method must be in form Namespace.Type.Method"
+                    });
+                }
+
+                var typeName = signature[..separator];
+                var methodName = signature[(separator + 1)..];
+                var targetType = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .Select(assembly => assembly.GetType(typeName, throwOnError: false, ignoreCase: false))
+                    .FirstOrDefault(type => type is not null);
+                if (targetType is null)
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = $"type not found: {typeName}"
+                    });
+                }
+
+                var method = targetType.GetMethod(
+                    methodName,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+                    binder: null,
+                    types: Type.EmptyTypes,
+                    modifiers: null);
+                if (method is null)
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = $"static parameterless method not found: {signature}"
+                    });
+                }
+
+                try
+                {
+                    method.Invoke(null, null);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    var inner = ex.InnerException ?? ex;
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = $"method threw: {inner.GetType().Name}: {inner.Message}"
+                    });
+                }
+
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = true,
+                    message = $"executed build method: {signature}",
+                    kind = "build-exec",
+                    content = JsonUtility.ToJson(new BuildOperationContent
+                    {
+                        summary = $"method={signature}",
+                        details = Array.Empty<string>()
+                    })
+                });
+            });
+            return JsonUtility.ToJson(new ProjectCommandResponse
+            {
+                ok = true,
+                message = $"build method queued: {options.method}",
+                kind = "build-exec"
+            });
+        }
+
+        private static string ExecuteBuildScenesGet()
+        {
+            var scenes = EditorBuildSettings.scenes
+                .Select((scene, index) => new BuildSceneEntry
+                {
+                    path = scene.path ?? string.Empty,
+                    enabled = scene.enabled,
+                    order = index
+                })
+                .ToArray();
+            return JsonUtility.ToJson(new ProjectCommandResponse
+            {
+                ok = true,
+                message = "build scenes loaded",
+                kind = "build-scenes",
+                content = JsonUtility.ToJson(new BuildScenesResponse { scenes = scenes })
+            });
+        }
+
+        private static string ExecuteBuildScenesSet(ProjectCommandRequest request)
+        {
+            BuildScenesUpdateRequest? payload;
+            try
+            {
+                payload = JsonUtility.FromJson<BuildScenesUpdateRequest>(request.content);
+            }
+            catch
+            {
+                payload = null;
+            }
+
+            if (payload?.scenes is null || payload.scenes.Length == 0)
+            {
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = "build-scenes-set requires scenes"
+                });
+            }
+
+            var updated = new List<EditorBuildSettingsScene>(payload.scenes.Length);
+            for (var i = 0; i < payload.scenes.Length; i++)
+            {
+                var scene = payload.scenes[i];
+                var path = (scene.path ?? string.Empty).Replace('\\', '/');
+                if (!IsValidAssetPath(path) || !path.EndsWith(".unity", StringComparison.OrdinalIgnoreCase))
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = $"invalid scene path: {path}"
+                    });
+                }
+
+                if (!File.Exists(Path.Combine(GetProjectRoot(), path.Replace('/', Path.DirectorySeparatorChar))))
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = $"scene file not found: {path}"
+                    });
+                }
+
+                updated.Add(new EditorBuildSettingsScene(path, scene.enabled));
+            }
+
+            EditorBuildSettings.scenes = updated.ToArray();
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
+            return JsonUtility.ToJson(new ProjectCommandResponse
+            {
+                ok = true,
+                message = "build scenes updated",
+                kind = "build-scenes",
+                content = JsonUtility.ToJson(new BuildOperationContent
+                {
+                    summary = $"{updated.Count} scene(s) saved",
+                    details = Array.Empty<string>()
+                })
+            });
+        }
+
+        private static string ExecuteBuildAddressables(ProjectCommandRequest request)
+        {
+            if (_buildInProgress)
+            {
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = $"build is already running: {_activeBuildAction}"
+                });
+            }
+
+            BuildAddressablesRequestOptions? options;
+            try
+            {
+                options = JsonUtility.FromJson<BuildAddressablesRequestOptions>(request.content);
+            }
+            catch
+            {
+                options = null;
+            }
+
+            options ??= new BuildAddressablesRequestOptions();
+            StartBackgroundBuild("addressables", () =>
+            {
+                var details = new List<string>();
+                var editorAssembly = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .FirstOrDefault(assembly =>
+                        string.Equals(assembly.GetName().Name, "Unity.Addressables.Editor", StringComparison.Ordinal));
+                if (editorAssembly is null)
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = "Addressables editor assembly is not loaded (install com.unity.addressables)"
+                    });
+                }
+
+                var settingsDefaultType = editorAssembly.GetType("UnityEditor.AddressableAssets.Settings.AddressableAssetSettingsDefaultObject");
+                var settingsProperty = settingsDefaultType?.GetProperty("Settings", BindingFlags.Public | BindingFlags.Static);
+                var settings = settingsProperty?.GetValue(null);
+                if (settings is null)
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = "Addressables settings asset was not found"
+                    });
+                }
+
+                if (options.clean)
+                {
+                    var cleanMethod = settings.GetType().GetMethod("CleanPlayerContent", BindingFlags.Public | BindingFlags.Instance)
+                                      ?? settings.GetType().GetMethod("CleanPlayerContent", BindingFlags.Public | BindingFlags.Static);
+                    if (cleanMethod is not null)
+                    {
+                        cleanMethod.Invoke(cleanMethod.IsStatic ? null : settings, null);
+                        details.Add("cleaned Addressables player content");
+                    }
+                }
+
+                if (_cancelRequested)
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = "build cancelled before Addressables build started"
+                    });
+                }
+
+                if (options.update)
+                {
+                    var contentUpdateType = editorAssembly.GetType("UnityEditor.AddressableAssets.Build.ContentUpdateScript");
+                    var buildUpdateMethod = contentUpdateType?.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                        .FirstOrDefault(method => method.Name.Equals("BuildContentUpdate", StringComparison.Ordinal));
+                    if (buildUpdateMethod is null)
+                    {
+                        return JsonUtility.ToJson(new ProjectCommandResponse
+                        {
+                            ok = false,
+                            message = "Addressables content update API not found in this Unity version"
+                        });
+                    }
+
+                    var parameters = buildUpdateMethod.GetParameters();
+                    if (parameters.Length == 0)
+                    {
+                        buildUpdateMethod.Invoke(null, null);
+                    }
+                    else if (parameters.Length == 1 && parameters[0].ParameterType == typeof(string))
+                    {
+                        var contentStatePath = ResolveAddressablesContentStatePath(editorAssembly, settings);
+                        if (string.IsNullOrWhiteSpace(contentStatePath))
+                        {
+                            return JsonUtility.ToJson(new ProjectCommandResponse
+                            {
+                                ok = false,
+                                message = "Addressables content state file path was not found; run a full Addressables build first"
+                            });
+                        }
+
+                        buildUpdateMethod.Invoke(null, new object[] { contentStatePath });
+                    }
+                    else
+                    {
+                        return JsonUtility.ToJson(new ProjectCommandResponse
+                        {
+                            ok = false,
+                            message = "Addressables content update API signature is unsupported"
+                        });
+                    }
+
+                    details.Add("executed Addressables content update build");
+                }
+                else
+                {
+                    var buildMethod = settings.GetType().GetMethod("BuildPlayerContent", BindingFlags.Public | BindingFlags.Instance)
+                                      ?? settings.GetType().GetMethod("BuildPlayerContent", BindingFlags.Public | BindingFlags.Static);
+                    if (buildMethod is null)
+                    {
+                        return JsonUtility.ToJson(new ProjectCommandResponse
+                        {
+                            ok = false,
+                            message = "Addressables BuildPlayerContent API not found"
+                        });
+                    }
+
+                    buildMethod.Invoke(buildMethod.IsStatic ? null : settings, null);
+                    details.Add("executed Addressables full content build");
+                }
+
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = true,
+                    message = "Addressables build completed",
+                    kind = "build-addressables",
+                    content = JsonUtility.ToJson(new BuildOperationContent
+                    {
+                        summary = options.update ? "mode=update" : "mode=full",
+                        details = details.ToArray()
+                    })
+                });
+            });
+            return JsonUtility.ToJson(new ProjectCommandResponse
+            {
+                ok = true,
+                message = "Addressables build queued",
+                kind = "build-addressables"
+            });
+        }
+
+        private static string? ResolveAddressablesContentStatePath(Assembly editorAssembly, object settings)
+        {
+            var settingsType = settings.GetType();
+            var contentStateProperty = settingsType.GetProperty(
+                "ContentStateBuildPath",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+            if (contentStateProperty is not null)
+            {
+                var pathValue = contentStateProperty.GetValue(contentStateProperty.GetMethod?.IsStatic == true ? null : settings) as string;
+                if (!string.IsNullOrWhiteSpace(pathValue))
+                {
+                    return pathValue;
+                }
+            }
+
+            var contentUpdateType = editorAssembly.GetType("UnityEditor.AddressableAssets.Build.ContentUpdateScript");
+            var getter = contentUpdateType?.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .FirstOrDefault(method =>
+                    method.Name.Equals("GetContentStateDataPath", StringComparison.Ordinal)
+                    && method.ReturnType == typeof(string));
+            if (getter is null)
+            {
+                return null;
+            }
+
+            var parameters = getter.GetParameters();
+            if (parameters.Length == 0)
+            {
+                return getter.Invoke(null, null) as string;
+            }
+
+            if (parameters.Length == 1 && parameters[0].ParameterType == typeof(bool))
+            {
+                return getter.Invoke(null, new object[] { true }) as string;
+            }
+
+            return null;
+        }
+
+        private static string ExecuteBuildCancel()
+        {
+            _cancelRequested = true;
+            lock (BuildStateLock)
+            {
+                _buildState.cancelRequested = true;
+                _buildState.message = "cancel requested";
+            }
+            var cancelApplied = TryInvokeBuildPipelineCancel();
+            if (!_buildInProgress)
+            {
+                _cancelRequested = false;
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = true,
+                    message = "no build is currently running"
+                });
+            }
+
+            return JsonUtility.ToJson(new ProjectCommandResponse
+            {
+                ok = true,
+                message = cancelApplied
+                    ? $"cancel signal sent to active build: {_activeBuildAction}"
+                    : $"cancel requested for active build: {_activeBuildAction}"
+            });
+        }
+
+        private static string ExecuteBuildTargets()
+        {
+            var targets = new[]
+            {
+                BuildTarget.StandaloneWindows64,
+                BuildTarget.Android,
+                BuildTarget.iOS,
+                BuildTarget.WebGL,
+                BuildTarget.StandaloneOSX,
+                BuildTarget.StandaloneLinux64
+            };
+
+            var entries = targets
+                .Select(target => new BuildTargetEntry
+                {
+                    name = GetBuildTargetDisplayName(target),
+                    installed = BuildPipeline.IsBuildTargetSupported(BuildPipeline.GetBuildTargetGroup(target), target),
+                    note = target.ToString()
+                })
+                .ToArray();
+
+            return JsonUtility.ToJson(new ProjectCommandResponse
+            {
+                ok = true,
+                message = "build targets loaded",
+                kind = "build-targets",
+                content = JsonUtility.ToJson(new BuildTargetsResponse { targets = entries })
+            });
+        }
+
+        private static void StartBackgroundBuild(string action, Func<string> execute)
+        {
+            _buildInProgress = true;
+            _activeBuildAction = action;
+            _cancelRequested = false;
+            var logPath = PrepareBuildLogFilePath();
+            lock (BuildStateLock)
+            {
+                _buildState = new BuildRuntimeState
+                {
+                    running = true,
+                    cancelRequested = false,
+                    progress01 = 0.01f,
+                    step = "queued",
+                    kind = action,
+                    logPath = logPath,
+                    startedAtUtc = DateTime.UtcNow.ToString("O"),
+                    lastHeartbeatUtc = DateTime.UtcNow.ToString("O"),
+                    success = false,
+                    message = "queued"
+                };
+            }
+
+            Application.logMessageReceivedThreaded += OnUnityLog;
+            AppendBuildDiagnostic($"build action scheduled on main thread dispatcher (batch={Application.isBatchMode})");
+            CLIDaemon.DispatchOnMainThread(RunBackground);
+
+            void RunBackground()
+            {
+                if (!IsUnityMainThread())
+                {
+                    AppendBuildDiagnostic(
+                        $"background build callback arrived on non-main thread (current={Environment.CurrentManagedThreadId}, main={_unityMainThreadId}); rescheduling");
+                    CLIDaemon.DispatchOnMainThread(RunBackground);
+                    return;
+                }
+
+                string payload;
+                try
+                {
+                    UpdateBuildStatus(step: "running", progress: 0.05f, message: $"starting {action}");
+                    AppendBuildDiagnostic($"build action started: {action}");
+                    payload = execute();
+                }
+                catch (Exception ex)
+                {
+                    AppendBuildDiagnostic($"unhandled build exception: {ex.GetType().Name}: {ex.Message}", isError: true);
+                    if (!string.IsNullOrWhiteSpace(ex.StackTrace))
+                    {
+                        AppendBuildDiagnostic(ex.StackTrace, isError: true);
+                    }
+                    payload = JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = $"{action} failed: {ex.GetType().Name}: {ex.Message}",
+                        kind = $"build-{action}",
+                        content = JsonUtility.ToJson(new BuildOperationContent
+                        {
+                            summary = $"{action} failed with unhandled exception",
+                            details = new[]
+                            {
+                                $"{ex.GetType().FullName}: {ex.Message}",
+                                ex.StackTrace ?? string.Empty
+                            }
+                        })
+                    });
+                }
+                finally
+                {
+                    Application.logMessageReceivedThreaded -= OnUnityLog;
+                    _buildInProgress = false;
+                    _activeBuildAction = string.Empty;
+                    _cancelRequested = false;
+                }
+
+                ProjectCommandResponse parsed;
+                try
+                {
+                    parsed = JsonUtility.FromJson<ProjectCommandResponse>(payload) ?? new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = "build returned invalid response",
+                        kind = $"build-{action}"
+                    };
+                }
+                catch
+                {
+                    parsed = new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = "build returned invalid response",
+                        kind = $"build-{action}"
+                    };
+                }
+
+                var outputPath = TryExtractOutputPath(parsed.content);
+                lock (BuildStateLock)
+                {
+                    _buildState.running = false;
+                    _buildState.cancelRequested = false;
+                    _buildState.progress01 = 1f;
+                    _buildState.step = parsed.ok ? "completed" : "failed";
+                    _buildState.finishedAtUtc = DateTime.UtcNow.ToString("O");
+                    _buildState.success = parsed.ok;
+                    _buildState.message = parsed.message ?? string.Empty;
+                    _buildState.outputPath = outputPath;
+                    _buildState.lastHeartbeatUtc = DateTime.UtcNow.ToString("O");
+                }
+            }
+        }
+
+        private static string RunBuildRun(BuildTarget buildTarget, BuildRunRequestOptions options)
+        {
+            if (!IsUnityMainThread())
+            {
+                AppendBuildDiagnostic(
+                    $"build-run rejected: called off main thread (current={Environment.CurrentManagedThreadId}, main={_unityMainThreadId})",
+                    isError: true);
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = "build-run must execute on Unity main thread"
+                });
+            }
+
+            var buildStartedAt = DateTime.UtcNow;
+            try
+            {
+                AppendBuildDiagnostic($"build-run executing on main thread id={Environment.CurrentManagedThreadId}");
+                if (options.clean)
+                {
+                    UpdateBuildStatus(step: "cleaning caches", progress: 0.1f, message: "cleaning build caches");
+                    AppendBuildDiagnostic("cleaning build caches");
+                    CleanBuildCaches();
+                }
+
+                UpdateBuildStatus(step: "collecting scenes", progress: 0.15f, message: "collecting enabled scenes");
+                var enabledScenes = EditorBuildSettings.scenes
+                    .Where(scene => scene.enabled)
+                    .Select(scene => scene.path)
+                    .Where(path => !string.IsNullOrWhiteSpace(path))
+                    .ToArray();
+                AppendBuildDiagnostic($"enabled scene count: {enabledScenes.Length}");
+                if (enabledScenes.Length == 0)
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = "no enabled scenes in EditorBuildSettings"
+                    });
+                }
+
+                var buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
+                if (!BuildPipeline.IsBuildTargetSupported(buildTargetGroup, buildTarget))
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = $"build target module is not installed: {buildTarget}"
+                    });
+                }
+
+                var outputPath = ResolveBuildOutputPath(buildTarget, options.outputPath);
+                var buildOptions = BuildOptions.None;
+                if (options.development)
+                {
+                    buildOptions |= BuildOptions.Development;
+                }
+
+                if (options.scriptDebugging)
+                {
+                    buildOptions |= BuildOptions.AllowDebugging;
+                }
+
+                UpdateBuildStatus(step: "building player", progress: 0.25f, message: $"BuildPipeline.BuildPlayer({buildTarget})");
+                AppendBuildDiagnostic($"build target={buildTarget}, group={buildTargetGroup}, output={outputPath}, options={buildOptions}");
+
+                var result = BuildPipeline.BuildPlayer(new BuildPlayerOptions
+                {
+                    scenes = enabledScenes,
+                    target = buildTarget,
+                    locationPathName = outputPath,
+                    options = buildOptions
+                });
+                if (result is null)
+                {
+                    return JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = "Unity returned no build report"
+                    });
+                }
+
+                var summary = result.summary;
+                AppendBuildDiagnostic($"build summary result={summary.result}, warnings={summary.totalWarnings}, errors={summary.totalErrors}, output={summary.outputPath}");
+                var detail = JsonUtility.ToJson(new BuildOperationContent
+                {
+                    summary = $"target={buildTarget}, result={summary.result}, output={summary.outputPath}",
+                    details = new[]
+                    {
+                        $"duration={summary.totalTime.TotalSeconds:0.0}s",
+                        $"elapsed={(DateTime.UtcNow - buildStartedAt).TotalSeconds:0.0}s",
+                        $"size={summary.totalSize} bytes",
+                        $"warnings={summary.totalWarnings}, errors={summary.totalErrors}"
+                    }
+                });
+
+                return summary.result == BuildResult.Succeeded
+                    ? JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = true,
+                        message = $"build completed for {buildTarget}",
+                        kind = "build-run",
+                        content = detail
+                    })
+                    : JsonUtility.ToJson(new ProjectCommandResponse
+                    {
+                        ok = false,
+                        message = $"build failed for {buildTarget} ({summary.result})",
+                        kind = "build-run",
+                        content = detail
+                    });
+            }
+            catch (Exception ex)
+            {
+                AppendBuildDiagnostic($"build-run exception: {ex.GetType().Name}: {ex.Message}", isError: true);
+                if (!string.IsNullOrWhiteSpace(ex.StackTrace))
+                {
+                    AppendBuildDiagnostic(ex.StackTrace, isError: true);
+                }
+
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = $"build-run failed: {ex.GetType().Name}: {ex.Message}",
+                    kind = "build-run",
+                    content = JsonUtility.ToJson(new BuildOperationContent
+                    {
+                        summary = "build-run exception",
+                        details = new[]
+                        {
+                            $"{ex.GetType().FullName}: {ex.Message}",
+                            ex.StackTrace ?? string.Empty
+                        }
+                    })
+                });
+            }
+        }
+
+        private static bool TryInvokeBuildPipelineCancel()
+        {
+            try
+            {
+                var cancelMethod = typeof(BuildPipeline).GetMethod("CancelBuild", BindingFlags.Public | BindingFlags.Static);
+                if (cancelMethod is null)
+                {
+                    return false;
+                }
+
+                var result = cancelMethod.Invoke(null, null);
+                return result is bool isCanceled ? isCanceled : true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static bool TryParseBuildTarget(string rawTarget, out BuildTarget target)
+        {
+            var normalized = rawTarget.Replace("-", string.Empty, StringComparison.Ordinal)
+                .Replace("_", string.Empty, StringComparison.Ordinal)
+                .ToLowerInvariant();
+            target = normalized switch
+            {
+                "win64" or "windows64" or "standalonewindows64" => BuildTarget.StandaloneWindows64,
+                "android" => BuildTarget.Android,
+                "ios" => BuildTarget.iOS,
+                "webgl" => BuildTarget.WebGL,
+                "mac" or "macos" or "osx" or "standaloneosx" => BuildTarget.StandaloneOSX,
+                "linux" or "linux64" or "standalonelinux64" => BuildTarget.StandaloneLinux64,
+                _ => BuildTarget.NoTarget
+            };
+            return target != BuildTarget.NoTarget;
+        }
+
+        private static string GetBuildTargetDisplayName(BuildTarget target)
+        {
+            return target switch
+            {
+                BuildTarget.StandaloneWindows64 => "Win64",
+                BuildTarget.Android => "Android",
+                BuildTarget.iOS => "iOS",
+                BuildTarget.WebGL => "WebGL",
+                BuildTarget.StandaloneOSX => "macOS",
+                BuildTarget.StandaloneLinux64 => "Linux64",
+                _ => target.ToString()
+            };
+        }
+
+        private static void CleanBuildCaches()
+        {
+            DeleteDirectorySafe(Path.Combine(GetProjectRoot(), "Library", "Bee"));
+            DeleteDirectorySafe(Path.Combine(GetProjectRoot(), "Library", "Il2cppBuildCache"));
+            DeleteDirectorySafe(Path.Combine(GetProjectRoot(), "Build"));
+        }
+
+        private static void DeleteDirectorySafe(string path)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[unifocl] Failed to delete build cache path '{path}': {ex.Message}");
+            }
+        }
+
+        private static string ResolveBuildOutputPath(BuildTarget target, string? requestedOutputPath)
+        {
+            var projectRoot = GetProjectRoot();
+            var buildRoot = string.IsNullOrWhiteSpace(requestedOutputPath)
+                ? Path.Combine(projectRoot, "Build", GetBuildTargetDisplayName(target), DateTime.UtcNow.ToString("yyyyMMdd-HHmmss"))
+                : ResolveAbsolutePath(projectRoot, requestedOutputPath);
+            var productName = string.IsNullOrWhiteSpace(PlayerSettings.productName)
+                ? "UnityPlayer"
+                : PlayerSettings.productName;
+            var isDirectoryTarget = target is BuildTarget.iOS or BuildTarget.WebGL;
+
+            if (isDirectoryTarget)
+            {
+                Directory.CreateDirectory(buildRoot);
+                return buildRoot;
+            }
+
+            var extension = target switch
+            {
+                BuildTarget.StandaloneWindows64 => ".exe",
+                BuildTarget.Android => ".apk",
+                BuildTarget.StandaloneOSX => ".app",
+                BuildTarget.StandaloneLinux64 => string.Empty,
+                _ => string.Empty
+            };
+            var normalizedRoot = buildRoot.Replace('\\', '/');
+            var treatAsDirectory = string.IsNullOrWhiteSpace(Path.GetExtension(buildRoot))
+                                   || normalizedRoot.EndsWith("/", StringComparison.Ordinal)
+                                   || Directory.Exists(buildRoot);
+            if (treatAsDirectory)
+            {
+                Directory.CreateDirectory(buildRoot);
+                return Path.Combine(buildRoot, $"{productName}{extension}");
+            }
+
+            var directory = Path.GetDirectoryName(buildRoot);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            return buildRoot;
+        }
+
+        private static string ResolveAbsolutePath(string projectRoot, string path)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                return path;
+            }
+
+            return Path.GetFullPath(Path.Combine(projectRoot, path));
+        }
+
+        private static void OnUnityLog(string condition, string stackTrace, LogType type)
+        {
+            string? logPath;
+            string currentStep;
+            float currentProgress;
+            lock (BuildStateLock)
+            {
+                if (!_buildState.running)
+                {
+                    return;
+                }
+
+                logPath = _buildState.logPath;
+                currentStep = _buildState.step;
+                currentProgress = _buildState.progress01;
+            }
+
+            if (string.IsNullOrWhiteSpace(logPath))
+            {
+                return;
+            }
+
+            var level = type switch
+            {
+                LogType.Error => "error",
+                LogType.Assert => "error",
+                LogType.Exception => "error",
+                LogType.Warning => "warning",
+                _ => "info"
+            };
+            var line = $"{DateTime.UtcNow:O}|{level}|{condition?.Replace(Environment.NewLine, " ").Replace('\n', ' ') ?? string.Empty}";
+            try
+            {
+                File.AppendAllText(logPath, line + Environment.NewLine, Encoding.UTF8);
+                if (!string.IsNullOrWhiteSpace(stackTrace) && level.Equals("error", StringComparison.OrdinalIgnoreCase))
+                {
+                    File.AppendAllText(logPath, $"{DateTime.UtcNow:O}|{level}|{stackTrace.Replace(Environment.NewLine, " ").Replace('\n', ' ')}{Environment.NewLine}", Encoding.UTF8);
+                }
+            }
+            catch
+            {
+            }
+
+            var lowered = condition?.ToLowerInvariant() ?? string.Empty;
+            var step = lowered.Contains("il2cpp", StringComparison.Ordinal) ? "Compiling IL2CPP"
+                : lowered.Contains("shader", StringComparison.Ordinal) ? "Compiling shaders"
+                : lowered.Contains("addressable", StringComparison.Ordinal) ? "Building Addressables"
+                : lowered.Contains("build", StringComparison.Ordinal) ? "Building player"
+                : currentStep;
+
+            var progress = currentProgress;
+            var match = PercentRegex.Match(condition ?? string.Empty);
+            if (match.Success
+                && int.TryParse(match.Groups[1].Value, out var percent)
+                && percent >= 0
+                && percent <= 100)
+            {
+                progress = Math.Max(progress, percent / 100f);
+            }
+            else
+            {
+                progress = Math.Min(0.95f, progress + 0.002f);
+            }
+
+            UpdateBuildStatus(step, progress, condition ?? string.Empty);
+        }
+
+        private static void UpdateBuildStatus(string step, float progress, string message)
+        {
+            lock (BuildStateLock)
+            {
+                _buildState.step = string.IsNullOrWhiteSpace(step) ? _buildState.step : step;
+                _buildState.progress01 = Math.Clamp(progress, 0f, 1f);
+                _buildState.message = string.IsNullOrWhiteSpace(message) ? _buildState.message : message;
+                _buildState.lastHeartbeatUtc = DateTime.UtcNow.ToString("O");
+            }
+        }
+
+        private static bool IsUnityMainThread()
+        {
+            return _unityMainThreadId != 0
+                   && Environment.CurrentManagedThreadId == _unityMainThreadId;
+        }
+
+        private static void AppendBuildDiagnostic(string message, bool isError = false)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return;
+            }
+
+            string? logPath;
+            lock (BuildStateLock)
+            {
+                _buildState.lastDiagnostic = message.Length > 600 ? message[..600] : message;
+                if (isError)
+                {
+                    _buildState.lastException = _buildState.lastDiagnostic;
+                }
+
+                _buildState.lastHeartbeatUtc = DateTime.UtcNow.ToString("O");
+                logPath = _buildState.logPath;
+            }
+
+            if (string.IsNullOrWhiteSpace(logPath))
+            {
+                return;
+            }
+
+            var level = isError ? "error" : "info";
+            var normalized = message.Replace(Environment.NewLine, " ").Replace('\n', ' ').Replace('\r', ' ');
+            var line = $"{DateTime.UtcNow:O}|{level}|{normalized}";
+            try
+            {
+                File.AppendAllText(logPath, line + Environment.NewLine, Encoding.UTF8);
+            }
+            catch
+            {
+            }
+        }
+
+        private static string PrepareBuildLogFilePath()
+        {
+            var root = Path.Combine(GetProjectRoot(), ".unifocl", "logs");
+            Directory.CreateDirectory(root);
+            var filePath = Path.Combine(root, $"build-{DateTime.UtcNow:yyyyMMdd-HHmmss}.txt");
+            try
+            {
+                File.WriteAllText(filePath, string.Empty, Encoding.UTF8);
+            }
+            catch
+            {
+            }
+
+            return filePath;
+        }
+
+        private static string? TryExtractOutputPath(string? content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return null;
+            }
+
+            try
+            {
+                var parsed = JsonUtility.FromJson<BuildOperationContent>(content);
+                if (parsed is null || string.IsNullOrWhiteSpace(parsed.summary))
+                {
+                    return null;
+                }
+
+                var marker = "output=";
+                var index = parsed.summary.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+                if (index < 0)
+                {
+                    return null;
+                }
+
+                return parsed.summary[(index + marker.Length)..].Trim();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static BuildLogLine ParseLogLine(string rawLine)
+        {
+            if (string.IsNullOrWhiteSpace(rawLine))
+            {
+                return new BuildLogLine { level = "info", text = string.Empty };
+            }
+
+            var first = rawLine.IndexOf('|');
+            if (first < 0)
+            {
+                return new BuildLogLine { level = "info", text = rawLine };
+            }
+
+            var second = rawLine.IndexOf('|', first + 1);
+            if (second < 0)
+            {
+                return new BuildLogLine { level = "info", text = rawLine[(first + 1)..] };
+            }
+
+            var level = rawLine[(first + 1)..second];
+            var text = rawLine[(second + 1)..];
+            return new BuildLogLine
+            {
+                level = string.IsNullOrWhiteSpace(level) ? "info" : level,
+                text = text
+            };
+        }
+
+        [Serializable]
+        private sealed class BuildRunRequestOptions
+        {
+            public string target = string.Empty;
+            public bool development;
+            public bool scriptDebugging;
+            public bool clean;
+            public string outputPath = string.Empty;
+        }
+
+        [Serializable]
+        private sealed class BuildExecRequestOptions
+        {
+            public string method = string.Empty;
+        }
+
+        [Serializable]
+        private sealed class BuildAddressablesRequestOptions
+        {
+            public bool clean;
+            public bool update;
+        }
+
+        [Serializable]
+        private sealed class BuildOperationContent
+        {
+            public string summary = string.Empty;
+            public string[] details = Array.Empty<string>();
+        }
+
+        [Serializable]
+        private sealed class BuildSceneEntry
+        {
+            public string path = string.Empty;
+            public bool enabled;
+            public int order;
+        }
+
+        [Serializable]
+        private sealed class BuildScenesResponse
+        {
+            public BuildSceneEntry[] scenes = Array.Empty<BuildSceneEntry>();
+        }
+
+        [Serializable]
+        private sealed class BuildScenesUpdateRequest
+        {
+            public BuildSceneEntry[] scenes = Array.Empty<BuildSceneEntry>();
+        }
+
+        [Serializable]
+        private sealed class BuildTargetEntry
+        {
+            public string name = string.Empty;
+            public bool installed;
+            public string note = string.Empty;
+        }
+
+        [Serializable]
+        private sealed class BuildTargetsResponse
+        {
+            public BuildTargetEntry[] targets = Array.Empty<BuildTargetEntry>();
+        }
+
+        [Serializable]
+        private sealed class BuildStatusResponse
+        {
+            public bool running;
+            public bool cancelRequested;
+            public float progress01;
+            public string step = string.Empty;
+            public string kind = string.Empty;
+            public string logPath = string.Empty;
+            public string outputPath = string.Empty;
+            public string startedAtUtc = string.Empty;
+            public string finishedAtUtc = string.Empty;
+            public bool success;
+            public string message = string.Empty;
+            public string lastHeartbeatUtc = string.Empty;
+            public string lastDiagnostic = string.Empty;
+            public string lastException = string.Empty;
+        }
+
+        [Serializable]
+        private sealed class BuildLogChunkResponse
+        {
+            public long nextOffset;
+            public BuildLogLine[] lines = Array.Empty<BuildLogLine>();
+        }
+
+        [Serializable]
+        private sealed class BuildLogLine
+        {
+            public string level = string.Empty;
+            public string text = string.Empty;
+        }
+
+        private sealed class BuildRuntimeState
+        {
+            public bool running;
+            public bool cancelRequested;
+            public float progress01;
+            public string step = "idle";
+            public string kind = string.Empty;
+            public string logPath = string.Empty;
+            public string outputPath = string.Empty;
+            public string startedAtUtc = string.Empty;
+            public string finishedAtUtc = string.Empty;
+            public bool success;
+            public string message = "idle";
+            public string lastHeartbeatUtc = string.Empty;
+            public string lastDiagnostic = string.Empty;
+            public string lastException = string.Empty;
         }
 
         private static UpmListRequestOptions ParseUpmListOptions(string rawContent)

--- a/src/unifocl/Models/ProjectBridgeModels.cs
+++ b/src/unifocl/Models/ProjectBridgeModels.cs
@@ -9,3 +9,27 @@ internal sealed record ProjectCommandResponseDto(
     string Message,
     string? Kind,
     string? Content);
+
+internal sealed record BuildStatusDto(
+    bool Running,
+    bool CancelRequested,
+    float Progress01,
+    string Step,
+    string Kind,
+    string? LogPath,
+    string? OutputPath,
+    string? StartedAtUtc,
+    string? FinishedAtUtc,
+    bool Success,
+    string Message,
+    string? LastHeartbeatUtc,
+    string? LastDiagnostic,
+    string? LastException);
+
+internal sealed record BuildLogChunkDto(
+    long NextOffset,
+    List<BuildLogLineDto> Lines);
+
+internal sealed record BuildLogLineDto(
+    string Level,
+    string Text);

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -2,6 +2,11 @@ using Spectre.Console;
 using System.Text;
 
 var launchArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();
+if (BuildLogTailService.TryRunFromArgs(launchArgs))
+{
+    return;
+}
+
 if (DaemonControlService.TryParseDaemonServiceArgs(launchArgs, out var serviceOptions, out var daemonParseError))
 {
     if (daemonParseError is not null)
@@ -70,7 +75,18 @@ var commands = new List<CommandSpec>
     new("/protocol", "Show supported JSON schema capabilities", "/protocol"),
     new("/upm list [--outdated] [--builtin] [--git]", "List installed Unity packages (UPM)", "/upm list"),
     new("/upm ls [--outdated] [--builtin] [--git]", "Alias for /upm list", "/upm ls"),
-    new("/upm", "Unity Package Manager commands", "/upm")
+    new("/upm", "Unity Package Manager commands", "/upm"),
+    new("/build <run|exec|scenes|addressables|cancel|targets>", "Build pipeline commands", "/build"),
+    new("/build run [target] [--dev] [--debug] [--clean] [--path <output-path>]", "Run Unity build for target (prompts when omitted)", "/build run"),
+    new("/build exec <Method>", "Execute static build method (e.g., CI.Builder.BuildAndroidProd)", "/build exec"),
+    new("/build scenes", "Open interactive scene build-settings TUI", "/build scenes"),
+    new("/build addressables [--clean] [--update]", "Build Addressables content", "/build addressables"),
+    new("/build cancel", "Request cancellation of an ongoing build", "/build cancel"),
+    new("/build targets", "List installed Unity build support targets", "/build targets"),
+    new("/build logs", "Open restartable build log tail viewer", "/build logs"),
+    new("/b [target] [--dev] [--debug] [--clean] [--path <output-path>]", "Alias for /build run", "/b"),
+    new("/bx <Method>", "Alias for /build exec", "/bx"),
+    new("/ba [--clean] [--update]", "Alias for /build addressables", "/ba")
 };
 
 var projectCommands = new List<CommandSpec>
@@ -97,7 +113,17 @@ var projectCommands = new List<CommandSpec>
     new("move <...>", "Move/reorder item in active mode", "move"),
     new("mv <...>", "Alias for move", "mv"),
     new("upm list [--outdated] [--builtin] [--git]", "List installed Unity packages (UPM)", "upm list"),
-    new("upm ls [--outdated] [--builtin] [--git]", "Alias for upm list", "upm ls")
+    new("upm ls [--outdated] [--builtin] [--git]", "Alias for upm list", "upm ls"),
+    new("build run [target] [--dev] [--debug] [--clean] [--path <output-path>]", "Run Unity build for target", "build run"),
+    new("build exec <Method>", "Execute static build method", "build exec"),
+    new("build scenes", "Open interactive scene build-settings TUI", "build scenes"),
+    new("build addressables [--clean] [--update]", "Build Addressables content", "build addressables"),
+    new("build cancel", "Request cancellation of an ongoing build", "build cancel"),
+    new("build targets", "List installed Unity build support targets", "build targets"),
+    new("build logs", "Open restartable build log tail viewer", "build logs"),
+    new("b [target] [--dev] [--debug] [--clean] [--path <output-path>]", "Alias for build run", "b"),
+    new("bx <Method>", "Alias for build exec", "bx"),
+    new("ba [--clean] [--update]", "Alias for build addressables", "ba")
 };
 
 var streamLog = new List<string>();
@@ -108,6 +134,7 @@ var daemonControlService = new DaemonControlService();
 var projectLifecycleService = new ProjectLifecycleService();
 var projectCommandRouterService = new ProjectCommandRouterService();
 var hierarchyTui = new HierarchyTui();
+var buildCommandService = new BuildCommandService();
 SeedBootLog(streamLog);
 RenderInitialLog(streamLog);
 
@@ -163,6 +190,17 @@ while (true)
 
         if (!input.StartsWith('/'))
         {
+            if (TryNormalizeProjectBuildCommand(input, out var normalizedBuildInput))
+            {
+                await buildCommandService.HandleBuildCommandAsync(
+                    normalizedBuildInput,
+                    session,
+                    daemonControlService,
+                    daemonRuntime,
+                    line => AppendLog(streamLog, line));
+                continue;
+            }
+
             var handledProjectCommand = await projectCommandRouterService.TryHandleProjectCommandAsync(
                 input,
                 session,
@@ -303,6 +341,17 @@ while (true)
             continue;
         }
 
+        if (matched.Trigger.StartsWith("/build", StringComparison.Ordinal))
+        {
+            await buildCommandService.HandleBuildCommandAsync(
+                input,
+                session,
+                daemonControlService,
+                daemonRuntime,
+                line => AppendLog(streamLog, line));
+            continue;
+        }
+
         if (matched.Trigger is "/keybinds" or "/shortcuts")
         {
             WriteKeybindsHelp(streamLog, session);
@@ -333,6 +382,12 @@ while (true)
                 session,
                 line => AppendLog(streamLog, line),
                 streamLog);
+            if (matched.Trigger == "/daemon attach")
+            {
+                await buildCommandService.NotifyAttachedBuildIfAnyAsync(
+                    session,
+                    line => AppendLog(streamLog, line));
+            }
             continue;
         }
         if (await projectLifecycleService.TryHandleLifecycleCommandAsync(
@@ -1211,6 +1266,9 @@ static string NormalizeSlashCommand(string input)
         "/p" => "/project",
         "/h" => "/hierarchy",
         "/i" => "/inspect",
+        "/b" => "/build run",
+        "/bx" => "/build exec",
+        "/ba" => "/build addressables",
         "/exit" => "/quit",
         _ => commandToken
     };
@@ -1226,6 +1284,36 @@ static CommandSpec? MatchCommand(string input, List<CommandSpec> commands)
         .OrderByDescending(c => c.Trigger.Length)
         .FirstOrDefault(c => normalized == c.Trigger
                              || normalized.StartsWith(c.Trigger + " ", StringComparison.OrdinalIgnoreCase));
+}
+
+static bool TryNormalizeProjectBuildCommand(string input, out string normalizedBuildInput)
+{
+    normalizedBuildInput = string.Empty;
+    var trimmed = input.Trim();
+    if (string.IsNullOrWhiteSpace(trimmed))
+    {
+        return false;
+    }
+
+    var commandEnd = trimmed.IndexOf(' ');
+    var head = commandEnd >= 0 ? trimmed[..commandEnd] : trimmed;
+    var tail = commandEnd >= 0 ? trimmed[commandEnd..] : string.Empty;
+    var normalizedHead = head.ToLowerInvariant() switch
+    {
+        "build" => "/build",
+        "b" => "/build run",
+        "bx" => "/build exec",
+        "ba" => "/build addressables",
+        _ => string.Empty
+    };
+
+    if (string.IsNullOrWhiteSpace(normalizedHead))
+    {
+        return false;
+    }
+
+    normalizedBuildInput = normalizedHead + tail;
+    return true;
 }
 
 static void AppendLog(List<string> streamLog, string line)

--- a/src/unifocl/Services/BuildCommandService.cs
+++ b/src/unifocl/Services/BuildCommandService.cs
@@ -1,0 +1,1318 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using Spectre.Console;
+
+internal sealed class BuildCommandService
+{
+    private static readonly JsonSerializerOptions WriteJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private static readonly JsonSerializerOptions ReadJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HierarchyDaemonClient _daemonClient = new();
+    private readonly Dictionary<string, List<BuildTargetCandidate>> _buildTargetCache = new(StringComparer.OrdinalIgnoreCase);
+
+    public async Task HandleBuildCommandAsync(
+        string input,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        if (session.Mode != CliMode.Project || string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+        {
+            log("[yellow]mode[/]: open a project first with /open");
+            return;
+        }
+
+        var tokens = Tokenize(input);
+        if (tokens.Count == 0 || !tokens[0].Equals("/build", StringComparison.OrdinalIgnoreCase))
+        {
+            log("[x] usage: /build <run|exec|scenes|addressables|cancel|targets|logs>");
+            return;
+        }
+
+        if (tokens.Count < 2)
+        {
+            log("[x] usage: /build <run|exec|scenes|addressables|cancel|targets|logs>");
+            return;
+        }
+
+        var subcommand = tokens[1].ToLowerInvariant();
+        switch (subcommand)
+        {
+            case "run":
+                await HandleRunAsync(tokens, session, daemonControlService, daemonRuntime, log);
+                return;
+            case "exec":
+                await HandleExecAsync(tokens, session, daemonControlService, daemonRuntime, log);
+                return;
+            case "scenes":
+                await HandleScenesAsync(tokens, session, daemonControlService, daemonRuntime, log);
+                return;
+            case "addressables":
+                await HandleAddressablesAsync(tokens, session, daemonControlService, daemonRuntime, log);
+                return;
+            case "cancel":
+                await HandleCancelAsync(tokens, session, daemonControlService, daemonRuntime, log);
+                return;
+            case "targets":
+                await HandleTargetsAsync(tokens, session, daemonControlService, daemonRuntime, log);
+                return;
+            case "logs":
+                await HandleLogsAsync(tokens, session, daemonControlService, daemonRuntime, log);
+                return;
+            default:
+                log($"[x] unsupported build subcommand: {Markup.Escape(tokens[1])}");
+                log("supported: /build run | /build exec | /build scenes | /build addressables | /build cancel | /build targets | /build logs");
+                return;
+        }
+    }
+
+    public async Task NotifyAttachedBuildIfAnyAsync(CliSessionState session, Action<string> log)
+    {
+        if (session.AttachedPort is not int port)
+        {
+            return;
+        }
+
+        var status = await _daemonClient.GetBuildStatusAsync(port);
+        if (status is null || !status.Running)
+        {
+            return;
+        }
+
+        var step = string.IsNullOrWhiteSpace(status.Step) ? "running" : status.Step;
+        log($"[yellow]build[/]: resumed monitoring for ongoing {Markup.Escape(status.Kind)} build - {Markup.Escape(step)} ({status.Progress01 * 100:0}%)");
+    }
+
+    private async Task HandleRunAsync(
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        try
+        {
+            var dev = false;
+            var debug = false;
+            var clean = false;
+            string? outputPath = null;
+            var positionalArgs = new List<string>();
+            for (var i = 2; i < tokens.Count; i++)
+            {
+                var option = tokens[i];
+                if (!option.StartsWith("--", StringComparison.Ordinal))
+                {
+                    positionalArgs.Add(option);
+                    continue;
+                }
+
+                if (option.Equals("--dev", StringComparison.OrdinalIgnoreCase))
+                {
+                    dev = true;
+                    continue;
+                }
+
+                if (option.Equals("--debug", StringComparison.OrdinalIgnoreCase))
+                {
+                    debug = true;
+                    continue;
+                }
+
+                if (option.Equals("--clean", StringComparison.OrdinalIgnoreCase))
+                {
+                    clean = true;
+                    continue;
+                }
+
+                if (option.Equals("--path", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (i + 1 >= tokens.Count)
+                    {
+                        log("[x] usage: /build run [target] [--dev] [--debug] [--clean] [--path <output-path>]");
+                        return;
+                    }
+
+                    outputPath = tokens[++i];
+                    continue;
+                }
+
+                if (option.StartsWith("--path=", StringComparison.OrdinalIgnoreCase))
+                {
+                    outputPath = option["--path=".Length..];
+                    continue;
+                }
+
+                log($"[x] unsupported flag: {Markup.Escape(option)}");
+                log("supported flags: --dev --debug --clean --path <output-path>");
+                return;
+            }
+
+            var unityReady = await RunWithSpinnerAsync(
+                "Ensuring Unity bridge context...",
+                () => EnsureUnityContextAsync(session, daemonControlService, daemonRuntime, requireUnityBridge: true));
+            if (!unityReady)
+            {
+                log("[x] build run failed: Unity editor bridge is unavailable; set UNITY_PATH or open Unity editor for this project");
+                return;
+            }
+
+            var targetCandidates = await GetBuildTargetCandidatesAsync(session, log, forceRefresh: false, showStatus: true);
+            if (targetCandidates.Count == 0)
+            {
+                log("[x] build run failed: target list is unavailable");
+                return;
+            }
+
+            var requestedTarget = positionalArgs.FirstOrDefault();
+            var selectedTarget = ResolveSelectedTarget(requestedTarget, targetCandidates, log);
+            if (selectedTarget is null)
+            {
+                return;
+            }
+
+            if (!selectedTarget.Installed)
+            {
+                log($"[yellow]build[/]: target [white]{Markup.Escape(selectedTarget.DisplayName)}[/] is not installed; queuing install then build");
+                var installed = await TryInstallTargetSupportAsync(selectedTarget, session, daemonControlService, daemonRuntime, log);
+                if (!installed)
+                {
+                    log($"[x] build run failed: could not install target support for {Markup.Escape(selectedTarget.DisplayName)}");
+                    return;
+                }
+            }
+
+            var payload = JsonSerializer.Serialize(
+                new BuildRunRequestPayload(selectedTarget.TargetToken, dev, debug, clean, outputPath),
+                WriteJsonOptions);
+            var response = await RunWithSpinnerAsync(
+                "Queueing build run...",
+                () => ExecuteProjectCommandAsync(session, new ProjectCommandRequestDto("build-run", null, null, payload)));
+            EmitProjectResponse("build run", response, log);
+            if (!response.Ok)
+            {
+                return;
+            }
+
+            await MonitorBuildProgressAsync(session, daemonControlService, daemonRuntime, log, promptDeploy: true);
+        }
+        catch (Exception ex)
+        {
+            log($"[x] build run crashed in CLI: {Markup.Escape(ex.GetType().Name)}: {Markup.Escape(ex.Message)}");
+            if (!string.IsNullOrWhiteSpace(ex.StackTrace))
+            {
+                var firstLine = ex.StackTrace.Split('\n', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim();
+                if (!string.IsNullOrWhiteSpace(firstLine))
+                {
+                    log($"[grey]build[/]: stack {Markup.Escape(firstLine)}");
+                }
+            }
+        }
+    }
+
+    private async Task HandleExecAsync(
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        if (tokens.Count < 3)
+        {
+            log("[x] usage: /build exec <Method>");
+            return;
+        }
+
+        var method = string.Join(' ', tokens.Skip(2)).Trim();
+        if (string.IsNullOrWhiteSpace(method))
+        {
+            log("[x] usage: /build exec <Method>");
+            return;
+        }
+
+        var unityReady = await RunWithSpinnerAsync(
+            "Ensuring Unity bridge context...",
+            () => EnsureUnityContextAsync(session, daemonControlService, daemonRuntime, requireUnityBridge: true));
+        if (!unityReady)
+        {
+            log("[x] build exec failed: Unity editor bridge is unavailable; set UNITY_PATH or open Unity editor for this project");
+            return;
+        }
+
+        var payload = JsonSerializer.Serialize(new BuildExecRequestPayload(method), WriteJsonOptions);
+        var response = await RunWithSpinnerAsync(
+            "Queueing build exec...",
+            () => ExecuteProjectCommandAsync(session, new ProjectCommandRequestDto("build-exec", null, null, payload)));
+        EmitProjectResponse("build exec", response, log);
+        if (!response.Ok)
+        {
+            return;
+        }
+
+        await MonitorBuildProgressAsync(session, daemonControlService, daemonRuntime, log, promptDeploy: false);
+    }
+
+    private async Task HandleScenesAsync(
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        if (tokens.Count != 2)
+        {
+            log("[x] usage: /build scenes");
+            return;
+        }
+
+        var unityReady = await RunWithSpinnerAsync(
+            "Ensuring Unity bridge context...",
+            () => EnsureUnityContextAsync(session, daemonControlService, daemonRuntime, requireUnityBridge: true));
+        if (!unityReady)
+        {
+            log("[x] build scenes failed: Unity editor bridge is unavailable; set UNITY_PATH or open Unity editor for this project");
+            return;
+        }
+
+        var response = await RunWithSpinnerAsync(
+            "Loading build scenes...",
+            () => ExecuteProjectCommandAsync(session, new ProjectCommandRequestDto("build-scenes-get", null, null, null)));
+        if (!response.Ok)
+        {
+            EmitProjectResponse("build scenes", response, log);
+            return;
+        }
+
+        BuildScenesResponsePayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<BuildScenesResponsePayload>(response.Content ?? string.Empty, ReadJsonOptions);
+        }
+        catch (Exception ex)
+        {
+            log($"[x] build scenes failed: invalid payload ({Markup.Escape(ex.Message)})");
+            return;
+        }
+
+        var scenes = (payload?.Scenes ?? [])
+            .Where(scene => !string.IsNullOrWhiteSpace(scene.Path))
+            .ToList();
+        if (scenes.Count == 0)
+        {
+            log("[yellow]build[/]: no scenes are currently configured in EditorBuildSettings");
+            return;
+        }
+
+        var prompt = new MultiSelectionPrompt<string>()
+            .Title("Select scenes to [green]enable[/] in [grey]EditorBuildSettings[/]")
+            .NotRequired()
+            .InstructionsText("[grey](Press [blue]<space>[/] to toggle, [green]<enter>[/] to save)[/]");
+        foreach (var scene in scenes)
+        {
+            prompt.AddChoice(scene.Path!);
+        }
+
+        var selected = AnsiConsole.Prompt(prompt);
+        var selectedSet = new HashSet<string>(selected, StringComparer.OrdinalIgnoreCase);
+        var updatePayload = new BuildScenesUpdateRequestPayload(
+            scenes.Select(scene => new BuildSceneEntryPayload(scene.Path!, selectedSet.Contains(scene.Path!))).ToList());
+        var content = JsonSerializer.Serialize(updatePayload, WriteJsonOptions);
+        var saveResponse = await RunWithSpinnerAsync(
+            "Saving build scenes...",
+            () => ExecuteProjectCommandAsync(
+                session,
+                new ProjectCommandRequestDto("build-scenes-set", null, null, content)));
+        EmitProjectResponse("build scenes", saveResponse, log);
+    }
+
+    private async Task HandleAddressablesAsync(
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        var clean = false;
+        var update = false;
+        for (var i = 2; i < tokens.Count; i++)
+        {
+            var option = tokens[i];
+            if (option.Equals("--clean", StringComparison.OrdinalIgnoreCase))
+            {
+                clean = true;
+                continue;
+            }
+
+            if (option.Equals("--update", StringComparison.OrdinalIgnoreCase))
+            {
+                update = true;
+                continue;
+            }
+
+            log($"[x] unsupported flag: {Markup.Escape(option)}");
+            log("supported flags: --clean --update");
+            return;
+        }
+
+        var unityReady = await RunWithSpinnerAsync(
+            "Ensuring Unity bridge context...",
+            () => EnsureUnityContextAsync(session, daemonControlService, daemonRuntime, requireUnityBridge: true));
+        if (!unityReady)
+        {
+            log("[x] build addressables failed: Unity editor bridge is unavailable; set UNITY_PATH or open Unity editor for this project");
+            return;
+        }
+
+        var payload = JsonSerializer.Serialize(new BuildAddressablesRequestPayload(clean, update), WriteJsonOptions);
+        var response = await RunWithSpinnerAsync(
+            "Queueing addressables build...",
+            () => ExecuteProjectCommandAsync(
+                session,
+                new ProjectCommandRequestDto("build-addressables", null, null, payload)));
+        EmitProjectResponse("build addressables", response, log);
+        if (!response.Ok)
+        {
+            return;
+        }
+
+        await MonitorBuildProgressAsync(session, daemonControlService, daemonRuntime, log, promptDeploy: false);
+    }
+
+    private async Task HandleCancelAsync(
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        if (tokens.Count != 2)
+        {
+            log("[x] usage: /build cancel");
+            return;
+        }
+
+        await CancelBuildAndTeardownAsync(session, daemonControlService, daemonRuntime, log, promptReturnKey: true);
+    }
+
+    private async Task HandleTargetsAsync(
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        if (tokens.Count != 2)
+        {
+            log("[x] usage: /build targets");
+            return;
+        }
+
+        var unityReady = await RunWithSpinnerAsync(
+            "Ensuring Unity bridge context...",
+            () => EnsureUnityContextAsync(session, daemonControlService, daemonRuntime, requireUnityBridge: true));
+        if (!unityReady)
+        {
+            log("[x] build targets failed: Unity editor bridge is unavailable; set UNITY_PATH or open Unity editor for this project");
+            return;
+        }
+
+        var targets = await GetBuildTargetCandidatesAsync(session, log, forceRefresh: false, showStatus: true);
+        if (targets.Count == 0)
+        {
+            log("[yellow]build[/]: no build targets were reported by the bridge");
+            return;
+        }
+
+        log("[grey]build[/]: installed build target support");
+        foreach (var target in targets)
+        {
+            var mark = target.Installed ? "[green]installed[/]" : "[grey]not installed[/]";
+            var note = string.IsNullOrWhiteSpace(target.Note) ? string.Empty : $" [grey]({Markup.Escape(target.Note)})[/]";
+            log($" - [white]{Markup.Escape(target.DisplayName)}[/]: {mark}{note}");
+        }
+    }
+
+    private async Task<List<BuildTargetCandidate>> GetBuildTargetCandidatesAsync(
+        CliSessionState session,
+        Action<string> log,
+        bool forceRefresh,
+        bool showStatus)
+    {
+        if (!string.IsNullOrWhiteSpace(session.CurrentProjectPath)
+            && !forceRefresh
+            && _buildTargetCache.TryGetValue(session.CurrentProjectPath, out var cached))
+        {
+            return cached;
+        }
+
+        async Task<List<BuildTargetCandidate>> QueryAsync()
+        {
+            var response = await ExecuteProjectCommandAsync(session, new ProjectCommandRequestDto("build-targets", null, null, null));
+            if (!response.Ok)
+            {
+                EmitProjectResponse("build targets", response, log);
+                return [];
+            }
+
+            BuildTargetsResponsePayload? payload;
+            try
+            {
+                payload = JsonSerializer.Deserialize<BuildTargetsResponsePayload>(response.Content ?? string.Empty, ReadJsonOptions);
+            }
+            catch (Exception ex)
+            {
+                log($"[x] build targets failed: invalid payload ({Markup.Escape(ex.Message)})");
+                return [];
+            }
+
+            var parsed = (payload?.Targets ?? [])
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.Name))
+                .Select(entry =>
+                {
+                    var targetToken = string.IsNullOrWhiteSpace(entry.Note) ? entry.Name! : entry.Note!;
+                    return new BuildTargetCandidate(
+                        entry.Name!,
+                        targetToken,
+                        entry.Installed,
+                        ResolveUnityHubModuleId(entry.Name!, targetToken),
+                        entry.Note);
+                })
+                .ToList();
+
+            if (!string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+            {
+                _buildTargetCache[session.CurrentProjectPath] = parsed;
+            }
+
+            return parsed;
+        }
+
+        if (!showStatus || Console.IsInputRedirected)
+        {
+            return await QueryAsync();
+        }
+
+        var result = new List<BuildTargetCandidate>();
+        await AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots)
+            .StartAsync("Querying installed build targets...", async _ =>
+            {
+                result = await QueryAsync();
+            });
+        return result;
+    }
+
+    private BuildTargetCandidate? ResolveSelectedTarget(string? requestedTarget, IReadOnlyList<BuildTargetCandidate> targets, Action<string> log)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedTarget))
+        {
+            var matched = MatchTarget(requestedTarget, targets);
+            if (matched is not null)
+            {
+                return matched;
+            }
+
+            log($"[x] build run failed: unknown target '{Markup.Escape(requestedTarget)}'");
+            log($"[grey]build[/]: available targets -> {string.Join(", ", targets.Select(t => t.DisplayName))}");
+            return null;
+        }
+
+        if (Console.IsInputRedirected)
+        {
+            var fallback = targets.FirstOrDefault(target => target.Installed) ?? targets.FirstOrDefault();
+            if (fallback is null)
+            {
+                log("[x] build run failed: no selectable target");
+                return null;
+            }
+
+            log($"[yellow]build[/]: non-interactive mode; defaulting to {Markup.Escape(fallback.DisplayName)}");
+            return fallback;
+        }
+
+        var ordered = targets
+            .OrderByDescending(target => target.Installed)
+            .ThenBy(target => target.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var prompt = new SelectionPrompt<BuildTargetCandidate>()
+            .Title("Select build target")
+            .PageSize(Math.Min(12, ordered.Count))
+            .UseConverter(target => target.Installed
+                ? $"[white]{Markup.Escape(target.DisplayName)}[/] [green](installed)[/]"
+                : $"[grey]{Markup.Escape(target.DisplayName)}[/] [dim](not installed, will install)[/]")
+            .AddChoices(ordered);
+        return AnsiConsole.Prompt(prompt);
+    }
+
+    private static BuildTargetCandidate? MatchTarget(string raw, IReadOnlyList<BuildTargetCandidate> targets)
+    {
+        var normalized = NormalizeTarget(raw);
+        foreach (var target in targets)
+        {
+            if (NormalizeTarget(target.DisplayName) == normalized
+                || NormalizeTarget(target.TargetToken) == normalized
+                || (target.Note is not null && NormalizeTarget(target.Note) == normalized))
+            {
+                return target;
+            }
+
+            foreach (var alias in EnumerateTargetAliases(target))
+            {
+                if (NormalizeTarget(alias) == normalized)
+                {
+                    return target;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateTargetAliases(BuildTargetCandidate target)
+    {
+        var token = target.TargetToken;
+        if (token.Equals("StandaloneWindows64", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return "win64";
+            yield return "windows64";
+        }
+        else if (token.Equals("Android", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return "android";
+        }
+        else if (token.Equals("iOS", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return "ios";
+        }
+        else if (token.Equals("WebGL", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return "webgl";
+        }
+        else if (token.Equals("StandaloneOSX", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return "mac";
+            yield return "macos";
+            yield return "osx";
+        }
+        else if (token.Equals("StandaloneLinux64", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return "linux";
+            yield return "linux64";
+        }
+    }
+
+    private static string NormalizeTarget(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                sb.Append(char.ToLowerInvariant(ch));
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private async Task<bool> TryInstallTargetSupportAsync(
+        BuildTargetCandidate target,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        if (string.IsNullOrWhiteSpace(target.ModuleId))
+        {
+            log($"[x] install failed: no Unity Hub module mapping for {Markup.Escape(target.DisplayName)}");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+        {
+            log("[x] install failed: project path is unavailable");
+            return false;
+        }
+
+        if (!UnityEditorPathService.TryReadProjectEditorVersion(session.CurrentProjectPath, out var version, out var versionError))
+        {
+            log($"[x] install failed: could not resolve Unity editor version ({Markup.Escape(versionError ?? "unknown error")})");
+            return false;
+        }
+
+        if (!TryResolveUnityHubPath(out var unityHubPath))
+        {
+            log("[x] install failed: Unity Hub executable was not found (set UNITY_HUB_PATH)");
+            return false;
+        }
+
+        log($"[grey]build[/]: installing module [white]{Markup.Escape(target.ModuleId)}[/] for Unity [white]{Markup.Escape(version)}[/]");
+        var installArgs = $"-- --headless install-modules --version {version} --module {target.ModuleId}";
+        var exitCode = await RunProcessStreamingAsync(unityHubPath, installArgs, line =>
+            log($"[grey]hub[/]: {Markup.Escape(line)}"));
+        if (exitCode != 0)
+        {
+            log($"[x] install failed: Unity Hub exited with code {exitCode}");
+            return false;
+        }
+
+        if (session.AttachedPort is int attachedPort)
+        {
+            await daemonControlService.StopDaemonByPortAsync(attachedPort, daemonRuntime, session, _ => { });
+        }
+
+        var unityReady = await RunWithSpinnerAsync(
+            "Restarting Unity bridge after module install...",
+            () => EnsureUnityContextAsync(session, daemonControlService, daemonRuntime, requireUnityBridge: true));
+        if (!unityReady)
+        {
+            log("[x] install succeeded but bridge restart failed");
+            return false;
+        }
+
+        var refreshedTargets = await GetBuildTargetCandidatesAsync(session, log, forceRefresh: true, showStatus: true);
+        var refreshed = MatchTarget(target.TargetToken, refreshedTargets);
+        if (refreshed?.Installed == true)
+        {
+            log($"[green]build[/]: module installation complete for {Markup.Escape(target.DisplayName)}");
+            return true;
+        }
+
+        log($"[x] install failed: target {Markup.Escape(target.DisplayName)} still reports not installed");
+        return false;
+    }
+
+    private static bool TryResolveUnityHubPath(out string executablePath)
+    {
+        var env = Environment.GetEnvironmentVariable("UNITY_HUB_PATH");
+        if (!string.IsNullOrWhiteSpace(env) && File.Exists(env))
+        {
+            executablePath = env;
+            return true;
+        }
+
+        var candidates = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+            ? new[]
+            {
+                "/Applications/Unity Hub.app/Contents/MacOS/Unity Hub",
+                "/Applications/Unity Hub.app/Contents/MacOS/UnityHub"
+            }
+            : RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? new[]
+                {
+                    @"C:\Program Files\Unity Hub\Unity Hub.exe",
+                    @"C:\Program Files\Unity Hub\UnityHub.exe"
+                }
+                : new[]
+                {
+                    "/usr/bin/unityhub",
+                    "/opt/unityhub/unityhub"
+                };
+        var existing = candidates.FirstOrDefault(File.Exists);
+        if (!string.IsNullOrWhiteSpace(existing))
+        {
+            executablePath = existing;
+            return true;
+        }
+
+        executablePath = string.Empty;
+        return false;
+    }
+
+    private static async Task<int> RunProcessStreamingAsync(string fileName, string arguments, Action<string> onLine)
+    {
+        var psi = new ProcessStartInfo(fileName, arguments)
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        using var process = new Process { StartInfo = psi, EnableRaisingEvents = true };
+        process.OutputDataReceived += (_, eventArgs) =>
+        {
+            if (!string.IsNullOrWhiteSpace(eventArgs.Data))
+            {
+                onLine(eventArgs.Data);
+            }
+        };
+        process.ErrorDataReceived += (_, eventArgs) =>
+        {
+            if (!string.IsNullOrWhiteSpace(eventArgs.Data))
+            {
+                onLine(eventArgs.Data);
+            }
+        };
+
+        if (!process.Start())
+        {
+            return -1;
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        await process.WaitForExitAsync();
+        return process.ExitCode;
+    }
+
+    private static string? ResolveUnityHubModuleId(string displayName, string targetToken)
+    {
+        var normalized = NormalizeTarget(targetToken);
+        if (normalized == NormalizeTarget("StandaloneWindows64") || NormalizeTarget(displayName) == NormalizeTarget("Win64"))
+        {
+            return "windows-il2cpp";
+        }
+
+        if (normalized == NormalizeTarget("Android"))
+        {
+            return "android";
+        }
+
+        if (normalized == NormalizeTarget("iOS"))
+        {
+            return "ios";
+        }
+
+        if (normalized == NormalizeTarget("WebGL"))
+        {
+            return "webgl";
+        }
+
+        if (normalized == NormalizeTarget("StandaloneOSX"))
+        {
+            return "mac-il2cpp";
+        }
+
+        if (normalized == NormalizeTarget("StandaloneLinux64"))
+        {
+            return "linux-il2cpp";
+        }
+
+        return null;
+    }
+
+    private async Task HandleLogsAsync(
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log)
+    {
+        _ = tokens;
+        var unityReady = await RunWithSpinnerAsync(
+            "Connecting to daemon...",
+            () => EnsureUnityContextAsync(session, daemonControlService, daemonRuntime, requireUnityBridge: false));
+        if (!unityReady)
+        {
+            log("[x] build logs failed: daemon/bridge is unavailable");
+            return;
+        }
+
+        if (session.AttachedPort is not int port)
+        {
+            log("[x] build logs failed: daemon is not attached");
+            return;
+        }
+
+        var status = await RunWithSpinnerAsync("Fetching build log status...", () => _daemonClient.GetBuildStatusAsync(port));
+        if (status is null || string.IsNullOrWhiteSpace(status.LogPath))
+        {
+            log("[yellow]build[/]: no build log is available yet");
+            return;
+        }
+
+        BuildLogTailService.RunInteractive(status.LogPath!, "Build Logs");
+    }
+
+    private async Task MonitorBuildProgressAsync(
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log,
+        bool promptDeploy)
+    {
+        if (session.AttachedPort is not int port)
+        {
+            return;
+        }
+
+        var logOffset = 0L;
+        var recentLogLines = new List<BuildLogLineDto>();
+        var errorsOnly = false;
+        var lastHeartbeatUtc = DateTime.MinValue;
+        var lastStatusSnapshot = string.Empty;
+        var statusUnchangedSince = DateTime.UtcNow;
+        var canceledByUser = false;
+
+        while (true)
+        {
+            var status = await _daemonClient.GetBuildStatusAsync(port);
+            if (status is null)
+            {
+                RenderBuildMonitorFrame(
+                    null,
+                    recentLogLines,
+                    errorsOnly,
+                    "daemon unreachable (retrying)",
+                    null);
+                await Task.Delay(1000);
+                continue;
+            }
+
+            if (DateTime.TryParse(status.LastHeartbeatUtc, out var parsedHeartbeat))
+            {
+                lastHeartbeatUtc = parsedHeartbeat.ToUniversalTime();
+            }
+            else
+            {
+                lastHeartbeatUtc = DateTime.UtcNow;
+            }
+
+            var snapshot = $"{status.Step}|{status.Progress01:0.000}|{status.Message}|{status.LastDiagnostic}";
+            if (!snapshot.Equals(lastStatusSnapshot, StringComparison.Ordinal))
+            {
+                lastStatusSnapshot = snapshot;
+                statusUnchangedSince = DateTime.UtcNow;
+            }
+
+            if (!string.IsNullOrWhiteSpace(status.LogPath))
+            {
+                var chunk = await _daemonClient.GetBuildLogChunkAsync(port, logOffset, 120, errorsOnly: false);
+                if (chunk is not null)
+                {
+                    logOffset = chunk.NextOffset;
+                    if (chunk.Lines.Count > 0)
+                    {
+                        recentLogLines.AddRange(chunk.Lines);
+                        if (recentLogLines.Count > 40)
+                        {
+                            recentLogLines.RemoveRange(0, recentLogLines.Count - 40);
+                        }
+                    }
+                }
+            }
+
+            var footer = status.Running
+                ? "E: toggle error filter | C: cancel build | Q: hide monitor"
+                : "Build finished";
+            var elapsedNoStatusChange = DateTime.UtcNow - statusUnchangedSince;
+            var heartbeatAge = DateTime.UtcNow - lastHeartbeatUtc;
+            var stallHint = status.Running && (elapsedNoStatusChange > TimeSpan.FromSeconds(20) || heartbeatAge > TimeSpan.FromSeconds(20))
+                ? $"No status change for {(int)elapsedNoStatusChange.TotalSeconds}s (heartbeat age {(int)heartbeatAge.TotalSeconds}s)"
+                : null;
+            RenderBuildMonitorFrame(status, recentLogLines, errorsOnly, footer, stallHint);
+
+            if (!status.Running)
+            {
+                break;
+            }
+
+            var delayUntil = DateTime.UtcNow.AddMilliseconds(500);
+            while (DateTime.UtcNow < delayUntil)
+            {
+                if (!Console.KeyAvailable)
+                {
+                    await Task.Delay(40);
+                    continue;
+                }
+
+                var key = Console.ReadKey(intercept: true);
+                if (key.Key == ConsoleKey.E)
+                {
+                    errorsOnly = !errorsOnly;
+                    break;
+                }
+
+                if (key.Key == ConsoleKey.C)
+                {
+                    canceledByUser = true;
+                    await CancelBuildAndTeardownAsync(session, daemonControlService, daemonRuntime, log, promptReturnKey: true);
+                    break;
+                }
+
+                if (key.Key is ConsoleKey.Q or ConsoleKey.Escape)
+                {
+                    break;
+                }
+            }
+
+            if (canceledByUser)
+            {
+                session.ContextMode = CliContextMode.Project;
+                return;
+            }
+        }
+
+        var finalStatus = await _daemonClient.GetBuildStatusAsync(port);
+        if (finalStatus is null)
+        {
+            log("[yellow]build[/]: finished, but final status could not be fetched");
+            return;
+        }
+
+        var icon = finalStatus.Success ? "[green]success[/]" : "[red]failed[/]";
+        log($"[grey]build[/]: status {icon} - {Markup.Escape(finalStatus.Message ?? string.Empty)}");
+        if (!string.IsNullOrWhiteSpace(finalStatus.OutputPath))
+        {
+            var escapedPath = Markup.Escape(finalStatus.OutputPath!);
+            var url = Uri.TryCreate(finalStatus.OutputPath, UriKind.Absolute, out var parsed)
+                ? parsed.AbsoluteUri
+                : $"file://{finalStatus.OutputPath.Replace(" ", "%20", StringComparison.Ordinal)}";
+            log($"[grey]build[/]: output [link={Markup.Escape(url)}]{escapedPath}[/]");
+        }
+        if (!string.IsNullOrWhiteSpace(finalStatus.LogPath))
+        {
+            log($"[grey]build[/]: log file [white]{Markup.Escape(finalStatus.LogPath)}[/]");
+        }
+
+        if (!finalStatus.Success || !promptDeploy || string.IsNullOrWhiteSpace(finalStatus.OutputPath))
+        {
+            return;
+        }
+
+        if (!finalStatus.OutputPath.EndsWith(".apk", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        log("[grey]build[/]: Build successful. Deploy to connected ADB device? [Y/n]");
+        var answer = Console.ReadLine()?.Trim();
+        if (!string.IsNullOrWhiteSpace(answer) && answer.StartsWith("n", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        TryRunAdbInstall(finalStatus.OutputPath, log);
+    }
+
+    private async Task CancelBuildAndTeardownAsync(
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        Action<string> log,
+        bool promptReturnKey)
+    {
+        if (session.AttachedPort is not int port)
+        {
+            log("[x] build cancel failed: daemon is not attached");
+            return;
+        }
+
+        var beforeCancel = await RunWithSpinnerAsync(
+            "Capturing pre-cancel status...",
+            () => _daemonClient.GetBuildStatusAsync(port));
+        var response = await RunWithSpinnerAsync(
+            "Sending cancel signal...",
+            () => ExecuteProjectCommandAsync(session, new ProjectCommandRequestDto("build-cancel", null, null, null)));
+        EmitProjectResponse("build cancel", response, log);
+
+        var tornDown = await RunWithSpinnerAsync(
+            "Tearing down build daemon...",
+            () => daemonControlService.StopDaemonByPortAsync(port, daemonRuntime, session, _ => { }));
+        if (!tornDown)
+        {
+            log($"[x] build cancel failed: unable to teardown daemon port {port}");
+        }
+        else
+        {
+            log($"[yellow]build[/]: daemon port {port} terminated to tear down running build");
+        }
+
+        if (!string.IsNullOrWhiteSpace(beforeCancel?.LogPath) && File.Exists(beforeCancel.LogPath))
+        {
+            BuildLogTailService.ShowSnapshotAndWait(
+                beforeCancel.LogPath,
+                "Cancelled Build Log",
+                promptReturnKey && !Console.IsInputRedirected);
+        }
+        else if (promptReturnKey && !Console.IsInputRedirected)
+        {
+            AnsiConsole.MarkupLine("[grey]build[/]: cancelled. Press any key to return to project mode.");
+            _ = Console.ReadKey(intercept: true);
+        }
+
+        session.ContextMode = CliContextMode.Project;
+    }
+
+    private static void RenderBuildMonitorFrame(
+        BuildStatusDto? status,
+        IReadOnlyList<BuildLogLineDto> logLines,
+        bool errorsOnly,
+        string footer,
+        string? stallHint)
+    {
+        AnsiConsole.Clear();
+        var title = status is null
+            ? "[bold deepskyblue1]Build Monitor[/]"
+            : $"[bold deepskyblue1]Build Monitor[/] [grey]({Markup.Escape(status.Kind)})[/]";
+        AnsiConsole.MarkupLine(title);
+
+        if (status is null)
+        {
+            AnsiConsole.MarkupLine("[yellow]status[/]: waiting for daemon...");
+            AnsiConsole.MarkupLine($"[dim]{Markup.Escape(footer)}[/]");
+            return;
+        }
+
+        var progress = Math.Clamp(status.Progress01, 0f, 1f);
+        var blocks = 30;
+        var filled = (int)Math.Round(progress * blocks);
+        var bar = new string('■', Math.Clamp(filled, 0, blocks)) + new string('□', Math.Clamp(blocks - filled, 0, blocks));
+        var step = string.IsNullOrWhiteSpace(status.Step) ? "building..." : status.Step;
+        var state = status.Running ? "[yellow]running[/]" : (status.Success ? "[green]success[/]" : "[red]failed[/]");
+        AnsiConsole.MarkupLine($"[grey]state[/]: {state}  [grey]step[/]: [white]{Markup.Escape(step)}[/]");
+        AnsiConsole.MarkupLine($"[grey]progress[/]: [deepskyblue1]{Markup.Escape(bar)}[/] [white]{progress * 100:0}%[/]");
+        AnsiConsole.MarkupLine($"[grey]message[/]: {Markup.Escape(status.Message ?? string.Empty)}");
+        if (!string.IsNullOrWhiteSpace(status.LogPath))
+        {
+            AnsiConsole.MarkupLine($"[grey]log[/]: [white]{Markup.Escape(status.LogPath)}[/]");
+        }
+        if (!string.IsNullOrWhiteSpace(status.LastDiagnostic))
+        {
+            AnsiConsole.MarkupLine($"[grey]diagnostic[/]: {Markup.Escape(status.LastDiagnostic)}");
+        }
+        if (!string.IsNullOrWhiteSpace(status.LastException))
+        {
+            AnsiConsole.MarkupLine($"[red]exception[/]: {Markup.Escape(status.LastException)}");
+        }
+        if (!string.IsNullOrWhiteSpace(stallHint))
+        {
+            AnsiConsole.MarkupLine($"[yellow]stall[/]: {Markup.Escape(stallHint)}");
+        }
+        AnsiConsole.MarkupLine($"[dim]log filter: {(errorsOnly ? "errors only" : "all")}[/]");
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[grey]Live Logs[/]");
+
+        var visible = logLines
+            .Where(line => !errorsOnly || line.Level.Equals("error", StringComparison.OrdinalIgnoreCase))
+            .TakeLast(12)
+            .ToList();
+        if (visible.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]no log lines yet[/]");
+        }
+        else
+        {
+            foreach (var line in visible)
+            {
+                var style = line.Level.Equals("error", StringComparison.OrdinalIgnoreCase)
+                    ? "red"
+                    : (line.Level.Equals("warning", StringComparison.OrdinalIgnoreCase) ? "yellow" : "grey");
+                AnsiConsole.MarkupLine($"[{style}]{Markup.Escape(line.Text)}[/]");
+            }
+        }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"[dim]{Markup.Escape(footer)}[/]");
+    }
+
+    private static void TryRunAdbInstall(string apkPath, Action<string> log)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("adb", $"install -r \"{apkPath}\"")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                log("[x] adb deploy failed: unable to start adb process");
+                return;
+            }
+
+            process.WaitForExit();
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            if (process.ExitCode == 0)
+            {
+                log($"[green]adb[/]: {Markup.Escape(output.Trim())}");
+                return;
+            }
+
+            log($"[x] adb deploy failed: {Markup.Escape(string.IsNullOrWhiteSpace(error) ? output.Trim() : error.Trim())}");
+        }
+        catch (Exception ex)
+        {
+            log($"[x] adb deploy failed: {Markup.Escape(ex.Message)}");
+        }
+    }
+
+    private static void EmitProjectResponse(string actionLabel, ProjectCommandResponseDto response, Action<string> log)
+    {
+        if (!response.Ok)
+        {
+            log($"[x] {actionLabel} failed: {Markup.Escape(response.Message ?? "unknown error")}");
+            return;
+        }
+
+        log($"[green]build[/]: {Markup.Escape(response.Message)}");
+        if (string.IsNullOrWhiteSpace(response.Content))
+        {
+            return;
+        }
+
+        BuildOperationContentPayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<BuildOperationContentPayload>(response.Content, ReadJsonOptions);
+        }
+        catch
+        {
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(payload?.Summary))
+        {
+            log($"[grey]build[/]: {Markup.Escape(payload.Summary)}");
+        }
+
+        if (payload?.Details is null)
+        {
+            return;
+        }
+
+        foreach (var detail in payload.Details.Where(d => !string.IsNullOrWhiteSpace(d)))
+        {
+            log($"[grey]build[/]: {Markup.Escape(detail)}");
+        }
+    }
+
+    private async Task<ProjectCommandResponseDto> ExecuteProjectCommandAsync(CliSessionState session, ProjectCommandRequestDto request)
+    {
+        if (session.AttachedPort is not int port)
+        {
+            return new ProjectCommandResponseDto(false, "daemon is not attached", null, null);
+        }
+
+        return await _daemonClient.ExecuteProjectCommandAsync(port, request);
+    }
+
+    private static async Task<T> RunWithSpinnerAsync<T>(string statusText, Func<Task<T>> action)
+    {
+        if (Console.IsInputRedirected)
+        {
+            return await action();
+        }
+
+        var result = default(T);
+        await AnsiConsole.Status()
+            .Spinner(Spinner.Known.Dots)
+            .StartAsync(statusText, async _ =>
+            {
+                result = await action();
+            });
+        return result!;
+    }
+
+    private static async Task<bool> EnsureUnityContextAsync(
+        CliSessionState session,
+        DaemonControlService daemonControlService,
+        DaemonRuntime daemonRuntime,
+        bool requireUnityBridge = false)
+    {
+        if (await daemonControlService.TouchAttachedDaemonAsync(session))
+        {
+            if (!requireUnityBridge)
+            {
+                return true;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+        {
+            return false;
+        }
+
+        if (!requireUnityBridge
+            && DaemonControlService.IsUnityClientActiveForProject(session.CurrentProjectPath))
+        {
+            await daemonControlService.TryAttachProjectDaemonAsync(session.CurrentProjectPath, session);
+            return true;
+        }
+
+        return await daemonControlService.EnsureProjectDaemonAsync(
+            session.CurrentProjectPath,
+            daemonRuntime,
+            session,
+            _ => { },
+            requireUnityBridge);
+    }
+
+    private static List<string> Tokenize(string input)
+    {
+        var tokens = new List<string>();
+        var current = new StringBuilder();
+        var inQuotes = false;
+
+        foreach (var ch in input)
+        {
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (!inQuotes && char.IsWhiteSpace(ch))
+            {
+                if (current.Length > 0)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                }
+
+                continue;
+            }
+
+            current.Append(ch);
+        }
+
+        if (current.Length > 0)
+        {
+            tokens.Add(current.ToString());
+        }
+
+        return tokens;
+    }
+
+    private sealed record BuildRunRequestPayload(
+        string Target,
+        bool Development,
+        bool ScriptDebugging,
+        bool Clean,
+        string? OutputPath);
+
+    private sealed record BuildExecRequestPayload(string Method);
+
+    private sealed record BuildAddressablesRequestPayload(bool Clean, bool Update);
+
+    private sealed record BuildOperationContentPayload(string? Summary, List<string>? Details);
+
+    private sealed record BuildTargetsResponsePayload(List<BuildTargetPayload>? Targets);
+
+    private sealed record BuildTargetPayload(string? Name, bool Installed, string? Note);
+
+    private sealed record BuildTargetCandidate(
+        string DisplayName,
+        string TargetToken,
+        bool Installed,
+        string? ModuleId,
+        string? Note);
+
+    private sealed record BuildScenesResponsePayload(List<BuildSceneEntryPayload>? Scenes);
+
+    private sealed record BuildScenesUpdateRequestPayload(List<BuildSceneEntryPayload> Scenes);
+
+    private sealed record BuildSceneEntryPayload(string Path, bool Enabled);
+}

--- a/src/unifocl/Services/BuildLogTailService.cs
+++ b/src/unifocl/Services/BuildLogTailService.cs
@@ -1,0 +1,194 @@
+using System.Diagnostics;
+using System.Text;
+using Spectre.Console;
+
+internal static class BuildLogTailService
+{
+    public static bool TryRunFromArgs(string[] args)
+    {
+        if (args.Length < 2 || !args[0].Equals("--build-log-tail", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        RunInteractive(args[1], "Build Logs");
+        return true;
+    }
+
+    public static bool TryLaunchSecondaryTerminal(string logPath)
+    {
+        try
+        {
+            var processPath = Environment.ProcessPath;
+            if (string.IsNullOrWhiteSpace(processPath))
+            {
+                return false;
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                var escapedBinary = processPath.Replace("\"", "\\\"");
+                var escapedLog = logPath.Replace("\"", "\\\"");
+                var command = $"\\\"{escapedBinary}\\\" --build-log-tail \\\"{escapedLog}\\\"";
+                var script = $"tell application \"Terminal\" to do script \"{command}\"";
+                var psi = new ProcessStartInfo("osascript", $"-e \"{script}\"")
+                {
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+                using var process = Process.Start(psi);
+                return process is not null;
+            }
+        }
+        catch
+        {
+        }
+
+        return false;
+    }
+
+    public static void RunInteractive(string logPath, string title)
+    {
+        var offset = 0L;
+        var lines = new List<(string Level, string Text)>();
+        var errorsOnly = false;
+        var keep = 200;
+
+        while (true)
+        {
+            ReadNewLines(logPath, ref offset, lines);
+            if (lines.Count > keep)
+            {
+                lines.RemoveRange(0, lines.Count - keep);
+            }
+
+            AnsiConsole.Clear();
+            var mode = errorsOnly ? "ERRORS ONLY" : "ALL";
+            AnsiConsole.MarkupLine($"[bold deepskyblue1]{Markup.Escape(title)}[/] [grey]({Markup.Escape(mode)})[/]");
+            AnsiConsole.MarkupLine($"[dim]{Markup.Escape(logPath)}[/]");
+            AnsiConsole.MarkupLine("[dim]Keybinds: E = toggle error filter, Q = quit[/]");
+            AnsiConsole.WriteLine();
+
+            foreach (var line in lines)
+            {
+                if (errorsOnly && !line.Level.Equals("error", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var style = line.Level.Equals("error", StringComparison.OrdinalIgnoreCase)
+                    ? "red"
+                    : (line.Level.Equals("warning", StringComparison.OrdinalIgnoreCase) ? "yellow" : "grey");
+                AnsiConsole.MarkupLine($"[{style}]{Markup.Escape(line.Text)}[/]");
+            }
+
+            var end = DateTime.UtcNow.AddMilliseconds(250);
+            while (DateTime.UtcNow < end)
+            {
+                if (!Console.KeyAvailable)
+                {
+                    Thread.Sleep(25);
+                    continue;
+                }
+
+                var key = Console.ReadKey(intercept: true);
+                if (key.Key is ConsoleKey.Q or ConsoleKey.Escape)
+                {
+                    return;
+                }
+
+                if (key.Key == ConsoleKey.E)
+                {
+                    errorsOnly = !errorsOnly;
+                    break;
+                }
+            }
+        }
+    }
+
+    public static void ShowSnapshotAndWait(string logPath, string title, bool waitForKey)
+    {
+        var lines = new List<(string Level, string Text)>();
+        var offset = 0L;
+        ReadNewLines(logPath, ref offset, lines);
+        var visible = lines.TakeLast(60).ToList();
+
+        AnsiConsole.Clear();
+        AnsiConsole.MarkupLine($"[bold deepskyblue1]{Markup.Escape(title)}[/]");
+        AnsiConsole.MarkupLine($"[dim]{Markup.Escape(logPath)}[/]");
+        AnsiConsole.WriteLine();
+
+        if (visible.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[dim]no log lines captured[/]");
+        }
+        else
+        {
+            foreach (var line in visible)
+            {
+                var style = line.Level.Equals("error", StringComparison.OrdinalIgnoreCase)
+                    ? "red"
+                    : (line.Level.Equals("warning", StringComparison.OrdinalIgnoreCase) ? "yellow" : "grey");
+                AnsiConsole.MarkupLine($"[{style}]{Markup.Escape(line.Text)}[/]");
+            }
+        }
+
+        if (!waitForKey)
+        {
+            return;
+        }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[grey]Press any key to return to project mode...[/]");
+        _ = Console.ReadKey(intercept: true);
+    }
+
+    private static void ReadNewLines(string path, ref long offset, List<(string Level, string Text)> lines)
+    {
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        if (offset > stream.Length)
+        {
+            offset = 0;
+        }
+
+        stream.Seek(offset, SeekOrigin.Begin);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        while (!reader.EndOfStream)
+        {
+            var raw = reader.ReadLine();
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                continue;
+            }
+
+            lines.Add(ParseLine(raw));
+        }
+
+        offset = stream.Position;
+    }
+
+    private static (string Level, string Text) ParseLine(string line)
+    {
+        var first = line.IndexOf('|');
+        if (first < 0)
+        {
+            return ("info", line);
+        }
+
+        var second = line.IndexOf('|', first + 1);
+        if (second < 0)
+        {
+            return ("info", line[(first + 1)..]);
+        }
+
+        var level = line[(first + 1)..second];
+        var text = line[(second + 1)..];
+        return (string.IsNullOrWhiteSpace(level) ? "info" : level, text);
+    }
+}

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -1,8 +1,8 @@
 internal static class CliVersion
 {
     public const int Major = 0;
-    public const int Minor = 2;
-    public const int Patch = 9;
+    public const int Minor = 3;
+    public const int Patch = 0;
     public const string Protocol = "v2";
 
     public static string SemVer => $"{Major}.{Minor}.{Patch}";

--- a/src/unifocl/Services/HierarchyDaemonClient.cs
+++ b/src/unifocl/Services/HierarchyDaemonClient.cs
@@ -8,6 +8,7 @@ internal sealed class HierarchyDaemonClient
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan ProjectCommandTimeout = TimeSpan.FromSeconds(8);
+    private static readonly TimeSpan BuildStatusTimeout = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan SceneLoadTimeout = TimeSpan.FromSeconds(90);
     private static readonly TimeSpan SceneLoadStatusInterval = TimeSpan.FromSeconds(5);
     private const int SceneLoadRetryCount = 1;
@@ -91,7 +92,10 @@ internal sealed class HierarchyDaemonClient
     public async Task<ProjectCommandResponseDto> ExecuteProjectCommandAsync(int port, ProjectCommandRequestDto request, Action<string>? onStatus = null)
     {
         var isSceneLoad = request.Action.Equals("load-asset", StringComparison.OrdinalIgnoreCase);
-        var timeout = isSceneLoad ? SceneLoadTimeout : ProjectCommandTimeout;
+        var isBuildDispatch = request.Action.StartsWith("build-", StringComparison.OrdinalIgnoreCase);
+        var timeout = isSceneLoad
+            ? SceneLoadTimeout
+            : (isBuildDispatch ? TimeSpan.FromSeconds(20) : ProjectCommandTimeout);
         var maxAttempts = isSceneLoad ? SceneLoadRetryCount + 1 : 1;
         if (isSceneLoad)
         {
@@ -155,11 +159,48 @@ internal sealed class HierarchyDaemonClient
         return new ProjectCommandResponseDto(false, "daemon did not return a project response", null, null);
     }
 
-    private static async Task<string?> SendGetAsync(string uri)
+    public async Task<BuildStatusDto?> GetBuildStatusAsync(int port)
+    {
+        var payload = await SendGetAsync($"http://127.0.0.1:{port}/build/status", BuildStatusTimeout);
+        if (payload is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<BuildStatusDto>(payload, JsonOptions);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<BuildLogChunkDto?> GetBuildLogChunkAsync(int port, long offset, int limit, bool errorsOnly)
+    {
+        var query = $"offset={Math.Max(0, offset)}&limit={Math.Clamp(limit, 1, 400)}&errorsOnly={errorsOnly.ToString().ToLowerInvariant()}";
+        var payload = await SendGetAsync($"http://127.0.0.1:{port}/build/log?{query}", BuildStatusTimeout);
+        if (payload is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<BuildLogChunkDto>(payload, JsonOptions);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> SendGetAsync(string uri, TimeSpan? timeout = null)
     {
         try
         {
-            using var cts = new CancellationTokenSource(DefaultRequestTimeout);
+            using var cts = new CancellationTokenSource(timeout ?? DefaultRequestTimeout);
             var response = await Http.GetAsync(uri, cts.Token);
             if (!response.IsSuccessStatusCode)
             {

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -9,6 +9,7 @@ internal sealed class ProjectLifecycleService
     private readonly EditorDependencyInitializerService _editorDependencyInitializerService = new();
     private readonly ProjectViewService _projectViewService = new();
     private readonly RecentProjectHistoryService _recentProjectHistoryService = new();
+    private readonly HierarchyDaemonClient _daemonClient = new();
 
     public async Task<bool> TryHandleLifecycleCommandAsync(
         string input,
@@ -752,6 +753,18 @@ internal sealed class ProjectLifecycleService
         DaemonRuntime daemonRuntime,
         Action<string> log)
     {
+        if (session.AttachedPort is int attachedBuildPort)
+        {
+            var status = await _daemonClient.GetBuildStatusAsync(attachedBuildPort);
+            if (status?.Running == true)
+            {
+                var label = string.IsNullOrWhiteSpace(status.Kind) ? "build" : status.Kind;
+                session.ResetToBoot();
+                log($"[yellow]close[/]: detached only; active {Markup.Escape(label)} build continues on daemon port {attachedBuildPort}");
+                return true;
+            }
+        }
+
         var candidatePorts = new HashSet<int>();
         if (session.AttachedPort is int attachedPort)
         {


### PR DESCRIPTION
## Summary
- Introduces the `0.3.0` build workflow improvements centered on `/build` commands.
- Adds robust in-CLI UX for heavy operations: progress monitor, spinners, diagnostics, cancellation teardown, and output/log visibility.
- Adds build target selection/install flow and output path handling to reduce friction and conflicts.
- Adds `Changelog.md` with initial `0.3.0` entry.

Why this is needed:
- Build operations were difficult to observe/trust (silent waits, unclear status, weak diagnostics).
- Cancellation and daemon lifecycle behavior needed to be safer and clearer.
- Repeated builds needed better artifact routing and less collision risk.

## Related Issues
- Experienced #56 during this change.

## Type of Change
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Docs
- [ ] CI/Build
- [x] Chore

## Scope
- Affected areas/components:
- `src/unifocl/Program.cs`
- `src/unifocl/Services/BuildCommandService.cs` (new)
- `src/unifocl/Services/BuildLogTailService.cs` (new)
- `src/unifocl/Services/HierarchyDaemonClient.cs`
- `src/unifocl/Services/ProjectLifecycleService.cs`
- `src/unifocl/Models/ProjectBridgeModels.cs`
- `src/unifocl/Services/CliVersion.cs`
- `src/unifocl.unity/EditorScripts/CLIDaemon.cs`
- `src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs`
- `README.md`
- `Changelog.md` (new)

Out-of-scope / intentionally not addressed:
- New automated unit/integration test suite for build flows.
- Changes to external deployment/release pipelines.

## How to Test
1. Build CLI:
   - `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Open a Unity project with unifocl and run:
   - `/build run` (interactive target selection)
   - `/build run Android --path Build/Manual/android.apk`
3. Verify runtime behavior:
   - Progress/log monitor appears and updates
   - `/build cancel` tears down daemon path and returns to project mode
   - `/build targets` responds quickly (cached after first fetch)

Expected results:
- No silent heavy waits (spinner or progress shown).
- Build output/log path is visible.
- Cancellation performs teardown path consistently.

## Screenshots / Terminal Output (if applicable)
- N/A (CLI-only behavior changes).

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No secrets added; no credential handling introduced in this PR.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
