### PR TITLE
Make IntelliSense state-aware and start 0.11.0 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.11.0a1 - 2026-03-09
+
+### Changed
+- Started the `0.11.0` development cycle with `a1` suffix versioning.
+
 ## 0.10.0a2 - 2026-03-09
 
 ### Changed

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -829,7 +829,7 @@ static int RenderComposerFrame(
     else if (input.StartsWith('/'))
     {
         lines.Add(string.Empty);
-        lines.AddRange(GetSuggestionLines(input, commands, selectedFuzzyCandidateIndex));
+        lines.AddRange(GetSuggestionLines(input, commands, session, selectedFuzzyCandidateIndex));
     }
     else if (TryGetProjectMkTypeIntellisenseLines(input, session, selectedFuzzyCandidateIndex, out var mkTypeLines))
     {
@@ -852,7 +852,7 @@ static int RenderComposerFrame(
             ? inspectorCommands
             : projectCommands;
         lines.Add(string.Empty);
-        lines.AddRange(GetSuggestionLines(input, contextualCommands, selectedFuzzyCandidateIndex));
+        lines.AddRange(GetSuggestionLines(input, contextualCommands, session, selectedFuzzyCandidateIndex));
     }
     else if (session.Inspector is not null)
     {
@@ -1157,7 +1157,7 @@ static bool TryGetComposerIntellisenseCandidates(
 
     if (input.StartsWith('/'))
     {
-        candidates = GetSuggestionMatches(input, commands)
+        candidates = GetSuggestionMatches(input, commands, session)
             .Select(match => (match.Signature, (string?)match.Trigger))
             .ToList();
         return true;
@@ -1168,7 +1168,7 @@ static bool TryGetComposerIntellisenseCandidates(
         var contextualCommands = session.Inspector is not null
             ? inspectorCommands
             : projectCommands;
-        candidates = GetSuggestionMatches(input, contextualCommands)
+        candidates = GetSuggestionMatches(input, contextualCommands, session)
             .Select(match => (match.Signature, (string?)match.Trigger))
             .ToList();
         return true;
@@ -1708,9 +1708,13 @@ static bool TryGetUpmComposerCandidates(
     return true;
 }
 
-static IEnumerable<string> GetSuggestionLines(string query, List<CommandSpec> commands, int selectedSuggestionIndex)
+static IEnumerable<string> GetSuggestionLines(
+    string query,
+    List<CommandSpec> commands,
+    CliSessionState session,
+    int selectedSuggestionIndex)
 {
-    var matches = GetSuggestionMatches(query, commands);
+    var matches = GetSuggestionMatches(query, commands, session);
     if (matches.Count == 0)
     {
         return new[]
@@ -1742,10 +1746,11 @@ static IEnumerable<string> GetSuggestionLines(string query, List<CommandSpec> co
     return lines;
 }
 
-static List<CommandSpec> GetSuggestionMatches(string query, List<CommandSpec> commands)
+static List<CommandSpec> GetSuggestionMatches(string query, List<CommandSpec> commands, CliSessionState session)
 {
     var normalized = query.Trim().ToLowerInvariant();
     return commands
+        .Where(command => IsSuggestionAvailableForSession(command, session))
         .Where(c => !c.Description.StartsWith("Alias for", StringComparison.OrdinalIgnoreCase))
         .Where(c => c.Signature.Contains(normalized, StringComparison.OrdinalIgnoreCase)
                     || c.Description.Contains(normalized, StringComparison.OrdinalIgnoreCase)
@@ -1753,6 +1758,27 @@ static List<CommandSpec> GetSuggestionMatches(string query, List<CommandSpec> co
                     || normalized.StartsWith(c.Trigger, StringComparison.OrdinalIgnoreCase))
         .Take(14)
         .ToList();
+}
+
+static bool IsSuggestionAvailableForSession(CommandSpec command, CliSessionState session)
+{
+    var hasOpenProject = session.Mode == CliMode.Project
+        && !string.IsNullOrWhiteSpace(session.CurrentProjectPath);
+    if (hasOpenProject)
+    {
+        return true;
+    }
+
+    if (!command.Trigger.StartsWith('/'))
+    {
+        return false;
+    }
+
+    return !command.Trigger.StartsWith("/project", StringComparison.Ordinal)
+        && !command.Trigger.StartsWith("/hierarchy", StringComparison.Ordinal)
+        && !command.Trigger.StartsWith("/inspect", StringComparison.Ordinal)
+        && !command.Trigger.StartsWith("/upm", StringComparison.Ordinal)
+        && !command.Trigger.StartsWith("/build", StringComparison.Ordinal);
 }
 
 static bool TryGetFuzzyQueryIntellisenseLines(string input, CliSessionState session, int selectedFuzzyCandidateIndex, out List<string> lines)

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -1,9 +1,9 @@
 internal static class CliVersion
 {
     public const int Major = 0;
-    public const int Minor = 10;
+    public const int Minor = 11;
     public const int Patch = 0;
-    public const string DevCycle = "a2";
+    public const string DevCycle = "a1";
     public const string Protocol = "v5";
 
     public static string SemVer => string.IsNullOrWhiteSpace(DevCycle)


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Makes command IntelliSense context-aware based on session state.
  - Hides invalid suggestions before a project is opened (for example `/project`, `/hierarchy`, `/inspect`, `/build*`, `/upm*`, and project-context bare commands like `mk`/`load`).
  - Starts the next development cycle versioning: `0.11.0a1`.
- Why is this change needed?
  - Reduces misleading suggestions and prevents suggesting commands that cannot execute in the current state.
  - Keeps CLI suggestion UX aligned with actual command preconditions.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Program.cs`
  - `src/unifocl/Services/CliVersion.cs`
  - `CHANGELOG.md`
- Out-of-scope / intentionally not addressed:
  - No runtime command behavior changes (only suggestion visibility/filtering).
  - No protocol bump.

## How to Test
1. Launch CLI without opening a project.
2. Type `/` and confirm suggestions do not include `/project`, `/hierarchy`, `/inspect`, `/build...`, `/upm...`.
3. Open a project with `/open <path>`, then type `/` again and confirm those commands appear.
4. In project context, type non-slash commands and verify contextual suggestions appear as expected.
5. Run build validation:
   - `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`

Expected results:
- Pre-open suggestions are limited to valid lifecycle/system commands.
- Post-open suggestions include project-context commands.
- Build succeeds.

## Screenshots / Terminal Output (if applicable)
- Build: success (0 errors)
- Note: NU1900 warnings appeared due vulnerability feed access to `https://api.nuget.org/v3/index.json` in sandboxed network conditions.

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No credential, token, or secret handling changes.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
