### PR TITLE
Add hierarchy and inspector mode IntelliSense + bump 0.3.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.1 - 2026-03-08
+
+### Added
+- Hierarchy mode now provides in-prompt IntelliSense with command signatures, argument usage, and descriptions.
+- Hierarchy mode prompt now supports suggestion navigation and insertion (`↑/↓` + `Enter`) plus `Esc` dismissal behavior.
+
+### Changed
+- Project composer IntelliSense now uses inspector-specific command suggestions while in inspector context.
+- Inspector command suggestions now include context-specific command usage and explanations rather than only project-wide command listings.
+
 ## 0.3.0 - 2026-03-06
 
 ### Added

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -126,6 +126,30 @@ var projectCommands = new List<CommandSpec>
     new("ba [--clean] [--update]", "Alias for build addressables", "ba")
 };
 
+var inspectorCommands = new List<CommandSpec>
+{
+    new("inspect [idx|path]", "Enter inspector root target (default: current focus path)", "inspect"),
+    new("list", "Refresh and list inspector items at current depth", "list"),
+    new("ls", "Alias for list", "ls"),
+    new("enter <idx>", "Inspect component by index", "enter"),
+    new("cd <idx>", "Alias for enter", "cd"),
+    new("up", "Step up (fields -> components, components -> project)", "up"),
+    new("..", "Alias for up", ".."),
+    new(":i", "Alias for up", ":i"),
+    new("set <field> <value...>", "Set selected component field in inspector", "set"),
+    new("s <field> <value...>", "Alias for set", "s"),
+    new("set <Component>.<field> <value...>", "Set a field directly from inspector root", "set"),
+    new("toggle <component-index|field>", "Toggle component enabled state or bool field", "toggle"),
+    new("t <component-index|field>", "Alias for toggle", "t"),
+    new("f <query>", "Fuzzy find in inspector context", "f"),
+    new("ff <query>", "Alias for fuzzy find", "ff"),
+    new("scroll [body|stream] <up|down> [count]", "Scroll inspector body or command stream", "scroll"),
+    new("make|mk <...>", "Not implemented in inspector mode yet", "make"),
+    new("remove|rm <...>", "Not implemented in inspector mode yet", "remove"),
+    new("rename|rn <...>", "Not implemented in inspector mode yet", "rename"),
+    new("move|mv <...>", "Not implemented in inspector mode yet", "move")
+};
+
 var streamLog = new List<string>();
 var runtimePath = Path.Combine(Environment.CurrentDirectory, ".unifocl-runtime");
 var daemonRuntime = new DaemonRuntime(runtimePath);
@@ -143,7 +167,7 @@ while (true)
     string? rawInput;
     try
     {
-        rawInput = ReadInput(commands, projectCommands, streamLog, session);
+        rawInput = ReadInput(commands, projectCommands, inspectorCommands, streamLog, session);
     }
     catch (Exception ex)
     {
@@ -425,6 +449,7 @@ while (true)
 static string? ReadInput(
     List<CommandSpec> commands,
     List<CommandSpec> projectCommands,
+    List<CommandSpec> inspectorCommands,
     List<string> streamLog,
     CliSessionState session)
 {
@@ -434,12 +459,13 @@ static string? ReadInput(
         return Console.ReadLine();
     }
 
-    return ReadInteractiveInput(commands, projectCommands, streamLog, session);
+    return ReadInteractiveInput(commands, projectCommands, inspectorCommands, streamLog, session);
 }
 
 static string? ReadInteractiveInput(
     List<CommandSpec> commands,
     List<CommandSpec> projectCommands,
+    List<CommandSpec> inspectorCommands,
     List<string> streamLog,
     CliSessionState session)
 {
@@ -451,13 +477,14 @@ static string? ReadInteractiveInput(
         input.ToString(),
         commands,
         projectCommands,
+        inspectorCommands,
         session,
         selectedIntellisenseCandidateIndex,
         intellisenseDismissed);
 
     while (true)
     {
-        _ = TryGetComposerIntellisenseCandidates(input.ToString(), commands, projectCommands, session, out var allCandidates);
+        _ = TryGetComposerIntellisenseCandidates(input.ToString(), commands, projectCommands, inspectorCommands, session, out var allCandidates);
         var candidates = intellisenseDismissed ? [] : allCandidates;
         if (candidates.Count == 0)
         {
@@ -582,6 +609,7 @@ static string? ReadInteractiveInput(
             input.ToString(),
             commands,
             projectCommands,
+            inspectorCommands,
             session,
             selectedIntellisenseCandidateIndex,
             intellisenseDismissed);
@@ -592,6 +620,7 @@ static int RenderComposerFrame(
     string input,
     List<CommandSpec> commands,
     List<CommandSpec> projectCommands,
+    List<CommandSpec> inspectorCommands,
     CliSessionState session,
     int selectedFuzzyCandidateIndex,
     bool suppressIntellisense)
@@ -620,8 +649,11 @@ static int RenderComposerFrame(
     }
     else if (!string.IsNullOrWhiteSpace(input))
     {
+        var contextualCommands = session.Inspector is not null
+            ? inspectorCommands
+            : projectCommands;
         lines.Add(string.Empty);
-        lines.AddRange(GetSuggestionLines(input, projectCommands, selectedFuzzyCandidateIndex));
+        lines.AddRange(GetSuggestionLines(input, contextualCommands, selectedFuzzyCandidateIndex));
     }
     else if (session.Inspector is not null)
     {
@@ -884,6 +916,7 @@ static bool TryGetComposerIntellisenseCandidates(
     string input,
     List<CommandSpec> commands,
     List<CommandSpec> projectCommands,
+    List<CommandSpec> inspectorCommands,
     CliSessionState session,
     out List<(string Label, string? CommitCommand)> candidates)
 {
@@ -913,7 +946,10 @@ static bool TryGetComposerIntellisenseCandidates(
 
     if (!string.IsNullOrWhiteSpace(input))
     {
-        candidates = GetSuggestionMatches(input, projectCommands)
+        var contextualCommands = session.Inspector is not null
+            ? inspectorCommands
+            : projectCommands;
+        candidates = GetSuggestionMatches(input, contextualCommands)
             .Select(match => (match.Signature, (string?)match.Trigger))
             .ToList();
         return true;

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -2,7 +2,7 @@ internal static class CliVersion
 {
     public const int Major = 0;
     public const int Minor = 3;
-    public const int Patch = 0;
+    public const int Patch = 1;
     public const string Protocol = "v2";
 
     public static string SemVer => $"{Major}.{Minor}.{Patch}";

--- a/src/unifocl/Services/HierarchyTui.cs
+++ b/src/unifocl/Services/HierarchyTui.cs
@@ -11,6 +11,27 @@ internal sealed class HierarchyTui
     private const int FrameOverheadRows = 5;
     private const ConsoleKey FocusModeKey = ConsoleKey.F7;
 
+    private static readonly List<CommandSpec> HierarchyCommands =
+    [
+        new("list", "Refresh hierarchy snapshot", "list"),
+        new("ls", "Alias for list", "ls"),
+        new("ref", "Alias for list", "ref"),
+        new("enter <idx>", "Enter child object by visible index", "enter"),
+        new("cd <idx>", "Alias for enter", "cd"),
+        new("up", "Move to parent object", "up"),
+        new("..", "Alias for up", ".."),
+        new(":i", "Alias for up", ":i"),
+        new("make <name>", "Create empty GameObject under current object", "make"),
+        new("mk <name>", "Alias for make", "mk"),
+        new("mk cube <name> [-p]", "Create primitive cube", "mk cube"),
+        new("toggle <idx>", "Toggle active state by index", "toggle"),
+        new("t <idx>", "Alias for toggle", "t"),
+        new("f <query>", "Fuzzy search hierarchy paths", "f"),
+        new("ff <query>", "Alias for fuzzy search", "ff"),
+        new("scroll [tree|log] <up|down> [count]", "Scroll tree or command stream", "scroll"),
+        new("quit|exit|q|:q", "Exit hierarchy mode", "quit")
+    ];
+
     private readonly HierarchyDaemonClient _daemonClient = new();
     private int _treeScrollOffset;
     private int _commandScrollOffset = int.MaxValue;
@@ -62,7 +83,6 @@ internal sealed class HierarchyTui
             var treeLines = BuildTreeLines(snapshot, cwdId, out var indexMap, out var cwdPath, out _, null);
             RenderFrame(port, snapshot.Scene, treeLines.Select(line => line.Text).ToList(), commandLog, cwdPath);
 
-            Console.Write($"UnityCLI:{cwdPath} > ");
             var firstKey = Console.ReadKey(intercept: true);
             var firstIntent = KeyboardIntentReader.FromConsoleKey(firstKey);
             if (firstIntent == KeyboardIntent.FocusProject
@@ -81,7 +101,7 @@ internal sealed class HierarchyTui
                 continue;
             }
 
-            var input = ReadPromptInputFromFirstKey(firstKey);
+            var input = ReadPromptInputWithIntellisenseFromFirstKey(cwdPath, firstKey);
 
             if (string.IsNullOrWhiteSpace(input))
             {
@@ -130,7 +150,7 @@ internal sealed class HierarchyTui
 
             if (!handled)
             {
-                commandLog.Add("[!] unknown command (supported: list, enter, up, make, toggle, f, scroll, quit)");
+                commandLog.Add("[!] unknown command (type any text to view hierarchy intellisense)");
             }
 
             var nextSnapshot = await _daemonClient.GetSnapshotAsync(port);
@@ -742,8 +762,9 @@ internal sealed class HierarchyTui
         return null;
     }
 
-    private static string ReadPromptInputFromFirstKey(ConsoleKeyInfo firstKey)
+    private static string ReadPromptInputWithIntellisenseFromFirstKey(string cwdPath, ConsoleKeyInfo firstKey)
     {
+        var input = new StringBuilder();
         if (firstKey.Key == ConsoleKey.Enter)
         {
             Console.WriteLine();
@@ -756,41 +777,112 @@ internal sealed class HierarchyTui
             return string.Empty;
         }
 
-        var input = new StringBuilder();
         if (!TryAppendInputCharacter(firstKey, input))
         {
             Console.WriteLine();
             return string.Empty;
         }
 
+        var selectedIndex = 0;
+        var dismissed = false;
+        var selectionArmed = false;
+        var renderedLines = RenderPromptIntellisense(cwdPath, input.ToString(), selectedIndex, dismissed);
+
         while (true)
         {
+            var allCandidates = GetHierarchyIntellisenseCandidates(input.ToString());
+            var candidates = dismissed ? [] : allCandidates;
+            if (candidates.Count == 0)
+            {
+                selectedIndex = 0;
+            }
+            else
+            {
+                selectedIndex = Math.Clamp(selectedIndex, 0, candidates.Count - 1);
+            }
+
             var key = Console.ReadKey(intercept: true);
             if (key.Key == ConsoleKey.Enter)
             {
-                Console.WriteLine();
-                return input.ToString().Trim();
-            }
-
-            if (key.Key == ConsoleKey.Backspace)
-            {
-                if (input.Length == 0)
+                if (selectionArmed
+                    && candidates.Count > 0
+                    && selectedIndex >= 0
+                    && selectedIndex < candidates.Count
+                    && !string.IsNullOrWhiteSpace(candidates[selectedIndex].CommitCommand))
                 {
-                    continue;
+                    input.Clear();
+                    input.Append(candidates[selectedIndex].CommitCommand);
+                    dismissed = false;
+                    selectionArmed = false;
+                }
+                else
+                {
+                    ClearPromptFrame(renderedLines);
+                    Console.WriteLine($"UnityCLI:{cwdPath} > {input}");
+                    return input.ToString().Trim();
+                }
+            }
+            else if (key.Key == ConsoleKey.Backspace)
+            {
+                if (input.Length > 0)
+                {
+                    input.Length--;
                 }
 
-                input.Length--;
-                Console.Write("\b \b");
-                continue;
+                dismissed = false;
+                selectionArmed = false;
             }
-
-            if (key.Key == ConsoleKey.Escape)
+            else if (key.Key == ConsoleKey.Escape)
             {
-                Console.WriteLine();
-                return string.Empty;
+                if (!dismissed && allCandidates.Count > 0)
+                {
+                    dismissed = true;
+                }
+                else
+                {
+                    input.Clear();
+                    dismissed = false;
+                }
+
+                selectedIndex = 0;
+                selectionArmed = false;
+            }
+            else if (key.Key == ConsoleKey.UpArrow)
+            {
+                if (dismissed && allCandidates.Count > 0)
+                {
+                    dismissed = false;
+                    candidates = allCandidates;
+                }
+
+                if (candidates.Count > 0)
+                {
+                    selectedIndex = selectedIndex <= 0 ? candidates.Count - 1 : selectedIndex - 1;
+                    selectionArmed = true;
+                }
+            }
+            else if (key.Key == ConsoleKey.DownArrow)
+            {
+                if (dismissed && allCandidates.Count > 0)
+                {
+                    dismissed = false;
+                    candidates = allCandidates;
+                }
+
+                if (candidates.Count > 0)
+                {
+                    selectedIndex = selectedIndex >= candidates.Count - 1 ? 0 : selectedIndex + 1;
+                    selectionArmed = true;
+                }
+            }
+            else if (TryAppendInputCharacter(key, input))
+            {
+                dismissed = false;
+                selectionArmed = false;
             }
 
-            TryAppendInputCharacter(key, input);
+            ClearPromptFrame(renderedLines);
+            renderedLines = RenderPromptIntellisense(cwdPath, input.ToString(), selectedIndex, dismissed);
         }
     }
 
@@ -802,8 +894,93 @@ internal sealed class HierarchyTui
         }
 
         input.Append(key.KeyChar);
-        Console.Write(key.KeyChar);
         return true;
+    }
+
+    private static int RenderPromptIntellisense(
+        string cwdPath,
+        string input,
+        int selectedSuggestionIndex,
+        bool suppressIntellisense)
+    {
+        var lines = new List<string>
+        {
+            $"UnityCLI:{Markup.Escape(cwdPath)} > [bold white]{Markup.Escape(input)}[/]"
+        };
+
+        if (suppressIntellisense)
+        {
+            lines.Add("[dim]intellisense dismissed (Esc). Type or use ↑/↓ to reopen suggestions.[/]");
+        }
+        else
+        {
+            var matches = GetHierarchySuggestionMatches(input);
+            lines.Add("[grey]intellisense[/]: hierarchy commands [dim](up/down + enter to insert)[/]");
+            if (matches.Count == 0)
+            {
+                lines.Add(string.IsNullOrWhiteSpace(input)
+                    ? "[dim]no commands available[/]"
+                    : $"[dim]no matches for {Markup.Escape(input)}[/]");
+            }
+            else
+            {
+                var selected = Math.Clamp(selectedSuggestionIndex, 0, matches.Count - 1);
+                for (var i = 0; i < matches.Count; i++)
+                {
+                    var match = matches[i];
+                    var isSelected = i == selected;
+                    var prefix = isSelected
+                        ? $"[{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]>[/]"
+                        : "[grey] [/]";
+                    var signature = Markup.Escape(match.Signature);
+                    var description = Markup.Escape(match.Description);
+                    lines.Add(isSelected
+                        ? $"{prefix} [{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{signature}[/] [dim]- {description}[/]"
+                        : $"{prefix} [grey]{signature}[/] [dim]- {description}[/]");
+                }
+            }
+        }
+
+        foreach (var line in lines)
+        {
+            CliTheme.MarkupLine(line);
+        }
+
+        return lines.Count;
+    }
+
+    private static void ClearPromptFrame(int renderedLines)
+    {
+        for (var i = 0; i < renderedLines; i++)
+        {
+            Console.Write("\u001b[1A");
+            Console.Write("\r\u001b[2K");
+        }
+    }
+
+    private static List<CommandSpec> GetHierarchySuggestionMatches(string query)
+    {
+        var normalized = query.Trim().ToLowerInvariant();
+        IEnumerable<CommandSpec> source = HierarchyCommands
+            .Where(command => !command.Description.StartsWith("Alias for", StringComparison.OrdinalIgnoreCase));
+
+        if (!string.IsNullOrWhiteSpace(normalized))
+        {
+            source = source.Where(command =>
+                command.Signature.Contains(normalized, StringComparison.OrdinalIgnoreCase)
+                || command.Description.Contains(normalized, StringComparison.OrdinalIgnoreCase)
+                || command.Trigger.StartsWith(normalized, StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith(command.Trigger, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return source.Take(12).ToList();
+    }
+
+    private static List<(string Label, string CommitCommand)> GetHierarchyIntellisenseCandidates(string query)
+    {
+        return GetHierarchySuggestionMatches(query)
+            .Select(match => (match.Signature, match.Trigger))
+            .ToList();
     }
 
     private static string FormatHierarchyCommandFailure(string? message, string fallback = "hierarchy command failed")


### PR DESCRIPTION
## Summary
- Adds dedicated hierarchy-mode IntelliSense in the in-frame prompt with command signatures, argument usage, and command descriptions.
- Adds inspector-context IntelliSense command specs so composer suggestions reflect inspector commands instead of only project-wide commands.
- Bumps CLI version from `0.3.0` to `0.3.1` and records the change in `Changelog.md`.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Docs
- [ ] CI/Build
- [x] Chore

## Scope
- Affected areas/components:
- `src/unifocl/Program.cs`
- `src/unifocl/Services/HierarchyTui.cs`
- `src/unifocl/Services/CliVersion.cs`
- `Changelog.md`
- Out-of-scope / intentionally not addressed:
- Unity editor-side daemon protocol changes.
- Additional inspector command implementations (`make/rm/rn/mv`) beyond IntelliSense visibility.

## How to Test
1. `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Run CLI, open a project, enter `/hierarchy`, type partial commands and verify command/argument IntelliSense appears with descriptions.
3. Enter inspector mode (`/inspect ...`), type commands in composer, and verify inspector-specific command suggestions and usage are shown.

Expected results:
- Build succeeds.
- Hierarchy prompt supports command suggestions, arrow selection, enter insertion, and esc dismiss behavior.
- Inspector context shows inspector-focused command signatures and descriptions.

## Screenshots / Terminal Output (if applicable)
- Local build passed.
- Note: NU1900 warnings may appear in restricted network environments when querying NuGet vulnerability feed.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Changes are limited to command suggestion UX and version/changelog metadata.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
