### PR TITLE
Officialize 0.11.0 and add PR version-finalization rule

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -20,6 +20,7 @@ The agent must treat the following as **non-negotiable principles**:
 - **Contract Pipeline Strategy (Primary):** Shared transport contracts must be defined in protobuf `.proto` files under the `external/unifocl-protobuf` submodule and consumed via generated C# classes (`Unifocl.Shared`). CLI code must reference only generated protobuf DTOs for transport boundaries; Unity bridge code maps Unity types to/from these stable protobuf contracts.
 - **Plugin Sync:** After protobuf contract updates, run `./scripts/sync-protobuf-unity-plugin.sh` to rebuild `Unifocl.Shared.dll` and copy it into `src/unifocl.unity/EditorScripts/Plugins/`.
 - **Build Versioning Rule:** Development builds must use `aX` incremental suffixes in `CliVersion.SemVer` (for example: `0.3.2a1` -> `0.3.2a2`)
+- **PR Finalization Version Rule:** When finalizing changes for PR (push/PR creation), harden the version by closing the active dev-cycle suffix (set `CliVersion.DevCycle` to empty) and add an `Officialized` release entry in `CHANGELOG.md`.
 - **Bridge Protocol Rule:** If a change requires users to re-run `/init` (for example editor payload/package content changes), bump `CliVersion.Protocol` and include `/init` re-run guidance in the task summary/PR description.
 - **Repository Rules:** Always branch from `main` before any actions and create PRs using `.github/pull_request_template.md` in English
 - **Mainline Sync Rule:** Before finalizing work (push/PR), merge latest `main` (or `origin/main`) to detect upstream leading changes early and resolve any conflicts before continuing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.0 - 2026-03-10
+
+### Changed
+- Officialized `0.11.0` by closing the development cycle suffix.
+- Made command IntelliSense context-aware so invalid preconditions are no longer suggested (for example `/project`, `/hierarchy`, `/inspect`, `/build*`, `/upm*` before opening a project).
+
 ## 0.11.0a1 - 2026-03-09
 
 ### Changed

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -3,7 +3,7 @@ internal static class CliVersion
     public const int Major = 0;
     public const int Minor = 11;
     public const int Patch = 0;
-    public const string DevCycle = "a1";
+    public const string DevCycle = "";
     public const string Protocol = "v5";
 
     public static string SemVer => string.IsNullOrWhiteSpace(DevCycle)


### PR DESCRIPTION
## Summary
- What does this PR change?
- Why is this change needed?
Change docs to finalize version when creating PRs. Prevents dev cycle versions being merged to main
## Related Issues
- Closes #
- Related to #

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
- Out-of-scope / intentionally not addressed:

## How to Test
1. 
2. 
3. 

Expected results:
- 

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- 

## Security / Privacy Impact
- [x] No security impact.
- [x] Security impact reviewed.

Details:
- 

## Documentation
- [ ] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [x] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
