### PR TITLE
Release 0.9.0: stabilize inspector component workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.9.0 - 2026-03-09
+
+### Changed
+- Officialized `0.9.0` by closing the development cycle suffix.
+- Added inspector component-list workflow parity with project mode via `component add` / `component remove`, including fuzzy catalog IntelliSense and `DisallowMultipleComponent` guards in bridge mutations.
+- Standardized focus-mode controls to `F7` as the sole toggle across project/hierarchy/inspector contexts and updated keybind labels/docs accordingly.
+- Fixed inspector TUI resilience around focus-exit transitions:
+  - preserve component-list rendering on first focus-mode exit
+  - remove redundant focus on/off stream logs
+  - cap inspector component IntelliSense to first 10 visible suggestions with overflow indicator
+- Fixed prompt badge markup escaping so literal badges render correctly (`[inspect]`, `[safe]`) instead of leaking raw style tags.
+- Bumped bridge protocol to `v4`; projects must re-run `/init` to refresh embedded bridge payload.
+
+## 0.9.0a2 - 2026-03-09
+
+### Changed
+- Fixed inspector `comp` / `component` IntelliSense candidate duplication by enforcing unique component suggestion entries.
+- Fixed inspector composer prompt badge markup escaping so literal badges render correctly (`[inspect]`, `[safe]`) instead of leaking raw style tags.
+
+## 0.9.0a1 - 2026-03-09
+
+### Changed
+- Started the `0.9.0` development cycle with `a1` suffix versioning.
+- Added inspector component-list workflow parity with project mode via `component add` / `component remove`, including fuzzy catalog IntelliSense and `DisallowMultipleComponent` guards in bridge mutations.
+
 ## 0.8.0 - 2026-03-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -392,21 +392,20 @@ Use the `f` or `ff` command to trigger fuzzy search across your project or inspe
 The CLI provides keyboard-driven navigation for interacting with lists and structures without typing out indices.
 
 **Global Keybinds**
-* **`F7`**: Toggle focus for Hierarchy TUI, Project navigator, or Recent projects list.
-* **`F8`**: Toggle focus for Inspector.
+* **`F7`**: Toggle focus for Hierarchy TUI, Project navigator, Recent projects list, and Inspector.
 * **`Esc`**: Dismiss Intellisense, or clear input if already dismissed.
 * **`↑` / `↓`**: Navigate fuzzy/Intellisense candidates.
 * **`Enter`**: Insert selected suggestion or commit input.
 
 **Context-Specific Focus Navigation**
-Once focused (`F7` or `F8`), the arrow keys and tab behave contextually:
+Once focused (`F7`), the arrow keys and tab behave contextually:
 
 | Action | Hierarchy Focus | Project Focus | Inspector Focus |
 | :--- | :--- | :--- | :--- |
 | **`↑` / `↓`** | Move highlighted GameObject | Move highlighted file/folder | Move highlighted component/field |
 | **`Tab`** | Expand selected node | Reveal/open selected entry | Inspect selected component |
 | **`Shift+Tab`**| Collapse selected node | Move to parent folder | Back to component list |
-| **Exit Focus** | `Esc` or `F7` | `Esc` or `F7` | `Esc` or `F8` |
+| **Exit Focus** | `Esc` or `F7` | `Esc` or `F7` | `Esc` or `F7` |
 
 ---
 

--- a/src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs
+++ b/src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs
@@ -163,6 +163,7 @@ namespace UniFocl.EditorBridge
     internal sealed class InspectorMutationResponse
     {
         public bool ok;
+        public string message = string.Empty;
     }
 
     [Serializable]

--- a/src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -11,6 +12,8 @@ namespace UniFocl.EditorBridge
 {
     internal static class DaemonInspectorService
     {
+        private static readonly Dictionary<string, Type> ComponentTypeLookup = BuildComponentTypeLookup();
+
         public static string Execute(string payload)
         {
             InspectorBridgeRequest? request;
@@ -51,6 +54,12 @@ namespace UniFocl.EditorBridge
                         results = Find(request.targetPath, request.query, request.componentName)
                     });
 
+                case "add-component":
+                    return JsonUtility.ToJson(BuildComponentMutationResponse(TryAddComponent(request.targetPath, request.componentName, out var addError), addError));
+
+                case "remove-component":
+                    return JsonUtility.ToJson(BuildComponentMutationResponse(TryRemoveComponent(request.targetPath, request.componentIndex, request.componentName, out var removeError), removeError));
+
                 case "toggle-component":
                     return JsonUtility.ToJson(new InspectorMutationResponse
                     {
@@ -72,6 +81,15 @@ namespace UniFocl.EditorBridge
                 default:
                     return JsonUtility.ToJson(new InspectorMutationResponse { ok = false });
             }
+        }
+
+        private static InspectorMutationResponse BuildComponentMutationResponse(bool ok, string? error)
+        {
+            return new InspectorMutationResponse
+            {
+                ok = ok,
+                message = ok ? string.Empty : (error ?? "component mutation failed")
+            };
         }
 
         private static InspectorComponentEntry[] GetComponents(string? targetPath)
@@ -242,6 +260,71 @@ namespace UniFocl.EditorBridge
             return false;
         }
 
+        private static bool TryAddComponent(string? targetPath, string? componentTypeToken, out string? error)
+        {
+            error = null;
+            var target = ResolveTarget(targetPath);
+            if (target is null)
+            {
+                error = "inspector target was not found";
+                return false;
+            }
+
+            if (!TryResolveComponentType(componentTypeToken, out var componentType))
+            {
+                error = $"unsupported component type: {componentTypeToken}";
+                return false;
+            }
+
+            if (componentType == typeof(Transform))
+            {
+                error = "Transform cannot be added manually";
+                return false;
+            }
+
+            var disallowMultiple = Attribute.IsDefined(componentType, typeof(DisallowMultipleComponent), inherit: true);
+            if (disallowMultiple && target.GetComponent(componentType) is not null)
+            {
+                error = $"{componentType.Name} disallows multiple components on the same object";
+                return false;
+            }
+
+            Undo.RegisterCompleteObjectUndo(target, "unifocl add component");
+            var added = Undo.AddComponent(target, componentType);
+            if (added is null)
+            {
+                error = $"failed to add component: {componentType.Name}";
+                return false;
+            }
+
+            EditorUtility.SetDirty(target);
+            EditorUtility.SetDirty(added);
+            DaemonScenePersistenceService.PersistMutationScenes("inspector mutation", target.scene);
+            return true;
+        }
+
+        private static bool TryRemoveComponent(string? targetPath, int componentIndex, string? componentName, out string? error)
+        {
+            error = null;
+            var component = ResolveComponent(targetPath, componentIndex, componentName);
+            if (component is null)
+            {
+                error = "component was not found on target object";
+                return false;
+            }
+
+            if (component is Transform)
+            {
+                error = "Transform cannot be removed";
+                return false;
+            }
+
+            var scene = component.gameObject.scene;
+            Undo.DestroyObjectImmediate(component);
+            DaemonScenePersistenceService.PersistMutationScenes("inspector mutation", scene);
+            return true;
+        }
+
         private static bool ToggleField(string? targetPath, int componentIndex, string? componentName, string? fieldName)
         {
             var component = ResolveComponent(targetPath, componentIndex, componentName);
@@ -310,11 +393,44 @@ namespace UniFocl.EditorBridge
 
             if (!string.IsNullOrWhiteSpace(componentName))
             {
+                if (TryResolveComponentType(componentName, out var resolvedType))
+                {
+                    var typed = target.GetComponent(resolvedType);
+                    if (typed is not null)
+                    {
+                        return typed;
+                    }
+                }
+
                 return components.FirstOrDefault(component =>
                     component is not null && component.GetType().Name.Equals(componentName, StringComparison.OrdinalIgnoreCase));
             }
 
             return null;
+        }
+
+        private static bool TryResolveComponentType(string? token, out Type componentType)
+        {
+            componentType = typeof(Component);
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return false;
+            }
+
+            if (ComponentTypeLookup.TryGetValue(token.Trim(), out var exact))
+            {
+                componentType = exact;
+                return true;
+            }
+
+            var normalized = NormalizeTypeLookupKey(token);
+            if (ComponentTypeLookup.TryGetValue(normalized, out var matched))
+            {
+                componentType = matched;
+                return true;
+            }
+
+            return false;
         }
 
         private static GameObject? ResolveTarget(string? targetPath)
@@ -650,6 +766,58 @@ namespace UniFocl.EditorBridge
             }
 
             return true;
+        }
+
+        private static Dictionary<string, Type> BuildComponentTypeLookup()
+        {
+            var lookup = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type[] types;
+                try
+                {
+                    types = assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    types = ex.Types.Where(type => type is not null).Cast<Type>().ToArray();
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (var type in types)
+                {
+                    if (type.IsAbstract || !typeof(Component).IsAssignableFrom(type))
+                    {
+                        continue;
+                    }
+
+                    lookup[type.FullName ?? type.Name] = type;
+                    lookup[type.Name] = type;
+                    lookup[NormalizeTypeLookupKey(type.Name)] = type;
+                    if (!string.IsNullOrWhiteSpace(type.FullName))
+                    {
+                        lookup[NormalizeTypeLookupKey(type.FullName)] = type;
+                    }
+                }
+            }
+
+            return lookup;
+        }
+
+        private static string NormalizeTypeLookupKey(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var chars = value.Where(char.IsLetterOrDigit)
+                .Select(char.ToLowerInvariant)
+                .ToArray();
+            return new string(chars);
         }
 
         private static bool TryScore(string query, string candidate, out double score)

--- a/src/unifocl/Models/KeyboardIntentModels.cs
+++ b/src/unifocl/Models/KeyboardIntentModels.cs
@@ -9,6 +9,5 @@ internal enum KeyboardIntent
     Tab,
     ShiftTab,
     Escape,
-    FocusProject,
-    FocusInspector
+    FocusProject
 }

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -163,6 +163,9 @@ var inspectorCommands = new List<CommandSpec>
     new("e <field> <value...>", "Alias for edit", "e"),
     new("toggle <component-index|field>", "Toggle component enabled state or bool field", "toggle"),
     new("t <component-index|field>", "Alias for toggle", "t"),
+    new("component add <type>", "Add a component from catalog to inspected target", "component add"),
+    new("component remove <index|name>", "Remove a component from inspected target", "component remove"),
+    new("comp <add|remove> <...>", "Alias for component", "comp"),
     new("f <query>", "Fuzzy find in inspector context", "f"),
     new("ff <query>", "Alias for fuzzy find", "ff"),
     new("scroll [body|stream] <up|down> [count]", "Scroll inspector body or command stream", "scroll"),
@@ -688,8 +691,7 @@ static string? ReadInteractiveInput(
             case ConsoleKey.F7:
                 if (input.Length == 0
                     && session.ContextMode == CliContextMode.Inspector
-                    && session.Inspector is not null
-                    && session.Inspector.Depth == InspectorDepth.ComponentFields)
+                    && session.Inspector is not null)
                 {
                     Console.WriteLine();
                     return ":focus-inspector";
@@ -709,15 +711,6 @@ static string? ReadInteractiveInput(
                 {
                     Console.WriteLine();
                     return ":focus-recent";
-                }
-                break;
-            case ConsoleKey.F8:
-                if (input.Length == 0
-                    && session.ContextMode == CliContextMode.Inspector
-                    && session.Inspector is not null)
-                {
-                    Console.WriteLine();
-                    return ":focus-inspector";
                 }
                 break;
             default:
@@ -752,7 +745,8 @@ static bool ShouldCommitSuggestionOnEnter(
         return false;
     }
 
-    return IsMkTypeSelectionPhase(input, session);
+    return IsMkTypeSelectionPhase(input, session)
+        || IsInspectorComponentAddSelectionPhase(input, session);
 }
 
 static bool IsMkTypeSelectionPhase(string input, CliSessionState session)
@@ -781,6 +775,34 @@ static bool IsMkTypeSelectionPhase(string input, CliSessionState session)
     }
 
     return false;
+}
+
+static bool IsInspectorComponentAddSelectionPhase(string input, CliSessionState session)
+{
+    var context = session.Inspector;
+    if (context is null || context.Depth != InspectorDepth.ComponentList)
+    {
+        return false;
+    }
+
+    var tokens = TokenizeComposerInput(input.TrimStart());
+    if (tokens.Count == 0)
+    {
+        return false;
+    }
+
+    var command = tokens[0].ToLowerInvariant();
+    if (command is not ("component" or "comp"))
+    {
+        return false;
+    }
+
+    if (tokens.Count == 1)
+    {
+        return true;
+    }
+
+    return tokens[1].Equals("add", StringComparison.OrdinalIgnoreCase);
 }
 
 static int RenderComposerFrame(
@@ -814,6 +836,11 @@ static int RenderComposerFrame(
         lines.Add(string.Empty);
         lines.AddRange(mkTypeLines);
     }
+    else if (TryGetInspectorComponentIntellisenseLines(input, session, selectedFuzzyCandidateIndex, out var componentLines))
+    {
+        lines.Add(string.Empty);
+        lines.AddRange(componentLines);
+    }
     else if (TryGetFuzzyQueryIntellisenseLines(input, session, selectedFuzzyCandidateIndex, out var fuzzyLines))
     {
         lines.Add(string.Empty);
@@ -829,7 +856,8 @@ static int RenderComposerFrame(
     }
     else if (session.Inspector is not null)
     {
-        lines.Add("[dim]Inspector mode: list, enter <idx>, up, set/edit <field> <value>, toggle <field|idx>, field select + Enter interactive edit (vector/enum/bool/number/string-overlay), scroll [body|stream] <up|down> [n], F7/F8 focus nav[/]");
+        // Keep inspector idle composer minimal; avoid verbose default helper line.
+        lines.Add(string.Empty);
     }
     else if (session.ContextMode == CliContextMode.Project && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
     {
@@ -905,13 +933,13 @@ static string BuildPromptLabelMarkup(CliSessionState session)
     {
         var escapedPromptPath = Markup.Escape(context.PromptPath);
         return context.Depth == InspectorDepth.ComponentList
-            ? $"[bold deepskyblue1]UnityCLI[/][grey]:[/][{CliTheme.Info}]{escapedPromptPath}[/] [grey][inspect][/]"
+            ? $"[bold deepskyblue1]UnityCLI[/][grey]:[/][{CliTheme.Info}]{escapedPromptPath}[/] [grey][[inspect]][/]"
             : $"[bold deepskyblue1]UnityCLI[/][grey]:[/][{CliTheme.Info}]{escapedPromptPath}[/]";
     }
 
     if (session.ContextMode == CliContextMode.Project && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
     {
-        var safeLabel = session.SafeModeEnabled ? " [yellow][safe][/]" : string.Empty;
+        var safeLabel = session.SafeModeEnabled ? " [yellow][[safe]][/]" : string.Empty;
         return $"[bold deepskyblue1]unifocl[/][grey]:[/][{CliTheme.Info}]{Markup.Escape(session.CurrentProjectPath)}[/]{safeLabel}";
     }
 
@@ -1041,7 +1069,7 @@ static void WriteKeybindsHelp(List<string> streamLog, CliSessionState session)
     AppendLog(streamLog, "[grey]keybinds[/]: global");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F7[/] enter/exit hierarchy focus mode (inside /hierarchy)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F7[/] enter/exit project focus mode (project context), or recent selection mode after /recent");
-    AppendLog(streamLog, "[grey]keybinds[/]: [white]F8[/] enter/exit inspector focus mode (inspector context)");
+    AppendLog(streamLog, "[grey]keybinds[/]: [white]F7[/] enter/exit inspector focus mode (inspector context)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]Esc[/] dismiss intellisense (or clear input if already dismissed)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]↑/↓[/] fuzzy candidate selection in composer");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]Enter[/] insert selected intellisense suggestion, or commit input when none selected");
@@ -1069,7 +1097,7 @@ static void WriteKeybindsHelp(List<string> streamLog, CliSessionState session)
     AppendLog(streamLog, "[grey]keybinds[/]: [white]Shift+Tab[/] back to component list");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]F7[/] toggle between inspector interactive selection and command input (component inspection)");
     AppendLog(streamLog, "[grey]keybinds[/]: [white]Esc[/] fields -> component list, component list -> hierarchy");
-    AppendLog(streamLog, "[grey]keybinds[/]: [white]F8[/] exit inspector focus mode");
+    AppendLog(streamLog, "[grey]keybinds[/]: [white]F7[/] exit inspector focus mode");
 
     if (session.ContextMode == CliContextMode.Project && session.Inspector is null)
     {
@@ -1077,7 +1105,7 @@ static void WriteKeybindsHelp(List<string> streamLog, CliSessionState session)
     }
     else if (session.ContextMode == CliContextMode.Inspector && session.Inspector is not null)
     {
-        AppendLog(streamLog, "[grey]keybinds[/]: current context -> inspector (F8 available now)");
+        AppendLog(streamLog, "[grey]keybinds[/]: current context -> inspector (F7 available now)");
     }
     else if (session.ContextMode == CliContextMode.Hierarchy)
     {
@@ -1118,6 +1146,12 @@ static bool TryGetComposerIntellisenseCandidates(
     if (TryGetProjectMkTypeComposerCandidates(input, session, out var mkTypeCandidates))
     {
         candidates = mkTypeCandidates;
+        return true;
+    }
+
+    if (TryGetInspectorComponentComposerCandidates(input, session, out var componentCandidates))
+    {
+        candidates = componentCandidates;
         return true;
     }
 
@@ -1266,6 +1300,130 @@ static bool TryGetProjectMkTypeComposerCandidates(
                 $"mk {display}",
                 $"mk {match.Type} "));
         }
+    }
+
+    return true;
+}
+
+static bool TryGetInspectorComponentIntellisenseLines(
+    string input,
+    CliSessionState session,
+    int selectedSuggestionIndex,
+    out List<string> lines)
+{
+    lines = [];
+    if (!TryGetInspectorComponentComposerCandidates(input, session, out var candidates))
+    {
+        return false;
+    }
+
+    lines.Add("[grey]component[/]: add suggestions [dim](fuzzy, up/down + enter to insert)[/]");
+    if (candidates.Count == 0)
+    {
+        lines.Add("[dim]no component matches[/]");
+        return true;
+    }
+
+    const int maxSuggestions = 10;
+    var visibleCount = Math.Min(maxSuggestions, candidates.Count);
+    var selected = Math.Clamp(selectedSuggestionIndex, 0, visibleCount - 1);
+    for (var i = 0; i < visibleCount; i++)
+    {
+        var candidate = candidates[i];
+        var selectedLine = i == selected;
+        var prefix = selectedLine
+            ? $"[{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]>[/]"
+            : "[grey] [/]";
+        var escaped = Markup.Escape(candidate.Label);
+        lines.Add(selectedLine
+            ? $"{prefix} [{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{escaped}[/]"
+            : $"{prefix} [grey]{escaped}[/]");
+    }
+
+    if (candidates.Count > visibleCount)
+    {
+        lines.Add($"[dim]showing first {visibleCount}/{candidates.Count} matches[/]");
+    }
+
+    lines.Add(string.Empty);
+    lines.Add("[dim]Usage: component add <Component Name>[/]");
+    return true;
+}
+
+static bool TryGetInspectorComponentComposerCandidates(
+    string input,
+    CliSessionState session,
+    out List<(string Label, string? CommitCommand)> candidates)
+{
+    candidates = [];
+
+    var context = session.Inspector;
+    if (context is null || context.Depth != InspectorDepth.ComponentList)
+    {
+        return false;
+    }
+
+    var trimmed = input.TrimStart();
+    if (trimmed.StartsWith('/'))
+    {
+        return false;
+    }
+
+    var tokens = TokenizeComposerInput(trimmed);
+    if (tokens.Count == 0)
+    {
+        return false;
+    }
+
+    var root = tokens[0].ToLowerInvariant();
+    if (root is not ("component" or "comp"))
+    {
+        return false;
+    }
+
+    if (tokens.Count >= 2 && !tokens[1].Equals("add", StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    var query = tokens.Count >= 3
+        ? string.Join(' ', tokens.Skip(2))
+        : string.Empty;
+
+    var matches = new List<(string DisplayName, double Score)>();
+    foreach (var displayName in InspectorComponentCatalog.KnownDisplayNames)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            matches.Add((displayName, 1d));
+            continue;
+        }
+
+        if (displayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+        {
+            matches.Add((displayName, 0.9d));
+            continue;
+        }
+
+        if (FuzzyMatcher.TryScore(query, displayName, out var score))
+        {
+            matches.Add((displayName, score));
+        }
+    }
+
+    var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    foreach (var match in matches
+                 .OrderByDescending(x => x.Score)
+                 .ThenBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase))
+    {
+        if (!seen.Add(match.DisplayName))
+        {
+            continue;
+        }
+
+        candidates.Add((
+            $"component add {match.DisplayName}",
+            $"component add {match.DisplayName}"));
     }
 
     return true;

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -1,10 +1,10 @@
 internal static class CliVersion
 {
     public const int Major = 0;
-    public const int Minor = 8;
+    public const int Minor = 9;
     public const int Patch = 0;
     public const string DevCycle = "";
-    public const string Protocol = "v3";
+    public const string Protocol = "v4";
 
     public static string SemVer => string.IsNullOrWhiteSpace(DevCycle)
         ? $"{Major}.{Minor}.{Patch}"

--- a/src/unifocl/Services/InspectorComponentCatalog.cs
+++ b/src/unifocl/Services/InspectorComponentCatalog.cs
@@ -1,0 +1,207 @@
+using System.Text;
+
+internal static class InspectorComponentCatalog
+{
+    private sealed record ComponentCatalogEntry(string DisplayName, string TypeReference, string[] Aliases);
+
+    private static readonly List<ComponentCatalogEntry> Entries = BuildEntries();
+    private static readonly Dictionary<string, ComponentCatalogEntry> Lookup = BuildLookup(Entries);
+
+    public static IReadOnlyList<string> KnownDisplayNames => Entries
+        .Select(entry => entry.DisplayName)
+        .ToList();
+
+    public static bool TryResolve(string raw, out string displayName, out string typeReference, out string error)
+    {
+        displayName = string.Empty;
+        typeReference = string.Empty;
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            error = "component type is required";
+            return false;
+        }
+
+        var key = NormalizeKey(raw);
+        if (!Lookup.TryGetValue(key, out var entry))
+        {
+            error = $"unsupported component type: {raw}";
+            return false;
+        }
+
+        displayName = entry.DisplayName;
+        typeReference = entry.TypeReference;
+        return true;
+    }
+
+    public static string NormalizeKey(string raw)
+    {
+        var builder = new StringBuilder(raw.Length);
+        foreach (var ch in raw)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                builder.Append(char.ToLowerInvariant(ch));
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static Dictionary<string, ComponentCatalogEntry> BuildLookup(IEnumerable<ComponentCatalogEntry> entries)
+    {
+        var lookup = new Dictionary<string, ComponentCatalogEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+        {
+            lookup[NormalizeKey(entry.DisplayName)] = entry;
+            lookup[NormalizeKey(entry.TypeReference)] = entry;
+
+            var typeSimpleName = entry.TypeReference.Split('.', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+            if (!string.IsNullOrWhiteSpace(typeSimpleName))
+            {
+                lookup[NormalizeKey(typeSimpleName)] = entry;
+            }
+
+            foreach (var alias in entry.Aliases)
+            {
+                lookup[NormalizeKey(alias)] = entry;
+            }
+        }
+
+        return lookup;
+    }
+
+    private static List<ComponentCatalogEntry> BuildEntries()
+    {
+        var entries = new List<ComponentCatalogEntry>();
+        void Add(string displayName, string typeReference, params string[] aliases)
+            => entries.Add(new ComponentCatalogEntry(displayName, typeReference, aliases));
+
+        Add("Mesh Filter", "UnityEngine.MeshFilter");
+        Add("Mesh Renderer", "UnityEngine.MeshRenderer");
+        Add("Skinned Mesh Renderer", "UnityEngine.SkinnedMeshRenderer");
+        Add("Text Mesh", "UnityEngine.TextMesh");
+
+        Add("Rigidbody", "UnityEngine.Rigidbody");
+        Add("Character Controller", "UnityEngine.CharacterController");
+        Add("Box Collider", "UnityEngine.BoxCollider");
+        Add("Sphere Collider", "UnityEngine.SphereCollider");
+        Add("Capsule Collider", "UnityEngine.CapsuleCollider");
+        Add("Mesh Collider", "UnityEngine.MeshCollider");
+        Add("Wheel Collider", "UnityEngine.WheelCollider");
+        Add("Terrain Collider", "UnityEngine.TerrainCollider");
+        Add("Fixed Joint", "UnityEngine.FixedJoint");
+        Add("Spring Joint", "UnityEngine.SpringJoint");
+        Add("Hinge Joint", "UnityEngine.HingeJoint");
+        Add("Character Joint", "UnityEngine.CharacterJoint");
+        Add("Configurable Joint", "UnityEngine.ConfigurableJoint");
+        Add("Constant Force", "UnityEngine.ConstantForce");
+
+        Add("Rigidbody 2D", "UnityEngine.Rigidbody2D");
+        Add("Box Collider 2D", "UnityEngine.BoxCollider2D");
+        Add("Circle Collider 2D", "UnityEngine.CircleCollider2D");
+        Add("Edge Collider 2D", "UnityEngine.EdgeCollider2D");
+        Add("Polygon Collider 2D", "UnityEngine.PolygonCollider2D");
+        Add("Capsule Collider 2D", "UnityEngine.CapsuleCollider2D");
+        Add("Composite Collider 2D", "UnityEngine.CompositeCollider2D");
+        Add("Distance Joint 2D", "UnityEngine.DistanceJoint2D");
+        Add("Fixed Joint 2D", "UnityEngine.FixedJoint2D");
+        Add("Friction Joint 2D", "UnityEngine.FrictionJoint2D");
+        Add("Hinge Joint 2D", "UnityEngine.HingeJoint2D");
+        Add("Relative Joint 2D", "UnityEngine.RelativeJoint2D");
+        Add("Slider Joint 2D", "UnityEngine.SliderJoint2D");
+        Add("Spring Joint 2D", "UnityEngine.SpringJoint2D");
+        Add("Target Joint 2D", "UnityEngine.TargetJoint2D");
+        Add("Wheel Joint 2D", "UnityEngine.WheelJoint2D");
+        Add("Area Effector 2D", "UnityEngine.AreaEffector2D");
+        Add("Buoyancy Effector 2D", "UnityEngine.BuoyancyEffector2D");
+        Add("Point Effector 2D", "UnityEngine.PointEffector2D");
+        Add("Platform Effector 2D", "UnityEngine.PlatformEffector2D");
+        Add("Surface Effector 2D", "UnityEngine.SurfaceEffector2D");
+        Add("Constant Force 2D", "UnityEngine.ConstantForce2D");
+
+        Add("Audio Listener", "UnityEngine.AudioListener");
+        Add("Audio Source", "UnityEngine.AudioSource");
+        Add("Audio Reverb Zone", "UnityEngine.AudioReverbZone");
+        Add("Audio Low Pass Filter", "UnityEngine.AudioLowPassFilter");
+        Add("Audio High Pass Filter", "UnityEngine.AudioHighPassFilter");
+        Add("Audio Echo Filter", "UnityEngine.AudioEchoFilter");
+        Add("Audio Distortion Filter", "UnityEngine.AudioDistortionFilter");
+        Add("Audio Reverb Filter", "UnityEngine.AudioReverbFilter");
+        Add("Audio Chorus Filter", "UnityEngine.AudioChorusFilter");
+
+        Add("Camera", "UnityEngine.Camera");
+        Add("Light", "UnityEngine.Light");
+        Add("Particle System", "UnityEngine.ParticleSystem");
+        Add("Particle System Force Field", "UnityEngine.ParticleSystemForceField");
+        Add("Trail Renderer", "UnityEngine.TrailRenderer");
+        Add("Line Renderer", "UnityEngine.LineRenderer");
+        Add("Light Probe Group", "UnityEngine.LightProbeGroup");
+        Add("Light Probe Proxy Volume", "UnityEngine.LightProbeProxyVolume");
+        Add("Reflection Probe", "UnityEngine.ReflectionProbe");
+        Add("Flare Layer", "UnityEngine.FlareLayer");
+        Add("Halo", "UnityEngine.Rendering.Halo");
+        Add("Lens Flare", "UnityEngine.LensFlare");
+        Add("Projector", "UnityEngine.Projector");
+        Add("Skybox", "UnityEngine.Skybox");
+        Add("Sorting Group", "UnityEngine.Rendering.SortingGroup");
+        Add("Sprite Renderer", "UnityEngine.SpriteRenderer");
+        Add("Sprite Mask", "UnityEngine.SpriteMask");
+
+        Add("Canvas", "UnityEngine.Canvas");
+        Add("Canvas Group", "UnityEngine.CanvasGroup");
+        Add("Canvas Renderer", "UnityEngine.CanvasRenderer");
+        Add("Canvas Scaler", "UnityEngine.UI.CanvasScaler");
+        Add("Graphic Raycaster", "UnityEngine.UI.GraphicRaycaster");
+        Add("Text", "UnityEngine.UI.Text");
+        Add("TextMeshPro - Text (UI)", "TMPro.TextMeshProUGUI", "TextMeshPro Text UI");
+        Add("Image", "UnityEngine.UI.Image");
+        Add("Raw Image", "UnityEngine.UI.RawImage");
+        Add("Button", "UnityEngine.UI.Button");
+        Add("Toggle", "UnityEngine.UI.Toggle");
+        Add("Toggle Group", "UnityEngine.UI.ToggleGroup");
+        Add("Slider", "UnityEngine.UI.Slider");
+        Add("Scrollbar", "UnityEngine.UI.Scrollbar");
+        Add("Dropdown", "UnityEngine.UI.Dropdown");
+        Add("Input Field", "UnityEngine.UI.InputField");
+        Add("Scroll Rect", "UnityEngine.UI.ScrollRect");
+        Add("Layout Element", "UnityEngine.UI.LayoutElement");
+        Add("Content Size Fitter", "UnityEngine.UI.ContentSizeFitter");
+        Add("Aspect Ratio Fitter", "UnityEngine.UI.AspectRatioFitter");
+        Add("Horizontal Layout Group", "UnityEngine.UI.HorizontalLayoutGroup");
+        Add("Vertical Layout Group", "UnityEngine.UI.VerticalLayoutGroup");
+        Add("Grid Layout Group", "UnityEngine.UI.GridLayoutGroup");
+        Add("Mask", "UnityEngine.UI.Mask");
+        Add("Rect Mask 2D", "UnityEngine.UI.RectMask2D");
+        Add("Shadow", "UnityEngine.UI.Shadow");
+        Add("Outline", "UnityEngine.UI.Outline");
+        Add("Position As UV1", "UnityEngine.UI.PositionAsUV1");
+
+        Add("NavMesh Agent", "UnityEngine.AI.NavMeshAgent");
+        Add("NavMesh Obstacle", "UnityEngine.AI.NavMeshObstacle");
+        Add("Off Mesh Link", "UnityEngine.AI.OffMeshLink");
+
+        Add("Animator", "UnityEngine.Animator");
+        Add("Animation", "UnityEngine.Animation");
+        Add("Playable Director", "UnityEngine.Playables.PlayableDirector");
+
+        Add("Tilemap", "UnityEngine.Tilemaps.Tilemap");
+        Add("Tilemap Renderer", "UnityEngine.Tilemaps.TilemapRenderer");
+        Add("Tilemap Collider 2D", "UnityEngine.Tilemaps.TilemapCollider2D");
+        Add("Grid", "UnityEngine.Grid");
+
+        Add("Video Player", "UnityEngine.Video.VideoPlayer");
+
+        Add("Terrain", "UnityEngine.Terrain");
+        Add("Wind Zone", "UnityEngine.WindZone");
+        Add("Tree", "UnityEngine.Tree");
+
+        Add("Event System", "UnityEngine.EventSystems.EventSystem");
+        Add("Standalone Input Module", "UnityEngine.EventSystems.StandaloneInputModule");
+        Add("Physics Raycaster", "UnityEngine.EventSystems.PhysicsRaycaster");
+        Add("Physics 2D Raycaster", "UnityEngine.EventSystems.Physics2DRaycaster");
+
+        return entries;
+    }
+}

--- a/src/unifocl/Services/InspectorDaemonBridge.cs
+++ b/src/unifocl/Services/InspectorDaemonBridge.cs
@@ -27,6 +27,8 @@ internal sealed class InspectorDaemonBridge
                 "list-components" => JsonSerializer.Serialize(new { ok = false, components = Array.Empty<object>() }, _jsonOptions),
                 "list-fields" => JsonSerializer.Serialize(new { ok = false, fields = Array.Empty<object>() }, _jsonOptions),
                 "find" => JsonSerializer.Serialize(new { ok = false, results = Array.Empty<object>() }, _jsonOptions),
+                "add-component" => JsonSerializer.Serialize(new { ok = false, message = "inspector component mutation requires Bridge mode" }, _jsonOptions),
+                "remove-component" => JsonSerializer.Serialize(new { ok = false, message = "inspector component mutation requires Bridge mode" }, _jsonOptions),
                 "toggle-component" => JsonSerializer.Serialize(new { ok = false }, _jsonOptions),
                 "toggle-field" => JsonSerializer.Serialize(new { ok = false }, _jsonOptions),
                 "set-field" => JsonSerializer.Serialize(new { ok = false }, _jsonOptions),

--- a/src/unifocl/Services/InspectorModeService.cs
+++ b/src/unifocl/Services/InspectorModeService.cs
@@ -46,6 +46,8 @@ internal sealed class InspectorModeService
             "t" or
             "f" or
             "ff" or
+            "component" or
+            "comp" or
             "make" or
             "mk" or
             "remove" or
@@ -126,6 +128,16 @@ internal sealed class InspectorModeService
             case "ff":
                 await HandleFuzzyFindAsync(input, tokens, session, log);
                 return true;
+            case "component":
+                await HandleComponentAsync(input, tokens, session, log);
+                return true;
+            case "comp":
+                await HandleComponentAsync(
+                    $"component {string.Join(' ', tokens.Skip(1))}",
+                    ["component", .. tokens.Skip(1)],
+                    session,
+                    log);
+                return true;
             case "make":
             case "mk":
                 await HandleMakeAsync(input, tokens, session, log);
@@ -171,7 +183,6 @@ internal sealed class InspectorModeService
             await PopulateFieldsAsync(context, session, selectedComponentIndex, forceRefresh: context.Fields.Count == 0);
         }
 
-        AddStream(context, "[i] inspector focus mode enabled (up/down select, tab inspect, shift+tab back, esc back, f7/f8 exit)");
         var selectedComponentPosition = 0;
         var selectedFieldPosition = 0;
 
@@ -301,12 +312,23 @@ internal sealed class InspectorModeService
                     }
 
                     break;
-                case KeyboardIntent.FocusInspector:
                 case KeyboardIntent.FocusProject:
-                    AddStream(context, "[i] inspector focus mode disabled");
-                    context.FocusHighlightedFieldName = null;
-                    context.FocusHighlightedComponentIndex = null;
-                    _renderer.Render(context);
+                    if (context.Depth == InspectorDepth.ComponentFields)
+                    {
+                        StepUpToComponentList(context, "[i] returned to component list");
+                    }
+
+                    await PopulateComponentsAsync(context, session, forceRefresh: context.Components.Count == 0);
+
+                    if (context.FocusHighlightedComponentIndex is null && context.Components.Count > 0)
+                    {
+                        context.FocusHighlightedComponentIndex = context.Components
+                            .OrderBy(component => component.Index)
+                            .First()
+                            .Index;
+                    }
+
+                    _renderer.Render(context, context.FocusHighlightedComponentIndex, null, focusModeEnabled: false);
                     return;
                 case KeyboardIntent.Escape:
                     if (context.Depth == InspectorDepth.ComponentFields)
@@ -754,6 +776,156 @@ internal sealed class InspectorModeService
         _renderer.Render(context);
     }
 
+    private async Task HandleComponentAsync(
+        string input,
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        Action<string> log)
+    {
+        var context = session.Inspector;
+        if (context is null)
+        {
+            log("[grey]system[/]: component requires inspect mode");
+            return;
+        }
+
+        if (context.Depth != InspectorDepth.ComponentList)
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, "[!] component add/remove is available from the component list view (use up to return)");
+            _renderer.Render(context);
+            return;
+        }
+
+        if (tokens.Count < 2)
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, "[!] usage: component <add|remove> <type|index>");
+            _renderer.Render(context);
+            return;
+        }
+
+        var action = tokens[1].ToLowerInvariant();
+        switch (action)
+        {
+            case "add":
+                await HandleComponentAddAsync(input, tokens, session, context);
+                return;
+            case "remove":
+            case "rm":
+                await HandleComponentRemoveAsync(input, tokens, session, context);
+                return;
+            default:
+                AddStream(context, $"{context.PromptLabel} > {input}");
+                AddStream(context, "[!] usage: component <add|remove> <type|index>");
+                _renderer.Render(context);
+                return;
+        }
+    }
+
+    private async Task HandleComponentAddAsync(
+        string input,
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        InspectorContext context)
+    {
+        if (tokens.Count < 3)
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, "[!] usage: component add <component-type>");
+            _renderer.Render(context);
+            return;
+        }
+
+        var rawType = string.Join(' ', tokens.Skip(2)).Trim();
+        if (!InspectorComponentCatalog.TryResolve(rawType, out var displayName, out var typeReference, out var error))
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, $"[!] {error}");
+            AddStream(context, "[i] use fuzzy suggestions: component add <partial-name>");
+            _renderer.Render(context);
+            return;
+        }
+
+        AddStream(context, $"{context.PromptLabel} > {input}");
+        var mutation = await TrySendInspectorMutationWithMessageAsync(
+            session,
+            new InspectorBridgeRequest(
+                "add-component",
+                context.TargetPath,
+                null,
+                typeReference,
+                null,
+                null,
+                null));
+
+        if (!mutation.Ok)
+        {
+            var detail = string.IsNullOrWhiteSpace(mutation.Message)
+                ? "failed to add component in Bridge mode"
+                : mutation.Message!;
+            AddStream(context, $"[!] {detail}");
+            _renderer.Render(context);
+            return;
+        }
+
+        await PopulateComponentsAsync(context, session, forceRefresh: true);
+        AddStream(context, $"[+] added component: {displayName}");
+        _renderer.Render(context);
+    }
+
+    private async Task HandleComponentRemoveAsync(
+        string input,
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        InspectorContext context)
+    {
+        if (tokens.Count < 3)
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, "[!] usage: component remove <index|component-name>");
+            _renderer.Render(context);
+            return;
+        }
+
+        var selector = string.Join(' ', tokens.Skip(2)).Trim();
+        var target = ResolveComponentRemoveTarget(context, selector);
+        if (target is null)
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, $"[!] no component match for: {selector}");
+            AddStream(context, "[i] use component remove <index> to disambiguate");
+            _renderer.Render(context);
+            return;
+        }
+
+        AddStream(context, $"{context.PromptLabel} > {input}");
+        var mutation = await TrySendInspectorMutationWithMessageAsync(
+            session,
+            new InspectorBridgeRequest(
+                "remove-component",
+                context.TargetPath,
+                target.Index,
+                target.Name,
+                null,
+                null,
+                null));
+
+        if (!mutation.Ok)
+        {
+            var detail = string.IsNullOrWhiteSpace(mutation.Message)
+                ? "failed to remove component in Bridge mode"
+                : mutation.Message!;
+            AddStream(context, $"[!] {detail}");
+            _renderer.Render(context);
+            return;
+        }
+
+        await PopulateComponentsAsync(context, session, forceRefresh: true);
+        AddStream(context, $"[-] removed component: {target.Name}");
+        _renderer.Render(context);
+    }
+
     private async Task HandleRemoveAsync(
         string input,
         CliSessionState session,
@@ -1097,7 +1269,7 @@ internal sealed class InspectorModeService
         context.FollowStreamScroll = true;
         context.StreamScrollOffset = int.MaxValue;
         await PopulateFieldsAsync(context, session, componentIndex, forceRefresh: true);
-        AddStream(context, $"UnityCLI:{context.TargetPath} [inspect] > {rawCommand}");
+        AddStream(context, $"UnityCLI:{context.TargetPath} [[inspect]] > {rawCommand}");
         AddStream(context, $"[i] inspecting component: {component.Name}");
         if (context.Fields.Count == 0)
         {
@@ -1735,22 +1907,61 @@ internal sealed class InspectorModeService
         }
     }
 
+    private static InspectorComponentEntry? ResolveComponentRemoveTarget(InspectorContext context, string selector)
+    {
+        if (int.TryParse(selector, out var index))
+        {
+            return context.Components.FirstOrDefault(component => component.Index == index);
+        }
+
+        var matches = context.Components
+            .Where(component => component.Name.Equals(selector, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (matches.Count == 1)
+        {
+            return matches[0];
+        }
+
+        if (InspectorComponentCatalog.TryResolve(selector, out _, out var typeReference, out _))
+        {
+            var simpleName = typeReference.Split('.', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+            if (!string.IsNullOrWhiteSpace(simpleName))
+            {
+                var typedMatches = context.Components
+                    .Where(component => component.Name.Equals(simpleName, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                if (typedMatches.Count == 1)
+                {
+                    return typedMatches[0];
+                }
+            }
+        }
+
+        return null;
+    }
+
     private async Task<bool> TrySendInspectorMutationAsync(CliSessionState session, InspectorBridgeRequest request)
+    {
+        var result = await TrySendInspectorMutationWithMessageAsync(session, request);
+        return result.Ok;
+    }
+
+    private async Task<(bool Ok, string? Message)> TrySendInspectorMutationWithMessageAsync(CliSessionState session, InspectorBridgeRequest request)
     {
         var response = await SendBridgeRequestAsync(request, session);
         if (string.IsNullOrWhiteSpace(response))
         {
-            return false;
+            return (false, null);
         }
 
         try
         {
             var mutation = JsonSerializer.Deserialize<InspectorBridgeMutationResponse>(response, _jsonOptions);
-            return mutation?.Ok == true;
+            return (mutation?.Ok == true, mutation?.Message);
         }
         catch
         {
-            return false;
+            return (false, null);
         }
     }
 
@@ -2111,10 +2322,17 @@ internal sealed class InspectorModeService
             return;
         }
 
+        const int maxLines = 10;
         AddStream(context, $"[*] fuzzy results for: {query}");
-        for (var i = 0; i < buffered.Count; i++)
+        var shown = Math.Min(maxLines, buffered.Count);
+        for (var i = 0; i < shown; i++)
         {
             AddStream(context, $"[{i}] {buffered[i]}");
+        }
+
+        if (buffered.Count > shown)
+        {
+            AddStream(context, $"[i] showing first {shown}/{buffered.Count} results");
         }
     }
 
@@ -2150,7 +2368,7 @@ internal sealed class InspectorModeService
     private sealed record InspectorBridgeComponentsResponse(bool Ok, List<InspectorBridgeComponent>? Components);
     private sealed record InspectorBridgeFieldsResponse(bool Ok, List<InspectorBridgeField>? Fields);
     private sealed record InspectorBridgeSearchResponse(bool Ok, List<InspectorSearchResultDto>? Results);
-    private sealed record InspectorBridgeMutationResponse(bool Ok);
+    private sealed record InspectorBridgeMutationResponse(bool Ok, string? Message);
     private sealed record InspectorBridgeComponent(int Index, string Name, bool Enabled);
     private sealed record InspectorBridgeField(string Name, string Value, string Type, bool IsBoolean, List<string>? EnumOptions);
 }

--- a/src/unifocl/Services/InspectorTuiRenderer.cs
+++ b/src/unifocl/Services/InspectorTuiRenderer.cs
@@ -216,8 +216,8 @@ internal sealed class InspectorTuiRenderer
             ? context.PromptPath
             : context.TargetPath;
         var focusLabel = focusModeEnabled
-            ? " | FOCUS: ON (up/down, tab, enter edit, shift+tab, esc, f7/f8)"
-            : " | Focus Key: F8";
+            ? " | FOCUS: ON (up/down, tab, enter edit, shift+tab, esc, f7)"
+            : " | Focus Key: F7";
         return $"UnityCLI v{CliVersion.SemVer} | MODE: INSPECTOR | Target: {target}{focusLabel}";
     }
 

--- a/src/unifocl/Services/KeyboardIntentReader.cs
+++ b/src/unifocl/Services/KeyboardIntentReader.cs
@@ -71,11 +71,6 @@ internal static class KeyboardIntentReader
             return KeyboardIntent.FocusProject;
         }
 
-        if (key.Key == ConsoleKey.F8)
-        {
-            return KeyboardIntent.FocusInspector;
-        }
-
         return KeyboardIntent.None;
     }
 


### PR DESCRIPTION
## Summary
- Hardens CLI release version to `0.9.0` (removes dev suffix) and bumps bridge protocol to `v4`.
- Adds inspector component-list command workflow parity (`component add` / `component remove`) with catalog-driven fuzzy IntelliSense.
- Stabilizes inspector TUI focus transitions and first-exit rendering persistence.
- Unifies focus toggle to `F7` only and updates keybind labels/docs.
- Fixes prompt badge markup escaping so `[inspect]` / `[safe]` render as literal badges.
- Removes noisy focus on/off stream logs and enforces inspector component suggestion truncation to 10 visible lines.

Why this is needed:
- `0.9.0` finalization is required to start a stable post-release cycle.
- Inspector command ergonomics and TUI reliability had user-visible regressions (duplicate suggestions, first-exit collapse, literal style tag leaks).

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Docs
- [ ] CI/Build
- [x] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Program.cs`
  - `src/unifocl/Services/InspectorModeService.cs`
  - `src/unifocl/Services/InspectorTuiRenderer.cs`
  - `src/unifocl/Services/InspectorComponentCatalog.cs` (new)
  - `src/unifocl/Services/InspectorDaemonBridge.cs`
  - `src/unifocl/Services/CliVersion.cs`
  - `src/unifocl/Models/KeyboardIntentModels.cs`
  - `src/unifocl/Services/KeyboardIntentReader.cs`
  - `src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs`
  - `src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs`
  - `README.md`, `CHANGELOG.md`
- Out-of-scope / intentionally not addressed:
  - New inspector field-edit interaction modes beyond existing behavior
  - Full compatcheck environment provisioning for project-specific Unity UI assemblies

## How to Test
1. `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. Run CLI, open a project, enter inspector, and verify `component add` / `component remove` in component list.
3. Verify `comp`/`component` IntelliSense shows unique suggestions and only first 10 lines.
4. Verify `F7` is the only focus toggle and first focus-exit returns to persistent component list view.
5. Re-run `/init` in target Unity projects, then retest inspector component mutations in Bridge mode.

Expected results:
- CLI reports version `0.9.0` and protocol `v4`.
- Inspector focus transitions are stable (no first-exit collapse).
- No duplicate component IntelliSense entries.
- Prompt badges render literally without leaked markup tags.

## Screenshots / Terminal Output (if applicable)
- `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal` succeeded.
- `dotnet build src/unifocl.unity.compatcheck/unifocl.unity.compatcheck.csproj --disable-build-servers -v minimal` requires explicit Unity managed references; with `-p:UnityEditorManagedDir=...` it still fails in this workspace due missing Unity UI/EventSystems assembly resolution for compatcheck context.

## Breaking Changes
- [x] This PR introduces a breaking change.

If yes, describe migration steps:
- Bridge protocol bumped `v3` -> `v4`.
- Re-run `/init` for existing projects to refresh embedded bridge payload before using inspector component mutation commands.

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No credentials/secrets added.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
