### PR TITLE
Harden 0.5.1 and stabilize bridge scene persistence flow

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -20,6 +20,7 @@ The agent must treat the following as **non-negotiable principles**:
 - **Contract Pipeline Strategy (Primary):** Shared transport contracts must be defined in protobuf `.proto` files under the `external/unifocl-protobuf` submodule and consumed via generated C# classes (`Unifocl.Shared`). CLI code must reference only generated protobuf DTOs for transport boundaries; Unity bridge code maps Unity types to/from these stable protobuf contracts.
 - **Plugin Sync:** After protobuf contract updates, run `./scripts/sync-protobuf-unity-plugin.sh` to rebuild `Unifocl.Shared.dll` and copy it into `src/unifocl.unity/EditorScripts/Plugins/`.
 - **Build Versioning Rule:** Development builds must use `aX` incremental suffixes in `CliVersion.SemVer` (for example: `0.3.2a1` -> `0.3.2a2`)
+- **Bridge Protocol Rule:** If a change requires users to re-run `/init` (for example editor payload/package content changes), bump `CliVersion.Protocol` and include `/init` re-run guidance in the task summary/PR description.
 - **Repository Rules:** Always branch from `main` before any actions and create PRs using `.github/pull_request_template.md` in English
 - **Mainline Sync Rule:** Before finalizing work (push/PR), merge latest `main` (or `origin/main`) to detect upstream leading changes early and resolve any conflicts before continuing
 - **Deployment:** NEVER deploy or publish artifacts without permission

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.1 - 2026-03-09
+
+### Changed
+- Added `DaemonScenePersistenceService` as the shared save pipeline for Unity scene persistence operations.
+- Added `DaemonSceneManager` to centralize active-scene resolution and scene load/activation transitions for editor bridge services.
+- Hierarchy and inspector mutation flows now persist scenes through the shared persistence service.
+- Project scene-load flow now runs a shared persistence preflight save path before scene switching.
+- Embedded package payload generation now includes `DaemonSceneManager.cs` and `DaemonScenePersistenceService.cs` so `/init` installs compile-complete bridge sources.
+- Bumped bridge protocol to `v3`; projects must re-run `/init` to refresh embedded bridge payload.
+
 ## 0.5.0 - 2026-03-09
 
 ### Patch Train

--- a/src/unifocl.unity/EditorScripts/Services/DaemonHierarchyService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonHierarchyService.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
-using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
@@ -140,8 +139,7 @@ namespace UniFocl.EditorBridge
 
         private static string ExecuteCreate(HierarchyCommandRequest request)
         {
-            var activeScene = SceneManager.GetActiveScene();
-            if (!activeScene.IsValid())
+            if (!DaemonSceneManager.TryGetActiveScene(out var activeScene))
             {
                 return JsonUtility.ToJson(new HierarchyCommandResponse { ok = false, message = "active scene is not valid" });
             }
@@ -190,7 +188,7 @@ namespace UniFocl.EditorBridge
                 return JsonUtility.ToJson(new HierarchyCommandResponse { ok = false, message = "mk did not create any objects" });
             }
 
-            PersistSceneChanges(lastCreated.scene);
+            DaemonScenePersistenceService.PersistMutationScenes("hierarchy mutation", lastCreated.scene);
             _snapshotVersion++;
 
             return JsonUtility.ToJson(new HierarchyCommandResponse
@@ -548,7 +546,7 @@ namespace UniFocl.EditorBridge
 
             Undo.RecordObject(target, "unifocl toggle hierarchy active");
             target.SetActive(!target.activeSelf);
-            PersistSceneChanges(target.scene);
+            DaemonScenePersistenceService.PersistMutationScenes("hierarchy mutation", target.scene);
             _snapshotVersion++;
 
             return JsonUtility.ToJson(new HierarchyCommandResponse
@@ -577,7 +575,7 @@ namespace UniFocl.EditorBridge
             Undo.DestroyObjectImmediate(target);
             if (scene.IsValid())
             {
-                PersistSceneChanges(scene);
+                DaemonScenePersistenceService.PersistMutationScenes("hierarchy mutation", scene);
             }
 
             _snapshotVersion++;
@@ -611,7 +609,7 @@ namespace UniFocl.EditorBridge
 
             Undo.RecordObject(target, "unifocl rename hierarchy object");
             target.name = request.name.Trim();
-            PersistSceneChanges(target.scene);
+            DaemonScenePersistenceService.PersistMutationScenes("hierarchy mutation", target.scene);
             _snapshotVersion++;
 
             return JsonUtility.ToJson(new HierarchyCommandResponse
@@ -644,8 +642,7 @@ namespace UniFocl.EditorBridge
 
             if (nextParentId == SceneRootNodeId)
             {
-                var activeScene = SceneManager.GetActiveScene();
-                if (!activeScene.IsValid())
+                if (!DaemonSceneManager.TryGetActiveScene(out var activeScene))
                 {
                     return JsonUtility.ToJson(new HierarchyCommandResponse { ok = false, message = "active scene is not valid" });
                 }
@@ -653,7 +650,7 @@ namespace UniFocl.EditorBridge
                 Undo.SetTransformParent(target.transform, null, "unifocl move hierarchy object");
                 var previousScene = target.scene;
                 SceneManager.MoveGameObjectToScene(target, activeScene);
-                PersistSceneChanges(previousScene, activeScene);
+                DaemonScenePersistenceService.PersistMutationScenes("hierarchy mutation", previousScene, activeScene);
                 _snapshotVersion++;
                 return JsonUtility.ToJson(new HierarchyCommandResponse
                 {
@@ -684,7 +681,7 @@ namespace UniFocl.EditorBridge
             var previousParentScene = target.scene;
             Undo.SetTransformParent(target.transform, parentObject.transform, "unifocl move hierarchy object");
             SceneManager.MoveGameObjectToScene(target, parentObject.scene);
-            PersistSceneChanges(previousParentScene, parentObject.scene);
+            DaemonScenePersistenceService.PersistMutationScenes("hierarchy mutation", previousParentScene, parentObject.scene);
             _snapshotVersion++;
 
             return JsonUtility.ToJson(new HierarchyCommandResponse
@@ -696,29 +693,11 @@ namespace UniFocl.EditorBridge
             });
         }
 
-        private static void PersistSceneChanges(params Scene[] scenes)
-        {
-            var seen = new HashSet<int>();
-            foreach (var scene in scenes)
-            {
-                if (!scene.IsValid() || !seen.Add(scene.handle))
-                {
-                    continue;
-                }
-
-                EditorSceneManager.MarkSceneDirty(scene);
-                if (!EditorSceneManager.SaveScene(scene))
-                {
-                    Debug.LogWarning($"[unifocl] Failed to save scene '{scene.name}' (path: '{scene.path}') after hierarchy mutation.");
-                }
-            }
-        }
-
         private static HierarchySnapshotResponse BuildSnapshot()
         {
-            var scene = SceneManager.GetActiveScene();
+            var hasActiveScene = DaemonSceneManager.TryGetActiveScene(out var scene);
             var sceneName = ResolveSceneName(scene);
-            var children = scene.IsValid()
+            var children = hasActiveScene
                 ? scene.GetRootGameObjects()
                     .Select(ToDto)
                     .OrderBy(node => node.name, StringComparer.OrdinalIgnoreCase)

--- a/src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using UnityEditor;
-using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -218,7 +217,7 @@ namespace UniFocl.EditorBridge
                 Undo.RecordObject(behaviour, "unifocl toggle component enabled");
                 behaviour.enabled = !behaviour.enabled;
                 EditorUtility.SetDirty(behaviour);
-                PersistComponentSceneChanges(behaviour);
+                DaemonScenePersistenceService.PersistMutationScenes("inspector mutation", behaviour.gameObject.scene);
                 return true;
             }
 
@@ -227,7 +226,7 @@ namespace UniFocl.EditorBridge
                 Undo.RecordObject(renderer, "unifocl toggle renderer enabled");
                 renderer.enabled = !renderer.enabled;
                 EditorUtility.SetDirty(renderer);
-                PersistComponentSceneChanges(renderer);
+                DaemonScenePersistenceService.PersistMutationScenes("inspector mutation", renderer.gameObject.scene);
                 return true;
             }
 
@@ -236,7 +235,7 @@ namespace UniFocl.EditorBridge
                 Undo.RecordObject(collider, "unifocl toggle collider enabled");
                 collider.enabled = !collider.enabled;
                 EditorUtility.SetDirty(collider);
-                PersistComponentSceneChanges(collider);
+                DaemonScenePersistenceService.PersistMutationScenes("inspector mutation", collider.gameObject.scene);
                 return true;
             }
 
@@ -263,7 +262,7 @@ namespace UniFocl.EditorBridge
             property.boolValue = !property.boolValue;
             serializedObject.ApplyModifiedProperties();
             EditorUtility.SetDirty(component);
-            PersistComponentSceneChanges(component);
+            DaemonScenePersistenceService.PersistMutationScenes("inspector mutation", component.gameObject.scene);
             return true;
         }
 
@@ -291,23 +290,8 @@ namespace UniFocl.EditorBridge
 
             serializedObject.ApplyModifiedProperties();
             EditorUtility.SetDirty(component);
-            PersistComponentSceneChanges(component);
+            DaemonScenePersistenceService.PersistMutationScenes("inspector mutation", component.gameObject.scene);
             return true;
-        }
-
-        private static void PersistComponentSceneChanges(Component component)
-        {
-            var scene = component.gameObject.scene;
-            if (!scene.IsValid())
-            {
-                return;
-            }
-
-            EditorSceneManager.MarkSceneDirty(scene);
-            if (!EditorSceneManager.SaveScene(scene))
-            {
-                Debug.LogWarning($"[unifocl] Failed to save scene '{scene.name}' (path: '{scene.path}') after inspector mutation.");
-            }
         }
 
         private static Component? ResolveComponent(string? targetPath, int componentIndex, string? componentName)
@@ -335,8 +319,7 @@ namespace UniFocl.EditorBridge
 
         private static GameObject? ResolveTarget(string? targetPath)
         {
-            var scene = SceneManager.GetActiveScene();
-            if (!scene.IsValid())
+            if (!DaemonSceneManager.TryGetActiveScene(out var scene))
             {
                 return null;
             }

--- a/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
@@ -258,28 +258,19 @@ namespace UniFocl.EditorBridge
 
                 try
                 {
-                    var loadedScene = EditorSceneManager.OpenScene(requestedScenePath, OpenSceneMode.Single);
-                    if (!loadedScene.IsValid() || !loadedScene.isLoaded)
+                    if (DaemonSceneManager.TryGetActiveScene(out var activeScene))
                     {
-                        return JsonUtility.ToJson(new ProjectCommandResponse { ok = false, message = $"scene load failed: {requestedScenePath}" });
+                        DaemonScenePersistenceService.SaveScenesWithoutMarkDirty(
+                            "project scene-switch preflight",
+                            activeScene);
                     }
 
-                    var loadedScenePath = loadedScene.path.Replace('\\', '/');
-                    if (!loadedScenePath.Equals(requestedScenePath, StringComparison.OrdinalIgnoreCase))
+                    if (!DaemonSceneManager.TryLoadSceneSingleAndActivate(requestedScenePath, out _, out var loadError))
                     {
                         return JsonUtility.ToJson(new ProjectCommandResponse
                         {
                             ok = false,
-                            message = $"scene load failed: requested '{requestedScenePath}', loaded '{loadedScenePath}'"
-                        });
-                    }
-
-                    if (!TryEnsureActiveScene(loadedScene, requestedScenePath))
-                    {
-                        return JsonUtility.ToJson(new ProjectCommandResponse
-                        {
-                            ok = false,
-                            message = $"scene load failed: unable to activate scene '{requestedScenePath}'"
+                            message = loadError ?? $"scene load failed: {requestedScenePath}"
                         });
                     }
 
@@ -2228,44 +2219,6 @@ namespace UniFocl.EditorBridge
             return !string.IsNullOrWhiteSpace(assetPath)
                    && assetPath.StartsWith("Assets/", StringComparison.Ordinal)
                    && !assetPath.Contains("..", StringComparison.Ordinal);
-        }
-
-        private static bool TryEnsureActiveScene(Scene loadedScene, string requestedScenePath)
-        {
-            if (!loadedScene.IsValid() || !loadedScene.isLoaded)
-            {
-                return false;
-            }
-
-            if (IsRequestedSceneActive(requestedScenePath))
-            {
-                return true;
-            }
-
-            if (SceneManager.SetActiveScene(loadedScene) && IsRequestedSceneActive(requestedScenePath))
-            {
-                return true;
-            }
-
-            if (EditorSceneManager.SetActiveScene(loadedScene) && IsRequestedSceneActive(requestedScenePath))
-            {
-                return true;
-            }
-
-            // Opening with OpenSceneMode.Single usually makes the scene active already.
-            return IsRequestedSceneActive(requestedScenePath);
-        }
-
-        private static bool IsRequestedSceneActive(string requestedScenePath)
-        {
-            var activeScene = SceneManager.GetActiveScene();
-            if (!activeScene.IsValid() || !activeScene.isLoaded)
-            {
-                return false;
-            }
-
-            return activeScene.path.Replace('\\', '/')
-                .Equals(requestedScenePath, StringComparison.OrdinalIgnoreCase);
         }
 
         private static string GetProjectRoot()

--- a/src/unifocl.unity/EditorScripts/Services/DaemonSceneManager.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonSceneManager.cs
@@ -1,0 +1,120 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+
+namespace UniFocl.EditorBridge
+{
+    internal static class DaemonSceneManager
+    {
+        public static bool TryGetActiveScene(out Scene scene)
+        {
+            var activeScene = SceneManager.GetActiveScene();
+            if (IsValidLoadedScene(activeScene))
+            {
+                scene = activeScene;
+                return true;
+            }
+
+            for (var i = 0; i < SceneManager.sceneCount; i++)
+            {
+                var loaded = SceneManager.GetSceneAt(i);
+                if (IsValidLoadedScene(loaded))
+                {
+                    scene = loaded;
+                    return true;
+                }
+            }
+
+            scene = default;
+            return false;
+        }
+
+        public static bool TryResolveSceneForPersistence(Scene candidate, out Scene scene)
+        {
+            if (IsValidLoadedScene(candidate))
+            {
+                scene = candidate;
+                return true;
+            }
+
+            return TryGetActiveScene(out scene);
+        }
+
+        public static bool TryLoadSceneSingleAndActivate(string requestedScenePath, out Scene loadedScene, out string? error)
+        {
+            loadedScene = default;
+            error = null;
+
+            var openedScene = EditorSceneManager.OpenScene(requestedScenePath, OpenSceneMode.Single);
+            if (!IsValidLoadedScene(openedScene))
+            {
+                error = $"scene load failed: {requestedScenePath}";
+                return false;
+            }
+
+            var loadedScenePath = NormalizePath(openedScene.path);
+            if (!loadedScenePath.Equals(requestedScenePath, StringComparison.OrdinalIgnoreCase))
+            {
+                error = $"scene load failed: requested '{requestedScenePath}', loaded '{loadedScenePath}'";
+                return false;
+            }
+
+            if (!TryEnsureActiveScene(openedScene, requestedScenePath))
+            {
+                error = $"scene load failed: unable to activate scene '{requestedScenePath}'";
+                return false;
+            }
+
+            loadedScene = openedScene;
+            return true;
+        }
+
+        private static bool TryEnsureActiveScene(Scene loadedScene, string requestedScenePath)
+        {
+            if (!IsValidLoadedScene(loadedScene))
+            {
+                return false;
+            }
+
+            if (IsRequestedSceneActive(requestedScenePath))
+            {
+                return true;
+            }
+
+            if (SceneManager.SetActiveScene(loadedScene) && IsRequestedSceneActive(requestedScenePath))
+            {
+                return true;
+            }
+
+            if (EditorSceneManager.SetActiveScene(loadedScene) && IsRequestedSceneActive(requestedScenePath))
+            {
+                return true;
+            }
+
+            return IsRequestedSceneActive(requestedScenePath);
+        }
+
+        private static bool IsRequestedSceneActive(string requestedScenePath)
+        {
+            if (!TryGetActiveScene(out var activeScene))
+            {
+                return false;
+            }
+
+            return NormalizePath(activeScene.path)
+                .Equals(requestedScenePath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsValidLoadedScene(Scene scene)
+        {
+            return scene.IsValid() && scene.isLoaded;
+        }
+
+        private static string NormalizePath(string? scenePath)
+        {
+            return (scenePath ?? string.Empty).Replace('\\', '/');
+        }
+    }
+}
+#endif

--- a/src/unifocl.unity/EditorScripts/Services/DaemonScenePersistenceService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonScenePersistenceService.cs
@@ -1,0 +1,52 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace UniFocl.EditorBridge
+{
+    internal static class DaemonScenePersistenceService
+    {
+        public static void PersistMutationScenes(string mutationSource, params Scene[] scenes)
+        {
+            SaveScenes(markDirty: true, mutationSource, scenes);
+        }
+
+        public static void SaveScenesWithoutMarkDirty(string source, params Scene[] scenes)
+        {
+            SaveScenes(markDirty: false, source, scenes);
+        }
+
+        private static void SaveScenes(bool markDirty, string source, params Scene[] scenes)
+        {
+            var seen = new HashSet<int>();
+            foreach (var scene in scenes)
+            {
+                if (!DaemonSceneManager.TryResolveSceneForPersistence(scene, out var sceneToSave))
+                {
+                    Debug.LogWarning($"[unifocl] Skipping scene save after {source}: no valid loaded scene is available.");
+                    continue;
+                }
+
+                if (!seen.Add(sceneToSave.handle))
+                {
+                    continue;
+                }
+
+                if (markDirty)
+                {
+                    EditorSceneManager.MarkSceneDirty(sceneToSave);
+                }
+
+                if (!EditorSceneManager.SaveScene(sceneToSave))
+                {
+                    Debug.LogWarning(
+                        $"[unifocl] Failed to save scene '{sceneToSave.name}' (path: '{sceneToSave.path}') after {source}.");
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -2,9 +2,9 @@ internal static class CliVersion
 {
     public const int Major = 0;
     public const int Minor = 5;
-    public const int Patch = 0;
+    public const int Patch = 1;
     public const string DevCycle = "";
-    public const string Protocol = "v2";
+    public const string Protocol = "v3";
 
     public static string SemVer => string.IsNullOrWhiteSpace(DevCycle)
         ? $"{Major}.{Minor}.{Patch}"

--- a/src/unifocl/Services/EditorDependencyInitializerService.cs
+++ b/src/unifocl/Services/EditorDependencyInitializerService.cs
@@ -14,6 +14,8 @@ internal sealed class EditorDependencyInitializerService
     private const string DaemonHierarchyServiceResource = "Payload/EditorScripts/Services/DaemonHierarchyService.cs";
     private const string DaemonInspectorServiceResource = "Payload/EditorScripts/Services/DaemonInspectorService.cs";
     private const string DaemonProjectServiceResource = "Payload/EditorScripts/Services/DaemonProjectService.cs";
+    private const string DaemonSceneManagerResource = "Payload/EditorScripts/Services/DaemonSceneManager.cs";
+    private const string DaemonScenePersistenceServiceResource = "Payload/EditorScripts/Services/DaemonScenePersistenceService.cs";
     private const string SharedModelsSourceResource = "Payload/SharedModels/BridgeModels.cs";
 
     public OperationResult InitializeProject(string projectPath, Action<string> log)
@@ -112,7 +114,9 @@ internal sealed class EditorDependencyInitializerService
             Path.Combine(packagePath, "Editor", "Services", "DaemonAssetIndexService.cs"),
             Path.Combine(packagePath, "Editor", "Services", "DaemonHierarchyService.cs"),
             Path.Combine(packagePath, "Editor", "Services", "DaemonInspectorService.cs"),
-            Path.Combine(packagePath, "Editor", "Services", "DaemonProjectService.cs")
+            Path.Combine(packagePath, "Editor", "Services", "DaemonProjectService.cs"),
+            Path.Combine(packagePath, "Editor", "Services", "DaemonSceneManager.cs"),
+            Path.Combine(packagePath, "Editor", "Services", "DaemonScenePersistenceService.cs")
         };
         foreach (var requiredFile in requiredFiles)
         {
@@ -215,7 +219,9 @@ internal sealed class EditorDependencyInitializerService
                 (DaemonAssetIndexServiceResource, Path.Combine("Editor", "Services", "DaemonAssetIndexService.cs")),
                 (DaemonHierarchyServiceResource, Path.Combine("Editor", "Services", "DaemonHierarchyService.cs")),
                 (DaemonInspectorServiceResource, Path.Combine("Editor", "Services", "DaemonInspectorService.cs")),
-                (DaemonProjectServiceResource, Path.Combine("Editor", "Services", "DaemonProjectService.cs"))
+                (DaemonProjectServiceResource, Path.Combine("Editor", "Services", "DaemonProjectService.cs")),
+                (DaemonSceneManagerResource, Path.Combine("Editor", "Services", "DaemonSceneManager.cs")),
+                (DaemonScenePersistenceServiceResource, Path.Combine("Editor", "Services", "DaemonScenePersistenceService.cs"))
             };
 
             foreach (var item in resourceToTarget)

--- a/src/unifocl/unifocl.csproj
+++ b/src/unifocl/unifocl.csproj
@@ -22,6 +22,8 @@
     <EmbeddedResource Include="../unifocl.unity/EditorScripts/Services/DaemonHierarchyService.cs" LogicalName="Payload/EditorScripts/Services/DaemonHierarchyService.cs" />
     <EmbeddedResource Include="../unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs" LogicalName="Payload/EditorScripts/Services/DaemonInspectorService.cs" />
     <EmbeddedResource Include="../unifocl.unity/EditorScripts/Services/DaemonProjectService.cs" LogicalName="Payload/EditorScripts/Services/DaemonProjectService.cs" />
+    <EmbeddedResource Include="../unifocl.unity/EditorScripts/Services/DaemonSceneManager.cs" LogicalName="Payload/EditorScripts/Services/DaemonSceneManager.cs" />
+    <EmbeddedResource Include="../unifocl.unity/EditorScripts/Services/DaemonScenePersistenceService.cs" LogicalName="Payload/EditorScripts/Services/DaemonScenePersistenceService.cs" />
     <EmbeddedResource Include="../unifocl.unity/SharedModels/BridgeModels.cs" LogicalName="Payload/SharedModels/BridgeModels.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Harden release version to 0.5.1 (close a devcycle) and bump bridge protocol to v3
- Add shared Unity bridge scene abstractions: DaemonSceneManager and DaemonScenePersistenceService
- Route hierarchy, inspector, and project scene transition/persistence calls through the shared scene services
- Include new bridge service files in embedded package payload generation and /init installation validation
- Add AGENT rule: any /init-required payload change must bump protocol and include /init guidance

## Related Issues
- Closes #66
- Related to #68

## Type of Change
- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [x] Docs
- [x] CI/Build
- [x] Chore

## Scope
- Affected areas/components: CLI versioning/protocol, editor bridge payload embedding, Unity bridge hierarchy/inspector/project scene handling, init/install validation, agent workflow rules
- Out-of-scope / intentionally not addressed: project-mode render regression root fix (tracked separately)

## How to Test
1. Run dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal
2. In a Unity project, run /init from updated CLI and let Unity compile bridge package
3. Perform hierarchy/inspector mutations, restart Unity, and confirm mutations persist
4. Trigger project scene loads and verify active scene transition remains correct

Expected results:
- Build succeeds
- /init installs compile-complete bridge package (includes scene manager + persistence service)
- Scene mutations persist across editor restarts
- Scene load transitions activate requested scene consistently

## Screenshots / Terminal Output (if applicable)
- dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal passed

## Breaking Changes
- [x] This PR introduces a breaking change.

If yes, describe migration steps:
- Bridge protocol bumped to v3; re-run /init for existing projects to refresh embedded package payload

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No credential/material handling changes

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
