### PR TITLE
Finalize 0.12.0: project fuzzy type filter + inspector object-reference fuzzy picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## 0.12.0 - 2026-03-10
+
+### Changed
+- Officialized `0.12.0` by closing the development cycle suffix.
+- Added project-mode fuzzy `--type`/`-t` argument support (in addition to existing `t:<type>`) for type-scoped fuzzy queries.
+- Refactored project mk catalog usage so fuzzy-type parsing/filtering and mk type extension resolution now share `ProjectMkCatalog` as the common source of truth.
+- Added inspector ObjectReference search workflow via `set <field> --search <query> [--scene|--project]` and indexed assignment via `set <field> @<index>`.
+- Added inspector reference search scope flags:
+  - `--scene`: only search scene references
+  - `--project`: only search project asset references
+  - omitted flags search both scopes.
+- Added bridge-side `find-reference` inspector action and ObjectReference assignment support for:
+  - `scene:/...` and `scene:/...#Component`
+  - `asset:Assets/...` and direct `Assets/...` asset path
+  - `null` to clear reference fields.
+- Enabled interactive focus-mode editing for inspector `ObjectReference` fields:
+  - `Enter` on an `ObjectReference` field now opens a fuzzy reference picker.
+  - Supports live query typing, Up/Down selection, Enter apply, Esc cancel, and `Tab` scope cycle (`scene` / `project` / `all`).
+- Reworked inspector interactive `ObjectReference` fuzzy picker UI to render in the inspector stream pane (below the main TUI body).
+- Hardened ObjectReference type restriction in bridge reference search by resolving expected reference types from serialized property metadata (`PPtr<...>`) when reflection cannot resolve the backing field.
+- Reference suggestions for typed fields (for example animation controller references) are now filtered to compatible reference types instead of broad `UnityEngine.Object` matches.
+- Styled the selected row in inspector ObjectReference fuzzy picker preview with theme cursor highlight colors and fixed bracket-cell markup escaping for reliable Spectre rendering.
+- Bumped bridge protocol to `v6`; projects must re-run `/init` to refresh embedded bridge payload.
+
+## 0.12.0a6 - 2026-03-10
+
+### Changed
+- Fixed inspector reference-picker preview markup rendering by escaping literal bracket cells (`[index]`, `[scope]`) and using valid Spectre markup tags for styled rows.
+
+## 0.12.0a5 - 2026-03-10
+
+### Changed
+- Styled the selected row in inspector ObjectReference fuzzy picker preview with theme cursor highlight colors to improve visual focus and readability.
+
+## 0.12.0a4 - 2026-03-10
+
+### Changed
+- Reworked inspector interactive `ObjectReference` fuzzy picker UI to render in the inspector stream pane (below the main TUI body), removing the in-body overlay for this flow.
+- Hardened ObjectReference type restriction in bridge reference search by resolving expected reference types from serialized property metadata (`PPtr<...>`) when reflection cannot resolve the backing field.
+- Reference suggestions for typed fields (for example animation controller references) are now filtered to compatible reference types instead of broad `UnityEngine.Object` matches.
+
+## 0.12.0a3 - 2026-03-10
+
+### Changed
+- Enabled interactive focus-mode editing for inspector `ObjectReference` fields:
+  - `Enter` on an `ObjectReference` field now opens a fuzzy reference picker instead of showing "interactive edit not available".
+  - Supports live query typing, Up/Down selection, Enter apply, Esc cancel, and `Tab` scope cycle (`scene` / `project` / `all`).
+
+## 0.12.0a2 - 2026-03-10
+
+### Changed
+- Added inspector ObjectReference search workflow via `set <field> --search <query> [--scene|--project]` and indexed assignment via `set <field> @<index>`.
+- Added inspector reference search scope flags:
+  - `--scene`: only search scene references
+  - `--project`: only search project asset references
+  - omitted flags search both scopes.
+- Added bridge-side `find-reference` inspector action and ObjectReference assignment support for:
+  - `scene:/...` and `scene:/...#Component`
+  - `asset:Assets/...` and direct `Assets/...` asset path
+  - `null` to clear reference fields.
+
+## 0.12.0a1 - 2026-03-10
+
+### Changed
+- Started the `0.12.0` development cycle with `a1` suffix versioning.
+- Added project-mode fuzzy `--type`/`-t` argument support (in addition to existing `t:<type>`) for type-scoped fuzzy queries.
+- Refactored project mk catalog usage so fuzzy-type parsing/filtering and mk type extension resolution now share `ProjectMkCatalog` as the common source of truth.
+
 ## 0.11.0 - 2026-03-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -383,10 +383,10 @@ unifocl features a composer with Intellisense.
 * Type any standard text to receive project-mode suggestions.
 
 **Fuzzy Finding:**
-Use the `f` or `ff` command to trigger fuzzy search across your project or inspector. You can scope searches using the `t:<type>` filter.
-* **Syntax:** `f t:<type> <query>`
+Use the `f` or `ff` command to trigger fuzzy search across your project or inspector. In project mode, you can scope searches using `--type`/`-t` or `t:<type>`.
+* **Syntax:** `f [--type <type>|-t <type>|t:<type>] <query>`
 * **Supported Types:** `script`, `scene`, `prefab`, `material`, `animation`
-* **Example:** `f t:script PlayerController`
+* **Example:** `f --type script PlayerController`
 
 ### 6. Keybindings & Focus Modes
 The CLI provides keyboard-driven navigation for interacting with lists and structures without typing out indices.

--- a/src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs
+++ b/src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs
@@ -108,6 +108,8 @@ namespace UniFocl.EditorBridge
         public string fieldName = string.Empty;
         public string value = string.Empty;
         public string query = string.Empty;
+        public bool includeSceneReferences = true;
+        public bool includeProjectReferences = true;
     }
 
     [Serializable]
@@ -136,6 +138,7 @@ namespace UniFocl.EditorBridge
         public string name = string.Empty;
         public string path = string.Empty;
         public double score;
+        public string valueToken = string.Empty;
     }
 
     [Serializable]

--- a/src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs
@@ -30,6 +30,7 @@ namespace UniFocl.EditorBridge
         }
 
         private static readonly Dictionary<string, Type> ComponentTypeLookup = BuildComponentTypeLookup();
+        private static readonly Dictionary<string, Type> ObjectReferenceTypeLookup = BuildObjectReferenceTypeLookup();
 
         public static string Execute(string payload)
         {
@@ -69,6 +70,20 @@ namespace UniFocl.EditorBridge
                     {
                         ok = true,
                         results = Find(request.targetPath, request.query, request.componentName)
+                    });
+
+                case "find-reference":
+                    return JsonUtility.ToJson(new InspectorSearchResponse
+                    {
+                        ok = true,
+                        results = FindReference(
+                            request.targetPath,
+                            request.componentIndex,
+                            request.componentName,
+                            request.fieldName,
+                            request.query,
+                            request.includeSceneReferences,
+                            request.includeProjectReferences)
                     });
 
                 case "add-component":
@@ -237,6 +252,222 @@ namespace UniFocl.EditorBridge
                 .ThenBy(result => result.path, StringComparer.OrdinalIgnoreCase)
                 .Take(20)
                 .ToArray();
+        }
+
+        private static InspectorSearchResult[] FindReference(
+            string? targetPath,
+            int componentIndex,
+            string? componentName,
+            string? fieldName,
+            string? query,
+            bool includeSceneReferences,
+            bool includeProjectReferences)
+        {
+            var normalizedQuery = (query ?? string.Empty).Trim();
+            if (!includeSceneReferences && !includeProjectReferences)
+            {
+                includeSceneReferences = true;
+                includeProjectReferences = true;
+            }
+
+            var component = ResolveComponent(targetPath, componentIndex, componentName);
+            if (component is null || string.IsNullOrWhiteSpace(fieldName))
+            {
+                return Array.Empty<InspectorSearchResult>();
+            }
+
+            var serializedObject = new SerializedObject(component);
+            var property = FindPropertyByNameOrPath(serializedObject, fieldName);
+            if (property is null || property.propertyType != SerializedPropertyType.ObjectReference)
+            {
+                return Array.Empty<InspectorSearchResult>();
+            }
+
+            var expectedType = ResolveObjectReferenceExpectedType(property);
+            var results = new List<InspectorSearchResult>();
+            var seenTokens = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (includeSceneReferences)
+            {
+                CollectSceneReferenceCandidates(expectedType, normalizedQuery, results, seenTokens);
+            }
+
+            if (includeProjectReferences)
+            {
+                CollectProjectReferenceCandidates(expectedType, normalizedQuery, results, seenTokens);
+            }
+
+            return results
+                .OrderByDescending(result => result.score)
+                .ThenBy(result => result.path, StringComparer.OrdinalIgnoreCase)
+                .Take(20)
+                .ToArray();
+        }
+
+        private static void CollectSceneReferenceCandidates(
+            Type expectedType,
+            string query,
+            List<InspectorSearchResult> results,
+            HashSet<string> seenTokens)
+        {
+            if (!DaemonSceneManager.TryGetActiveScene(out var scene) || !scene.IsValid())
+            {
+                return;
+            }
+
+            foreach (var gameObject in EnumerateSceneGameObjects(scene))
+            {
+                var scenePath = BuildScenePath(gameObject.transform);
+                if (IsSceneGameObjectCompatible(expectedType))
+                {
+                    TryAppendReferenceCandidate(results, seenTokens, "scene", scenePath, $"scene:{scenePath}", query);
+                }
+
+                if (!typeof(Component).IsAssignableFrom(expectedType))
+                {
+                    continue;
+                }
+
+                foreach (var component in gameObject.GetComponents<Component>())
+                {
+                    if (component is null)
+                    {
+                        continue;
+                    }
+
+                    if (!expectedType.IsAssignableFrom(component.GetType()))
+                    {
+                        continue;
+                    }
+
+                    var path = $"{scenePath}#{component.GetType().Name}";
+                    TryAppendReferenceCandidate(results, seenTokens, "scene", path, $"scene:{path}", query);
+                }
+            }
+        }
+
+        private static void CollectProjectReferenceCandidates(
+            Type expectedType,
+            string query,
+            List<InspectorSearchResult> results,
+            HashSet<string> seenTokens)
+        {
+            foreach (var assetPath in AssetDatabase.GetAllAssetPaths())
+            {
+                if (!assetPath.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var assetType = AssetDatabase.GetMainAssetTypeAtPath(assetPath);
+                if (!IsProjectAssetCompatible(expectedType, assetType))
+                {
+                    continue;
+                }
+
+                TryAppendReferenceCandidate(results, seenTokens, "project", assetPath, $"asset:{assetPath}", query);
+            }
+        }
+
+        private static void TryAppendReferenceCandidate(
+            List<InspectorSearchResult> results,
+            HashSet<string> seenTokens,
+            string scope,
+            string displayPath,
+            string valueToken,
+            string query)
+        {
+            if (!seenTokens.Add(valueToken))
+            {
+                return;
+            }
+
+            var score = 1d;
+            if (!string.IsNullOrWhiteSpace(query))
+            {
+                var name = System.IO.Path.GetFileName(displayPath);
+                var scored = TryScore(query, displayPath, out score)
+                    || TryScore(query, name, out score);
+                if (!scored)
+                {
+                    return;
+                }
+            }
+
+            results.Add(new InspectorSearchResult
+            {
+                scope = scope,
+                componentIndex = -1,
+                name = displayPath,
+                path = displayPath,
+                score = score,
+                valueToken = valueToken
+            });
+        }
+
+        private static IEnumerable<GameObject> EnumerateSceneGameObjects(Scene scene)
+        {
+            foreach (var root in scene.GetRootGameObjects())
+            {
+                if (root is null)
+                {
+                    continue;
+                }
+
+                foreach (var item in EnumerateGameObjectsRecursive(root.transform))
+                {
+                    yield return item;
+                }
+            }
+        }
+
+        private static IEnumerable<GameObject> EnumerateGameObjectsRecursive(Transform node)
+        {
+            yield return node.gameObject;
+            for (var i = 0; i < node.childCount; i++)
+            {
+                foreach (var child in EnumerateGameObjectsRecursive(node.GetChild(i)))
+                {
+                    yield return child;
+                }
+            }
+        }
+
+        private static string BuildScenePath(Transform node)
+        {
+            var segments = new Stack<string>();
+            for (var current = node; current is not null; current = current.parent)
+            {
+                segments.Push(current.name);
+            }
+
+            return "/" + string.Join("/", segments);
+        }
+
+        private static bool IsSceneGameObjectCompatible(Type expectedType)
+        {
+            return expectedType == typeof(UnityEngine.Object)
+                   || expectedType.IsAssignableFrom(typeof(GameObject));
+        }
+
+        private static bool IsProjectAssetCompatible(Type expectedType, Type? assetType)
+        {
+            if (assetType is null)
+            {
+                return false;
+            }
+
+            if (expectedType == typeof(UnityEngine.Object))
+            {
+                return true;
+            }
+
+            if (typeof(Component).IsAssignableFrom(expectedType) && typeof(GameObject).IsAssignableFrom(assetType))
+            {
+                return true;
+            }
+
+            return expectedType.IsAssignableFrom(assetType);
         }
 
         private static bool ToggleComponent(string? targetPath, int componentIndex, string? componentName)
@@ -731,9 +962,198 @@ namespace UniFocl.EditorBridge
                         return false;
                     }
 
+                case SerializedPropertyType.ObjectReference:
+                    if (TryResolveObjectReferenceValue(property, rawValue, out var objectReference))
+                    {
+                        property.objectReferenceValue = objectReference;
+                        return true;
+                    }
+
+                    return false;
+
                 default:
                     return false;
             }
+        }
+
+        private static bool TryResolveObjectReferenceValue(SerializedProperty property, string rawValue, out UnityEngine.Object? resolved)
+        {
+            resolved = null;
+            var value = rawValue.Trim();
+            if (string.IsNullOrWhiteSpace(value) || value.Equals("null", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var expectedType = ResolveObjectReferenceExpectedType(property);
+            if (value.StartsWith("asset:", StringComparison.OrdinalIgnoreCase))
+            {
+                resolved = ResolveProjectReference(value["asset:".Length..], expectedType);
+                return resolved is not null;
+            }
+
+            if (value.StartsWith("scene:", StringComparison.OrdinalIgnoreCase))
+            {
+                resolved = ResolveSceneReference(value["scene:".Length..], expectedType);
+                return resolved is not null;
+            }
+
+            if (value.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
+            {
+                resolved = ResolveProjectReference(value, expectedType);
+                return resolved is not null;
+            }
+
+            if (value.StartsWith("/", StringComparison.Ordinal))
+            {
+                resolved = ResolveSceneReference(value, expectedType);
+                return resolved is not null;
+            }
+
+            return false;
+        }
+
+        private static Type ResolveObjectReferenceExpectedType(SerializedProperty property)
+        {
+            var fieldType = ResolveElementType(ResolveFieldInfo(property)?.FieldType);
+            if (fieldType is not null
+                && typeof(UnityEngine.Object).IsAssignableFrom(fieldType)
+                && fieldType != typeof(UnityEngine.Object))
+            {
+                return fieldType;
+            }
+
+            if (TryResolveSerializedReferenceType(property, out var serializedType))
+            {
+                return serializedType;
+            }
+
+            if (property.objectReferenceValue is not null)
+            {
+                return property.objectReferenceValue.GetType();
+            }
+
+            return typeof(UnityEngine.Object);
+        }
+
+        private static Type? ResolveElementType(Type? fieldType)
+        {
+            if (fieldType is null)
+            {
+                return null;
+            }
+
+            if (fieldType.IsArray)
+            {
+                return fieldType.GetElementType();
+            }
+
+            if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(List<>))
+            {
+                return fieldType.GetGenericArguments()[0];
+            }
+
+            return fieldType;
+        }
+
+        private static bool TryResolveSerializedReferenceType(SerializedProperty property, out Type resolvedType)
+        {
+            resolvedType = typeof(UnityEngine.Object);
+            var rawType = property.type?.Trim() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(rawType))
+            {
+                return false;
+            }
+
+            var normalized = rawType;
+            if (normalized.StartsWith("PPtr<", StringComparison.Ordinal) && normalized.EndsWith(">", StringComparison.Ordinal))
+            {
+                normalized = normalized["PPtr<".Length..^1];
+            }
+
+            if (normalized.StartsWith("$", StringComparison.Ordinal))
+            {
+                normalized = normalized[1..];
+            }
+
+            if (ObjectReferenceTypeLookup.TryGetValue(normalized, out var exact))
+            {
+                resolvedType = exact;
+                return true;
+            }
+
+            var key = NormalizeTypeLookupKey(normalized);
+            if (ObjectReferenceTypeLookup.TryGetValue(key, out var matched))
+            {
+                resolvedType = matched;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static UnityEngine.Object? ResolveProjectReference(string rawPath, Type expectedType)
+        {
+            var path = rawPath.Trim();
+            if (!path.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            if (typeof(Component).IsAssignableFrom(expectedType))
+            {
+                var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+                return prefab is null ? null : prefab.GetComponent(expectedType);
+            }
+
+            if (expectedType == typeof(UnityEngine.Object))
+            {
+                return AssetDatabase.LoadMainAssetAtPath(path);
+            }
+
+            return AssetDatabase.LoadAssetAtPath(path, expectedType);
+        }
+
+        private static UnityEngine.Object? ResolveSceneReference(string token, Type expectedType)
+        {
+            var normalized = token.Trim();
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                return null;
+            }
+
+            var separator = normalized.IndexOf('#');
+            var targetPath = separator >= 0 ? normalized[..separator] : normalized;
+            var componentToken = separator >= 0 ? normalized[(separator + 1)..] : null;
+            var gameObject = ResolveTarget(targetPath);
+            if (gameObject is null)
+            {
+                return null;
+            }
+
+            if (!string.IsNullOrWhiteSpace(componentToken))
+            {
+                var component = gameObject.GetComponents<Component>()
+                    .FirstOrDefault(candidate =>
+                        candidate is not null
+                        && (candidate.GetType().Name.Equals(componentToken, StringComparison.OrdinalIgnoreCase)
+                            || (candidate.GetType().FullName?.Equals(componentToken, StringComparison.OrdinalIgnoreCase) ?? false)));
+                return component is not null && expectedType.IsAssignableFrom(component.GetType())
+                    ? component
+                    : null;
+            }
+
+            if (expectedType == typeof(UnityEngine.Object) || expectedType.IsAssignableFrom(typeof(GameObject)))
+            {
+                return gameObject;
+            }
+
+            if (typeof(Component).IsAssignableFrom(expectedType))
+            {
+                return gameObject.GetComponent(expectedType);
+            }
+
+            return null;
         }
 
         private static string FormatPropertyValue(SerializedProperty property)
@@ -816,6 +1236,45 @@ namespace UniFocl.EditorBridge
                 foreach (var type in types)
                 {
                     if (type.IsAbstract || !typeof(Component).IsAssignableFrom(type))
+                    {
+                        continue;
+                    }
+
+                    lookup[type.FullName ?? type.Name] = type;
+                    lookup[type.Name] = type;
+                    lookup[NormalizeTypeLookupKey(type.Name)] = type;
+                    if (!string.IsNullOrWhiteSpace(type.FullName))
+                    {
+                        lookup[NormalizeTypeLookupKey(type.FullName)] = type;
+                    }
+                }
+            }
+
+            return lookup;
+        }
+
+        private static Dictionary<string, Type> BuildObjectReferenceTypeLookup()
+        {
+            var lookup = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type[] types;
+                try
+                {
+                    types = assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    types = ex.Types.Where(type => type is not null).Cast<Type>().ToArray();
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (var type in types)
+                {
+                    if (!typeof(UnityEngine.Object).IsAssignableFrom(type))
                     {
                         continue;
                     }

--- a/src/unifocl/Models/FuzzyModels.cs
+++ b/src/unifocl/Models/FuzzyModels.cs
@@ -34,5 +34,5 @@ internal sealed record InspectorSearchResultDto(
     int? ComponentIndex,
     string Name,
     string Path,
-    double Score);
-
+    double Score,
+    string? ValueToken = null);

--- a/src/unifocl/Models/InspectorModels.cs
+++ b/src/unifocl/Models/InspectorModels.cs
@@ -26,6 +26,8 @@ internal sealed class InspectorContext
     public bool InteractiveOverlayActive { get; set; }
     public string? InteractiveOverlayTitle { get; set; }
     public string? InteractiveOverlayValue { get; set; }
+    public List<string> InteractiveSearchPreviewRows { get; } = [];
+    public List<InspectorReferenceSearchEntry> LastReferenceSearchResults { get; } = [];
 
     public string PromptPath =>
         Depth == InspectorDepth.ComponentFields && !string.IsNullOrWhiteSpace(SelectedComponentName)
@@ -45,3 +47,8 @@ internal sealed record InspectorFieldEntry(
     string Type,
     bool IsBoolean,
     IReadOnlyList<string>? EnumOptions = null);
+
+internal sealed record InspectorReferenceSearchEntry(
+    string Scope,
+    string Path,
+    string ValueToken);

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -120,8 +120,8 @@ var projectCommands = new List<CommandSpec>
     new("s <field> <value...>", "Alias for set", "s"),
     new("toggle <target>", "Toggle bool/active/enabled in active mode", "toggle"),
     new("t <target>", "Alias for toggle", "t"),
-    new("f <query>", "Fuzzy find in active mode", "f"),
-    new("ff <query>", "Alias for fuzzy find", "ff"),
+    new("f [--type <type>|t:<type>] <query>", "Fuzzy find in active mode", "f"),
+    new("ff [--type <type>|t:<type>] <query>", "Alias for fuzzy find", "ff"),
     new("move <...>", "Move/reorder item in active mode", "move"),
     new("mv <...>", "Alias for move", "mv"),
     new("upm list [--outdated] [--builtin] [--git]", "List installed Unity packages (UPM)", "upm list"),
@@ -157,6 +157,7 @@ var inspectorCommands = new List<CommandSpec>
     new("..", "Alias for up", ".."),
     new(":i", "Alias for up", ":i"),
     new("set <field> <value...>", "Set selected component field in inspector", "set"),
+    new("set <field> --search <query> [--scene|--project]", "Search and list ObjectReference candidates for indexed assignment", "set"),
     new("s <field> <value...>", "Alias for set", "s"),
     new("set <Component>.<field> <value...>", "Set a field directly from inspector root", "set"),
     new("edit <field> <value...>", "Edit serialized field value for selected component", "edit"),
@@ -861,7 +862,7 @@ static int RenderComposerFrame(
     }
     else if (session.ContextMode == CliContextMode.Project && !string.IsNullOrWhiteSpace(session.CurrentProjectPath))
     {
-        lines.Add("[dim]Project mode: list, enter <idx>, up, f <query>, mk <type> [count] [--name], load <idx|name>, rename <idx> <new>, remove <idx>, move <...>, F7 focus nav[/]");
+        lines.Add("[dim]Project mode: list, enter <idx>, up, f [--type <type>|t:<type>] <query>, mk <type> [count] [--name], load <idx|name>, rename <idx> <new>, remove <idx>, move <...>, F7 focus nav[/]");
     }
     else
     {
@@ -1944,47 +1945,10 @@ static List<(string Path, string? CommitCommand)> GetInspectorFuzzyCandidates(In
 }
 
 static (string? TypeFilter, string Query) ParseProjectFuzzyQuery(string query)
-{
-    if (string.IsNullOrWhiteSpace(query))
-    {
-        return (null, string.Empty);
-    }
-
-    var tokens = query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-    string? typeFilter = null;
-    var remaining = new List<string>();
-    foreach (var token in tokens)
-    {
-        if (token.StartsWith("t:", StringComparison.OrdinalIgnoreCase))
-        {
-            typeFilter = token[2..];
-            continue;
-        }
-
-        remaining.Add(token);
-    }
-
-    return (typeFilter, remaining.Count == 0 ? string.Empty : string.Join(' ', remaining));
-}
+    => ProjectMkCatalog.ParseFuzzyQuery(query);
 
 static bool PassesProjectTypeFilter(string path, string? typeFilter)
-{
-    if (string.IsNullOrWhiteSpace(typeFilter))
-    {
-        return true;
-    }
-
-    var ext = Path.GetExtension(path).ToLowerInvariant();
-    return typeFilter.ToLowerInvariant() switch
-    {
-        "script" => ext == ".cs",
-        "scene" => ext == ".unity",
-        "prefab" => ext == ".prefab",
-        "material" => ext == ".mat",
-        "animation" => ext is ".anim" or ".controller",
-        _ => path.Contains(typeFilter, StringComparison.OrdinalIgnoreCase)
-    };
-}
+    => ProjectMkCatalog.PassesFuzzyTypeFilter(path, typeFilter);
 
 static bool TryParseExecLaunchOptions(string[] args, out ExecLaunchOptions? options, out string? error)
 {

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -1,10 +1,10 @@
 internal static class CliVersion
 {
     public const int Major = 0;
-    public const int Minor = 11;
+    public const int Minor = 12;
     public const int Patch = 0;
     public const string DevCycle = "";
-    public const string Protocol = "v5";
+    public const string Protocol = "v6";
 
     public static string SemVer => string.IsNullOrWhiteSpace(DevCycle)
         ? $"{Major}.{Minor}.{Patch}"

--- a/src/unifocl/Services/InspectorModeService.cs
+++ b/src/unifocl/Services/InspectorModeService.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Globalization;
+using Spectre.Console;
 
 internal sealed class InspectorModeService
 {
@@ -560,12 +561,13 @@ internal sealed class InspectorModeService
         {
             AddStream(context, $"{context.PromptLabel} > {input}");
             AddStream(context, "[!] usage: set <field> <value...>");
+            AddStream(context, "[!] usage (ObjectReference): set <field> --search <query> [--scene|--project]");
             _renderer.Render(context);
             return;
         }
 
         var fieldName = tokens[1];
-        var newValue = string.Join(' ', tokens.Skip(2));
+        var valueTokens = tokens.Skip(2).ToList();
 
         if (context.Depth != InspectorDepth.ComponentFields)
         {
@@ -609,32 +611,16 @@ internal sealed class InspectorModeService
                 return;
             }
 
-            var rootMutationOk = await TrySendInspectorMutationAsync(
+            await ApplySetFieldAsync(
+                input,
                 session,
-                new InspectorBridgeRequest(
-                    "set-field",
-                    context.TargetPath,
-                    component.Index,
-                    component.Name,
-                    rootField.Name,
-                    newValue,
-                    null));
-
-            AddStream(context, $"{context.PromptLabel} > {input}");
-            if (rootMutationOk)
-            {
-                var refreshedFields = await TryFetchFieldsFromBridgeAsync(session, context.TargetPath, component.Index);
-                var appliedValue = refreshedFields?
-                    .FirstOrDefault(f => f.Name.Equals(rootField.Name, StringComparison.OrdinalIgnoreCase))
-                    ?.Value ?? newValue;
-                AddStream(context, $"[=] ok: {component.Name}.{rootField.Name} updated to {appliedValue}");
-            }
-            else
-            {
-                AddStream(context, "[!] failed to set field in Bridge mode");
-            }
-
-            _renderer.Render(context);
+                context,
+                component.Index,
+                component.Name,
+                rootField,
+                valueTokens,
+                successLabel: $"{component.Name}.{rootField.Name}",
+                updateSelectedComponentFields: false);
             return;
         }
 
@@ -647,32 +633,278 @@ internal sealed class InspectorModeService
             return;
         }
 
+        await ApplySetFieldAsync(
+            input,
+            session,
+            context,
+            context.SelectedComponentIndex!.Value,
+            context.SelectedComponentName ?? string.Empty,
+            field,
+            valueTokens,
+            successLabel: field.Name,
+            updateSelectedComponentFields: true);
+    }
+
+    private async Task ApplySetFieldAsync(
+        string input,
+        CliSessionState session,
+        InspectorContext context,
+        int componentIndex,
+        string componentName,
+        InspectorFieldEntry field,
+        IReadOnlyList<string> valueTokens,
+        string successLabel,
+        bool updateSelectedComponentFields)
+    {
+        if (valueTokens.Count == 0)
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            AddStream(context, "[!] usage: set <field> <value...>");
+            _renderer.Render(context);
+            return;
+        }
+
+        if (IsObjectReferenceField(field)
+            && TryParseReferenceSearchArguments(valueTokens, out var query, out var includeScene, out var includeProject, out var searchError))
+        {
+            AddStream(context, $"{context.PromptLabel} > {input}");
+            if (!string.IsNullOrWhiteSpace(searchError))
+            {
+                AddStream(context, $"[!] {searchError}");
+                _renderer.Render(context);
+                return;
+            }
+
+            await SearchReferenceCandidatesAsync(
+                context,
+                session,
+                componentIndex,
+                componentName,
+                field.Name,
+                query,
+                includeScene,
+                includeProject);
+            _renderer.Render(context);
+            return;
+        }
+
+        var newValue = string.Join(' ', valueTokens).Trim();
+        if (IsObjectReferenceField(field)
+            && TryResolveReferenceSelectionValue(newValue, context.LastReferenceSearchResults, out var resolvedValue, out var selectionError))
+        {
+            if (!string.IsNullOrWhiteSpace(selectionError))
+            {
+                AddStream(context, $"{context.PromptLabel} > {input}");
+                AddStream(context, $"[!] {selectionError}");
+                _renderer.Render(context);
+                return;
+            }
+
+            newValue = resolvedValue;
+        }
+
         var mutationOk = await TrySendInspectorMutationAsync(
             session,
             new InspectorBridgeRequest(
                 "set-field",
                 context.TargetPath,
-                context.SelectedComponentIndex,
-                context.SelectedComponentName,
+                componentIndex,
+                componentName,
                 field.Name,
                 newValue,
                 null));
 
         AddStream(context, $"{context.PromptLabel} > {input}");
-        if (mutationOk)
+        if (!mutationOk)
         {
-            await PopulateFieldsAsync(context, session, context.SelectedComponentIndex!.Value, forceRefresh: true);
+            AddStream(context, "[!] failed to set field in Bridge mode");
+            _renderer.Render(context);
+            return;
+        }
+
+        if (updateSelectedComponentFields)
+        {
+            await PopulateFieldsAsync(context, session, componentIndex, forceRefresh: true);
             var appliedValue = context.Fields
                 .FirstOrDefault(f => f.Name.Equals(field.Name, StringComparison.OrdinalIgnoreCase))
                 ?.Value ?? newValue;
-            AddStream(context, $"[=] ok: {field.Name} updated to {appliedValue}");
-        }
-        else
-        {
-            AddStream(context, "[!] failed to set field in Bridge mode");
+            AddStream(context, $"[=] ok: {successLabel} updated to {appliedValue}");
+            _renderer.Render(context);
+            return;
         }
 
+        var refreshedFields = await TryFetchFieldsFromBridgeAsync(session, context.TargetPath, componentIndex);
+        var refreshedValue = refreshedFields?
+            .FirstOrDefault(f => f.Name.Equals(field.Name, StringComparison.OrdinalIgnoreCase))
+            ?.Value ?? newValue;
+        AddStream(context, $"[=] ok: {successLabel} updated to {refreshedValue}");
         _renderer.Render(context);
+    }
+
+    private async Task SearchReferenceCandidatesAsync(
+        InspectorContext context,
+        CliSessionState session,
+        int componentIndex,
+        string componentName,
+        string fieldName,
+        string query,
+        bool includeScene,
+        bool includeProject)
+    {
+        var payload = new InspectorBridgeRequest(
+            "find-reference",
+            context.TargetPath,
+            componentIndex,
+            componentName,
+            fieldName,
+            null,
+            query,
+            includeScene,
+            includeProject);
+        var responseJson = await SendBridgeRequestAsync(payload, session);
+        if (string.IsNullOrWhiteSpace(responseJson))
+        {
+            AddStream(context, "[!] failed to query reference candidates from Bridge mode");
+            return;
+        }
+
+        try
+        {
+            var response = JsonSerializer.Deserialize<InspectorBridgeSearchResponse>(responseJson, _jsonOptions);
+            if (response?.Ok != true || response.Results is null)
+            {
+                AddStream(context, "[!] failed to query reference candidates from Bridge mode");
+                return;
+            }
+
+            var referenceResults = response.Results
+                .Where(result => !string.IsNullOrWhiteSpace(result.Path) && !string.IsNullOrWhiteSpace(result.ValueToken))
+                .Select(result => new InspectorReferenceSearchEntry(
+                    string.IsNullOrWhiteSpace(result.Scope) ? "reference" : result.Scope,
+                    result.Path,
+                    result.ValueToken!))
+                .ToList();
+
+            context.LastReferenceSearchResults.Clear();
+            context.LastReferenceSearchResults.AddRange(referenceResults);
+            AppendInspectorReferenceSearchResults(context, query, includeScene, includeProject, referenceResults);
+        }
+        catch
+        {
+            AddStream(context, "[!] failed to parse reference candidates from Bridge mode");
+        }
+    }
+
+    private static bool TryParseReferenceSearchArguments(
+        IReadOnlyList<string> valueTokens,
+        out string query,
+        out bool includeScene,
+        out bool includeProject,
+        out string? error)
+    {
+        query = string.Empty;
+        includeScene = false;
+        includeProject = false;
+        error = null;
+        if (valueTokens.Count == 0
+            || !valueTokens[0].Equals("--search", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var queryTokens = new List<string>();
+        for (var i = 1; i < valueTokens.Count; i++)
+        {
+            var token = valueTokens[i];
+            if (token.Equals("--scene", StringComparison.OrdinalIgnoreCase))
+            {
+                includeScene = true;
+                continue;
+            }
+
+            if (token.Equals("--project", StringComparison.OrdinalIgnoreCase))
+            {
+                includeProject = true;
+                continue;
+            }
+
+            queryTokens.Add(token);
+        }
+
+        if (!includeScene && !includeProject)
+        {
+            includeScene = true;
+            includeProject = true;
+        }
+
+        query = string.Join(' ', queryTokens).Trim();
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            error = "usage: set <field> --search <query> [--scene|--project]";
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveReferenceSelectionValue(
+        string rawValue,
+        IReadOnlyList<InspectorReferenceSearchEntry> searchResults,
+        out string resolvedValue,
+        out string? error)
+    {
+        resolvedValue = rawValue;
+        error = null;
+        if (!rawValue.StartsWith("@", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(rawValue[1..], out var index) || index < 0 || index >= searchResults.Count)
+        {
+            error = "invalid reference index; run set <field> --search <query> first, then use @<index>";
+            return true;
+        }
+
+        resolvedValue = searchResults[index].ValueToken;
+        return true;
+    }
+
+    private static bool IsObjectReferenceField(InspectorFieldEntry field)
+        => field.Type.Equals("ObjectReference", StringComparison.OrdinalIgnoreCase);
+
+    private static void AppendInspectorReferenceSearchResults(
+        InspectorContext context,
+        string query,
+        bool includeScene,
+        bool includeProject,
+        IReadOnlyList<InspectorReferenceSearchEntry> results)
+    {
+        if (results.Count == 0)
+        {
+            AddStream(context, $"[x] no reference results for: {query}");
+            return;
+        }
+
+        var scopeLabel = includeScene && includeProject
+            ? "scene+project"
+            : includeScene
+                ? "scene"
+                : "project";
+        const int maxLines = 10;
+        AddStream(context, $"[*] reference results ({scopeLabel}) for: {query}");
+        var shown = Math.Min(maxLines, results.Count);
+        for (var i = 0; i < shown; i++)
+        {
+            var result = results[i];
+            AddStream(context, $"[{i}] [{result.Scope}] {result.Path}");
+        }
+
+        if (results.Count > shown)
+        {
+            AddStream(context, $"[i] showing first {shown}/{results.Count} results");
+        }
+
+        AddStream(context, "[i] use set <field> @<index> to assign a listed reference");
     }
 
     private async Task HandleFuzzyFindAsync(
@@ -1239,6 +1471,7 @@ internal sealed class InspectorModeService
         context.BodyScrollOffset = 0;
         context.FollowStreamScroll = true;
         context.StreamScrollOffset = int.MaxValue;
+        context.LastReferenceSearchResults.Clear();
         session.ContextMode = CliContextMode.Inspector;
         session.FocusPath = targetPath;
         await PopulateComponentsAsync(context, session, forceRefresh: true);
@@ -1275,6 +1508,7 @@ internal sealed class InspectorModeService
         context.BodyScrollOffset = 0;
         context.FollowStreamScroll = true;
         context.StreamScrollOffset = int.MaxValue;
+        context.LastReferenceSearchResults.Clear();
         await PopulateFieldsAsync(context, session, componentIndex, forceRefresh: true);
         AddStream(context, $"UnityCLI:{context.TargetPath} [[inspect]] > {rawCommand}");
         AddStream(context, $"[i] inspecting component: {component.Name}");
@@ -1347,6 +1581,12 @@ internal sealed class InspectorModeService
             return;
         }
 
+        if (IsObjectReferenceField(field))
+        {
+            await RunObjectReferenceFieldEditAsync(context, session, field);
+            return;
+        }
+
         if (IsNumericFieldType(field.Type))
         {
             await RunNumericFieldEditAsync(context, session, field);
@@ -1368,6 +1608,240 @@ internal sealed class InspectorModeService
 
         AddStream(context, $"[i] interactive edit not available for {field.Type}; use set/edit command");
         _renderer.Render(context, null, field.Name, focusModeEnabled: true);
+    }
+
+    private async Task RunObjectReferenceFieldEditAsync(
+        InspectorContext context,
+        CliSessionState session,
+        InspectorFieldEntry field)
+    {
+        if (context.SelectedComponentIndex is null || string.IsNullOrWhiteSpace(context.SelectedComponentName))
+        {
+            AddStream(context, "[!] no selected component for reference edit");
+            _renderer.Render(context, null, field.Name, focusModeEnabled: true);
+            return;
+        }
+
+        var query = string.Empty;
+        var includeScene = true;
+        var includeProject = true;
+        var selectedIndex = 0;
+        AddStream(context, "[i] reference edit: type query, Up/Down select, Enter apply, Tab scope(scene/project/all), Esc cancel");
+        BeginInteractiveEdit(context, field.Name, "reference", 0, 0);
+
+        try
+        {
+            while (true)
+            {
+                var results = await FetchReferenceSearchEntriesAsync(
+                    context,
+                    session,
+                    context.SelectedComponentIndex.Value,
+                    context.SelectedComponentName,
+                    field.Name,
+                    query,
+                    includeScene,
+                    includeProject);
+
+                context.LastReferenceSearchResults.Clear();
+                context.LastReferenceSearchResults.AddRange(results);
+                selectedIndex = results.Count == 0
+                    ? 0
+                    : Math.Clamp(selectedIndex, 0, Math.Min(7, results.Count - 1));
+                context.InteractiveSearchPreviewRows.Clear();
+                context.InteractiveSearchPreviewRows.AddRange(
+                    BuildReferencePreviewRows(query, includeScene, includeProject, results, selectedIndex));
+                _renderer.Render(context, null, field.Name, focusModeEnabled: true);
+
+                var key = Console.ReadKey(intercept: true);
+                switch (key.Key)
+                {
+                    case ConsoleKey.Escape:
+                        context.InteractiveSearchPreviewRows.Clear();
+                        AddStream(context, "[i] reference edit cancelled");
+                        _renderer.Render(context, null, field.Name, focusModeEnabled: true);
+                        return;
+
+                    case ConsoleKey.Enter:
+                        if (results.Count == 0)
+                        {
+                            AddStream(context, "[!] no reference result selected");
+                            continue;
+                        }
+
+                        var selected = results[Math.Clamp(selectedIndex, 0, results.Count - 1)];
+                        if (await ApplyInteractiveFieldValueAsync(context, session, field, selected.ValueToken))
+                        {
+                            context.InteractiveSearchPreviewRows.Clear();
+                            return;
+                        }
+
+                        context.InteractiveSearchPreviewRows.Clear();
+                        _renderer.Render(context, null, field.Name, focusModeEnabled: true);
+                        return;
+
+                    case ConsoleKey.UpArrow:
+                        if (results.Count > 0)
+                        {
+                            var cap = Math.Min(8, results.Count);
+                            selectedIndex = selectedIndex <= 0 ? cap - 1 : selectedIndex - 1;
+                        }
+
+                        break;
+
+                    case ConsoleKey.DownArrow:
+                        if (results.Count > 0)
+                        {
+                            var cap = Math.Min(8, results.Count);
+                            selectedIndex = (selectedIndex + 1) % cap;
+                        }
+
+                        break;
+
+                    case ConsoleKey.Tab:
+                        if (includeScene && includeProject)
+                        {
+                            includeScene = true;
+                            includeProject = false;
+                        }
+                        else if (includeScene)
+                        {
+                            includeScene = false;
+                            includeProject = true;
+                        }
+                        else
+                        {
+                            includeScene = true;
+                            includeProject = true;
+                        }
+
+                        selectedIndex = 0;
+                        break;
+
+                    case ConsoleKey.Backspace:
+                        if (query.Length > 0)
+                        {
+                            query = query[..^1];
+                            selectedIndex = 0;
+                        }
+
+                        break;
+
+                    default:
+                        if (!char.IsControl(key.KeyChar))
+                        {
+                            query += key.KeyChar;
+                            selectedIndex = 0;
+                        }
+
+                        break;
+                }
+            }
+        }
+        finally
+        {
+            context.InteractiveSearchPreviewRows.Clear();
+            EndInteractiveEdit(context);
+        }
+    }
+
+    private async Task<List<InspectorReferenceSearchEntry>> FetchReferenceSearchEntriesAsync(
+        InspectorContext context,
+        CliSessionState session,
+        int componentIndex,
+        string componentName,
+        string fieldName,
+        string query,
+        bool includeScene,
+        bool includeProject)
+    {
+        var payload = new InspectorBridgeRequest(
+            "find-reference",
+            context.TargetPath,
+            componentIndex,
+            componentName,
+            fieldName,
+            null,
+            query,
+            includeScene,
+            includeProject);
+        var responseJson = await SendBridgeRequestAsync(payload, session);
+        if (string.IsNullOrWhiteSpace(responseJson))
+        {
+            return [];
+        }
+
+        try
+        {
+            var response = JsonSerializer.Deserialize<InspectorBridgeSearchResponse>(responseJson, _jsonOptions);
+            if (response?.Ok != true || response.Results is null)
+            {
+                return [];
+            }
+
+            return response.Results
+                .Where(result => !string.IsNullOrWhiteSpace(result.Path) && !string.IsNullOrWhiteSpace(result.ValueToken))
+                .Select(result => new InspectorReferenceSearchEntry(
+                    string.IsNullOrWhiteSpace(result.Scope) ? "reference" : result.Scope,
+                    result.Path,
+                    result.ValueToken!))
+                .ToList();
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static IReadOnlyList<string> BuildReferencePreviewRows(
+        string query,
+        bool includeScene,
+        bool includeProject,
+        IReadOnlyList<InspectorReferenceSearchEntry> results,
+        int selectedIndex)
+    {
+        var scopeLabel = includeScene && includeProject
+            ? "all"
+            : includeScene
+                ? "scene"
+                : "project";
+        var lines = new List<string>
+        {
+            $"[grey]reference fuzzy[/] | query: {Markup.Escape(query)} | scope: {Markup.Escape(scopeLabel)}"
+        };
+
+        if (results.Count == 0)
+        {
+            lines.Add("no matches");
+            lines.Add("[grey]type to search references[/]");
+            return lines;
+        }
+
+        var shown = Math.Min(8, results.Count);
+        for (var i = 0; i < shown; i++)
+        {
+            var result = results[i];
+            var indexCell = Markup.Escape($"[{i}]");
+            var scopeCell = Markup.Escape($"[{result.Scope}]");
+            var escapedScope = Markup.Escape(result.Scope);
+            var escapedPath = Markup.Escape(result.Path);
+            if (i == selectedIndex)
+            {
+                lines.Add(
+                    $"[{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]▸ {indexCell} {scopeCell} {escapedPath}[/]");
+                continue;
+            }
+
+            lines.Add($"[grey] {indexCell} {scopeCell} {escapedPath}[/]");
+        }
+
+        if (results.Count > shown)
+        {
+            lines.Add($"... {results.Count - shown} more");
+        }
+
+        lines.Add("[grey]Enter apply | Tab scope | Esc cancel[/]");
+        return lines;
     }
 
     private async Task RunVectorFieldEditAsync(
@@ -1701,6 +2175,7 @@ internal sealed class InspectorModeService
         context.InteractiveOverlayActive = false;
         context.InteractiveOverlayTitle = null;
         context.InteractiveOverlayValue = null;
+        context.InteractiveSearchPreviewRows.Clear();
     }
 
     private static void SetInteractiveOverlay(InspectorContext context, string title, string value)
@@ -2373,7 +2848,9 @@ internal sealed class InspectorModeService
         string? ComponentName,
         string? FieldName,
         string? Value,
-        string? Query);
+        string? Query,
+        bool IncludeSceneReferences = true,
+        bool IncludeProjectReferences = true);
 
     private sealed record InspectorBridgeComponentsResponse(bool Ok, List<InspectorBridgeComponent>? Components);
     private sealed record InspectorBridgeFieldsResponse(bool Ok, List<InspectorBridgeField>? Fields);

--- a/src/unifocl/Services/InspectorTuiRenderer.cs
+++ b/src/unifocl/Services/InspectorTuiRenderer.cs
@@ -202,6 +202,16 @@ internal sealed class InspectorTuiRenderer
         var rows = context.CommandStream
             .Where(line => !line.StartsWith("UnityCLI:", StringComparison.OrdinalIgnoreCase))
             .ToList();
+        if (context.InteractiveSearchPreviewRows.Count > 0)
+        {
+            if (rows.Count > 0)
+            {
+                rows.Add(string.Empty);
+            }
+
+            rows.AddRange(context.InteractiveSearchPreviewRows);
+        }
+
         if (rows.Count == 0)
         {
             return [];

--- a/src/unifocl/Services/ProjectDaemonBridge.cs
+++ b/src/unifocl/Services/ProjectDaemonBridge.cs
@@ -333,33 +333,7 @@ internal sealed class ProjectDaemonBridge
 
     private static string ResolveStubExtension(string type)
     {
-        return ProjectMkCatalog.NormalizeKey(type) switch
-        {
-            "scene" => ".unity",
-            "prefab" => ".prefab",
-            "prefabvariant" => ".prefab",
-            "csharpscript" => ".cs",
-            "scriptableobjectscript" => ".cs",
-            "assemblydefinition" => ".asmdef",
-            "assemblydefinitionreference" => ".asmref",
-            "testingassemblydefinition" => ".asmdef",
-            "testingassemblydefinitionreference" => ".asmref",
-            "shader" => ".shader",
-            "computeshader" => ".compute",
-            "shaderincludefile" => ".hlsl",
-            "material" => ".mat",
-            "animatorcontroller" => ".controller",
-            "animatoroverridecontroller" => ".overrideController",
-            "animationclip" => ".anim",
-            "inputactions" => ".inputactions",
-            "uxmldocument" => ".uxml",
-            "ussstylesheet" => ".uss",
-            "shadergraph" => ".shadergraph",
-            "subgraph" => ".shadersubgraph",
-            "vfxgraph" => ".vfx",
-            "searchindex" => ".index",
-            _ => ".asset"
-        };
+        return ProjectMkCatalog.ResolveDefaultExtension(type);
     }
 
     private string EnsureUniqueStubAssetPath(string relativePath)

--- a/src/unifocl/Services/ProjectMkCatalog.cs
+++ b/src/unifocl/Services/ProjectMkCatalog.cs
@@ -31,6 +31,119 @@ internal static class ProjectMkCatalog
         return true;
     }
 
+    public static (string? TypeFilter, string Query) ParseFuzzyQuery(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return (null, string.Empty);
+        }
+
+        var tokens = query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        string? typeFilter = null;
+        var remaining = new List<string>();
+
+        for (var i = 0; i < tokens.Length; i++)
+        {
+            var token = tokens[i];
+
+            if (token.StartsWith("t:", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = token[2..].Trim();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    typeFilter = value;
+                    continue;
+                }
+            }
+
+            if (token.Equals("--type", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("-t", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 < tokens.Length && !string.IsNullOrWhiteSpace(tokens[i + 1]))
+                {
+                    typeFilter = tokens[++i];
+                    continue;
+                }
+
+                remaining.Add(token);
+                continue;
+            }
+
+            if (token.StartsWith("--type=", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = token["--type=".Length..].Trim();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    typeFilter = value;
+                    continue;
+                }
+            }
+
+            if (token.StartsWith("-t=", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = token["-t=".Length..].Trim();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    typeFilter = value;
+                    continue;
+                }
+            }
+
+            remaining.Add(token);
+        }
+
+        return (typeFilter, remaining.Count == 0 ? string.Empty : string.Join(' ', remaining));
+    }
+
+    public static bool PassesFuzzyTypeFilter(string path, string? typeFilter)
+    {
+        if (string.IsNullOrWhiteSpace(typeFilter))
+        {
+            return true;
+        }
+
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        var extensions = ResolveFilterExtensions(typeFilter);
+        if (extensions.Count > 0)
+        {
+            return extensions.Contains(ext);
+        }
+
+        return path.Contains(typeFilter, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string ResolveDefaultExtension(string type)
+    {
+        var key = NormalizeKey(type);
+        return key switch
+        {
+            "scene" => ".unity",
+            "prefab" => ".prefab",
+            "prefabvariant" => ".prefab",
+            "csharpscript" => ".cs",
+            "scriptableobjectscript" => ".cs",
+            "assemblydefinition" => ".asmdef",
+            "assemblydefinitionreference" => ".asmref",
+            "testingassemblydefinition" => ".asmdef",
+            "testingassemblydefinitionreference" => ".asmref",
+            "shader" => ".shader",
+            "computeshader" => ".compute",
+            "shaderincludefile" => ".hlsl",
+            "material" => ".mat",
+            "animatorcontroller" => ".controller",
+            "animatoroverridecontroller" => ".overrideController",
+            "animationclip" => ".anim",
+            "inputactions" => ".inputactions",
+            "uxmldocument" => ".uxml",
+            "ussstylesheet" => ".uss",
+            "shadergraph" => ".shadergraph",
+            "subgraph" => ".shadersubgraph",
+            "vfxgraph" => ".vfx",
+            "searchindex" => ".index",
+            _ => ".asset"
+        };
+    }
+
     public static string NormalizeKey(string raw)
     {
         var builder = new StringBuilder(raw.Length);
@@ -43,6 +156,43 @@ internal static class ProjectMkCatalog
         }
 
         return builder.ToString();
+    }
+
+    private static HashSet<string> ResolveFilterExtensions(string rawTypeFilter)
+    {
+        var extensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(rawTypeFilter))
+        {
+            return extensions;
+        }
+
+        if (TryNormalizeType(rawTypeFilter, out var canonicalType, out _))
+        {
+            AddCanonicalExtensions(canonicalType, extensions);
+        }
+
+        var filterKey = NormalizeKey(rawTypeFilter);
+        if (filterKey is "animation" or "anim")
+        {
+            extensions.Add(".anim");
+            extensions.Add(".controller");
+        }
+
+        return extensions;
+    }
+
+    private static void AddCanonicalExtensions(string canonicalType, HashSet<string> extensions)
+    {
+        var primaryExtension = ResolveDefaultExtension(canonicalType);
+        if (!string.IsNullOrWhiteSpace(primaryExtension))
+        {
+            extensions.Add(primaryExtension);
+        }
+
+        if (canonicalType.Equals("AnimationClip", StringComparison.OrdinalIgnoreCase))
+        {
+            extensions.Add(".controller");
+        }
     }
 
     private static Dictionary<string, string> BuildTypeLookup()

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -1442,7 +1442,7 @@ internal sealed class ProjectViewService
     {
         if (tokens.Count < 2)
         {
-            outputs.Add("[x] usage: f <query>");
+            outputs.Add("[x] usage: f [--type <type>|t:<type>] <query>");
             return true;
         }
 
@@ -2814,42 +2814,10 @@ $"using UnityEngine;{Environment.NewLine}{Environment.NewLine}[CreateAssetMenu(f
     }
 
     private static (string? TypeFilter, string Query) ParseProjectQuery(string query)
-    {
-        var tokens = query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        string? filter = null;
-        var remaining = new List<string>();
-        foreach (var token in tokens)
-        {
-            if (token.StartsWith("t:", StringComparison.OrdinalIgnoreCase))
-            {
-                filter = token[2..];
-                continue;
-            }
-
-            remaining.Add(token);
-        }
-
-        return (filter, remaining.Count == 0 ? string.Empty : string.Join(' ', remaining));
-    }
+        => ProjectMkCatalog.ParseFuzzyQuery(query);
 
     private static bool PassesTypeFilter(string path, string? typeFilter)
-    {
-        if (string.IsNullOrWhiteSpace(typeFilter))
-        {
-            return true;
-        }
-
-        var ext = Path.GetExtension(path).ToLowerInvariant();
-        return typeFilter.ToLowerInvariant() switch
-        {
-            "script" => ext == ".cs",
-            "scene" => ext == ".unity",
-            "prefab" => ext == ".prefab",
-            "material" => ext == ".mat",
-            "animation" => ext is ".anim" or ".controller",
-            _ => path.Contains(typeFilter, StringComparison.OrdinalIgnoreCase)
-        };
-    }
+        => ProjectMkCatalog.PassesFuzzyTypeFilter(path, typeFilter);
 
     private static string FormatProjectCommandFailure(string action, string? message)
     {


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Adds `--type`/`-t` support to project-mode fuzzy find and unifies fuzzy type parsing/filtering + mk extension mapping through `ProjectMkCatalog`.
  - Adds inspector ObjectReference reference-search workflow:
    - `set <field> --search <query> [--scene|--project]`
    - `set <field> @<index>` indexed assignment
    - interactive focus-mode picker on `Enter` for ObjectReference fields.
  - Moves ObjectReference fuzzy preview to the inspector stream pane (below the TUI body), and styles selected row with cursor highlight.
  - Fixes markup escaping for bracket cells in the preview (`[index]`, `[scope]`).
  - Hardens reference type restriction by resolving expected ObjectReference type from serialized metadata (`PPtr<...>`) when reflection cannot resolve the backing field.
  - Officializes release `0.12.0` and bumps bridge protocol to `v6`.
- Why is this change needed?
  - Project fuzzy filtering needed first-class typed flags and shared catalog logic to avoid drift.
  - Inspector reference assignment lacked a practical fuzzy workflow and returned over-broad suggestions for typed reference fields.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [x] Bug fix
- [x] Refactor
- [x] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Program.cs`
  - `src/unifocl/Services/ProjectMkCatalog.cs`
  - `src/unifocl/Services/ProjectViewService.cs`
  - `src/unifocl/Services/ProjectDaemonBridge.cs`
  - `src/unifocl/Services/InspectorModeService.cs`
  - `src/unifocl/Services/InspectorTuiRenderer.cs`
  - `src/unifocl/Models/InspectorModels.cs`
  - `src/unifocl/Models/FuzzyModels.cs`
  - `src/unifocl.unity/EditorScripts/Services/DaemonInspectorService.cs`
  - `src/unifocl.unity/EditorScripts/Models/DaemonBridgeModels.cs`
  - `src/unifocl/Services/CliVersion.cs`
  - `CHANGELOG.md`, `README.md`
- Out-of-scope / intentionally not addressed:
  - Additional inspector reference categories beyond scene/project
  - Expanded compatcheck automation in this environment

## How to Test
1. Build CLI:
   - `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal`
2. In project mode, run fuzzy find with type restriction:
   - `f --type script Player`
   - `f t:scene Main`
3. In inspector mode on an ObjectReference field:
   - `set <field> --search controller --project`
   - `set <field> @0`
   - Focus mode (`F7`) -> select ObjectReference field -> `Enter`, then type query / `Tab` scope / `Up|Down` / `Enter` apply.

Expected results:
- Project fuzzy results are constrained by requested type.
- ObjectReference suggestions are restricted to compatible types (e.g., animation controller fields only show compatible references).
- Selected reference preview row renders highlighted (no literal broken markup tags).

## Screenshots / Terminal Output (if applicable)
- `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal` passed.
- `dotnet build src/unifocl.unity.compatcheck/unifocl.unity.compatcheck.csproj --disable-build-servers -v minimal` requires Unity editor managed directory in this environment (`UnityEditorManagedDir`).

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- No credentials, tokens, or secret handling changes.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.

### /init guidance
- Bridge protocol was bumped to `v6`. Please re-run `/init` in target projects to refresh embedded bridge payload before using these changes.
