### PR TITLE
Finalize 0.12.1 and refine fuzzy/intellisense UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.12.1 - 2026-03-11
+
+### Changed
+- Officialized `0.12.1` by closing the development cycle suffix.
+- Updated composer IntelliSense Enter behavior to execute immediately when input already matches a catalog command trigger.
+- Improved hierarchy fuzzy flow by enabling live fuzzy preview suggestions during `f`/`ff` input and ensuring command execution is not blocked by prompt suggestions.
+- Added leaf-focused fuzzy suggestion styling across hierarchy/project/inspector results so parent path context is dimmed and the deepest segment is emphasized.
+
 ## 0.12.0 - 2026-03-10
 
 ### Changed

--- a/src/unifocl/Program.cs
+++ b/src/unifocl/Program.cs
@@ -592,7 +592,6 @@ static string? ReadInteractiveInput(
     var input = new StringBuilder();
     var selectedIntellisenseCandidateIndex = 0;
     var intellisenseDismissed = false;
-    var intellisenseSelectionArmed = false;
     var renderedLines = RenderComposerFrame(
         input.ToString(),
         commands,
@@ -620,17 +619,23 @@ static string? ReadInteractiveInput(
         switch (key.Key)
         {
             case ConsoleKey.Enter:
-                if ((intellisenseSelectionArmed
-                     || ShouldCommitSuggestionOnEnter(input.ToString(), session, candidates))
-                    && candidates.Count > 0
+                if (IsCatalogCommandInput(input.ToString(), commands, projectCommands, inspectorCommands, session))
+                {
+                    Console.WriteLine();
+                    return input.ToString();
+                }
+
+                if (candidates.Count > 0
                     && selectedIntellisenseCandidateIndex >= 0
                     && selectedIntellisenseCandidateIndex < candidates.Count
                     && !string.IsNullOrWhiteSpace(candidates[selectedIntellisenseCandidateIndex].CommitCommand))
                 {
+                    var currentInput = input.ToString();
+                    var acceptedCommand = candidates[selectedIntellisenseCandidateIndex].CommitCommand!;
                     input.Clear();
-                    input.Append(candidates[selectedIntellisenseCandidateIndex].CommitCommand!);
-                    intellisenseDismissed = false;
-                    intellisenseSelectionArmed = false;
+                    input.Append(MergeAcceptedSuggestion(currentInput, acceptedCommand));
+                    // Accepting a suggestion exits IntelliSense so next Enter executes.
+                    intellisenseDismissed = true;
                     break;
                 }
 
@@ -643,7 +648,6 @@ static string? ReadInteractiveInput(
                 }
 
                 intellisenseDismissed = false;
-                intellisenseSelectionArmed = false;
                 break;
             case ConsoleKey.Escape:
                 if (!intellisenseDismissed && allCandidates.Count > 0)
@@ -657,7 +661,6 @@ static string? ReadInteractiveInput(
                 }
 
                 selectedIntellisenseCandidateIndex = 0;
-                intellisenseSelectionArmed = false;
                 break;
             case ConsoleKey.UpArrow:
                 if (intellisenseDismissed && allCandidates.Count > 0)
@@ -671,7 +674,6 @@ static string? ReadInteractiveInput(
                     selectedIntellisenseCandidateIndex = selectedIntellisenseCandidateIndex <= 0
                         ? candidates.Count - 1
                         : selectedIntellisenseCandidateIndex - 1;
-                    intellisenseSelectionArmed = true;
                 }
                 break;
             case ConsoleKey.DownArrow:
@@ -686,7 +688,6 @@ static string? ReadInteractiveInput(
                     selectedIntellisenseCandidateIndex = selectedIntellisenseCandidateIndex >= candidates.Count - 1
                         ? 0
                         : selectedIntellisenseCandidateIndex + 1;
-                    intellisenseSelectionArmed = true;
                 }
                 break;
             case ConsoleKey.F7:
@@ -719,7 +720,6 @@ static string? ReadInteractiveInput(
                 {
                     input.Append(key.KeyChar);
                     intellisenseDismissed = false;
-                    intellisenseSelectionArmed = false;
                 }
                 break;
         }
@@ -734,76 +734,6 @@ static string? ReadInteractiveInput(
             selectedIntellisenseCandidateIndex,
             intellisenseDismissed);
     }
-}
-
-static bool ShouldCommitSuggestionOnEnter(
-    string input,
-    CliSessionState session,
-    IReadOnlyList<(string Label, string? CommitCommand)> candidates)
-{
-    if (candidates.Count == 0)
-    {
-        return false;
-    }
-
-    return IsMkTypeSelectionPhase(input, session)
-        || IsInspectorComponentAddSelectionPhase(input, session);
-}
-
-static bool IsMkTypeSelectionPhase(string input, CliSessionState session)
-{
-    if (session.Inspector is not null
-        || session.Mode != CliMode.Project
-        || string.IsNullOrWhiteSpace(session.CurrentProjectPath))
-    {
-        return false;
-    }
-
-    var tokens = TokenizeComposerInput(input.TrimStart());
-    if (tokens.Count == 0)
-    {
-        return false;
-    }
-
-    if (tokens[0].Equals("mk", StringComparison.OrdinalIgnoreCase))
-    {
-        return tokens.Count <= 1;
-    }
-
-    if (tokens[0].Equals("make", StringComparison.OrdinalIgnoreCase))
-    {
-        return !HasConcreteMakeType(tokens);
-    }
-
-    return false;
-}
-
-static bool IsInspectorComponentAddSelectionPhase(string input, CliSessionState session)
-{
-    var context = session.Inspector;
-    if (context is null || context.Depth != InspectorDepth.ComponentList)
-    {
-        return false;
-    }
-
-    var tokens = TokenizeComposerInput(input.TrimStart());
-    if (tokens.Count == 0)
-    {
-        return false;
-    }
-
-    var command = tokens[0].ToLowerInvariant();
-    if (command is not ("component" or "comp"))
-    {
-        return false;
-    }
-
-    if (tokens.Count == 1)
-    {
-        return true;
-    }
-
-    return tokens[1].Equals("add", StringComparison.OrdinalIgnoreCase);
 }
 
 static int RenderComposerFrame(
@@ -1581,6 +1511,133 @@ static List<string> TokenizeComposerInput(string input)
     return tokens;
 }
 
+static string MergeAcceptedSuggestion(string currentInput, string acceptedCommand)
+{
+    if (string.IsNullOrWhiteSpace(acceptedCommand))
+    {
+        return currentInput;
+    }
+
+    var trimmedCurrent = currentInput.TrimStart();
+    if (string.IsNullOrWhiteSpace(trimmedCurrent))
+    {
+        return acceptedCommand;
+    }
+
+    var tokenCount = CountTokens(acceptedCommand);
+    if (tokenCount <= 0)
+    {
+        return acceptedCommand;
+    }
+
+    var remainder = SliceAfterTokenCount(trimmedCurrent, tokenCount);
+    if (string.IsNullOrEmpty(remainder))
+    {
+        return acceptedCommand;
+    }
+
+    if (acceptedCommand.EndsWith(' '))
+    {
+        return acceptedCommand + remainder.TrimStart();
+    }
+
+    if (char.IsWhiteSpace(remainder[0]))
+    {
+        return acceptedCommand + remainder;
+    }
+
+    return $"{acceptedCommand} {remainder}";
+}
+
+static int CountTokens(string input)
+{
+    var count = 0;
+    var inQuotes = false;
+    var inToken = false;
+    foreach (var ch in input)
+    {
+        if (ch == '"')
+        {
+            inQuotes = !inQuotes;
+            continue;
+        }
+
+        if (!inQuotes && char.IsWhiteSpace(ch))
+        {
+            if (inToken)
+            {
+                count++;
+                inToken = false;
+            }
+
+            continue;
+        }
+
+        inToken = true;
+    }
+
+    if (inToken)
+    {
+        count++;
+    }
+
+    return count;
+}
+
+static string SliceAfterTokenCount(string input, int tokenCount)
+{
+    if (tokenCount <= 0)
+    {
+        return input;
+    }
+
+    var i = 0;
+    var consumed = 0;
+    var inQuotes = false;
+    var inToken = false;
+    while (i < input.Length)
+    {
+        var ch = input[i];
+        if (ch == '"')
+        {
+            inQuotes = !inQuotes;
+            if (!inToken)
+            {
+                inToken = true;
+            }
+
+            i++;
+            continue;
+        }
+
+        if (!inQuotes && char.IsWhiteSpace(ch))
+        {
+            if (inToken)
+            {
+                consumed++;
+                inToken = false;
+                if (consumed == tokenCount)
+                {
+                    return input[i..];
+                }
+            }
+
+            i++;
+            continue;
+        }
+
+        inToken = true;
+        i++;
+    }
+
+    if (inToken)
+    {
+        consumed++;
+    }
+
+    return consumed >= tokenCount ? string.Empty : input;
+}
+
 static bool TryGetUpmComposerCandidates(
     string input,
     CliSessionState session,
@@ -1709,6 +1766,33 @@ static bool TryGetUpmComposerCandidates(
     return true;
 }
 
+static bool IsCatalogCommandInput(
+    string input,
+    List<CommandSpec> commands,
+    List<CommandSpec> projectCommands,
+    List<CommandSpec> inspectorCommands,
+    CliSessionState session)
+{
+    var trimmed = input.Trim();
+    if (string.IsNullOrWhiteSpace(trimmed))
+    {
+        return false;
+    }
+
+    var tokens = TokenizeComposerInput(trimmed);
+    if (tokens.Count == 0)
+    {
+        return false;
+    }
+
+    var head = tokens[0];
+    IEnumerable<CommandSpec> catalog = head.StartsWith('/')
+        ? commands
+        : (session.Inspector is not null ? inspectorCommands : projectCommands);
+
+    return catalog.Any(command => command.Trigger.Equals(head, StringComparison.OrdinalIgnoreCase));
+}
+
 static IEnumerable<string> GetSuggestionLines(
     string query,
     List<CommandSpec> commands,
@@ -1798,6 +1882,7 @@ static bool TryGetFuzzyQueryIntellisenseLines(string input, CliSessionState sess
     }
 
     var selected = Math.Clamp(selectedFuzzyCandidateIndex, 0, candidates.Count - 1);
+    var inspectorMode = session.Inspector is not null;
     for (var i = 0; i < candidates.Count && i < 10; i++)
     {
         var candidate = candidates[i];
@@ -1805,10 +1890,12 @@ static bool TryGetFuzzyQueryIntellisenseLines(string input, CliSessionState sess
         var prefix = selectedLine
             ? $"[{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]>[/]"
             : "[grey] [/]";
-        var escapedPath = Markup.Escape(candidate.Path);
+        var formattedPath = inspectorMode
+            ? FormatInspectorFuzzyCandidateLabel(candidate.Path, selectedLine)
+            : FormatProjectFuzzyCandidateLabel(candidate.Path, selectedLine);
         lines.Add(selectedLine
-            ? $"{prefix} [{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{i}[/] [{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{escapedPath}[/]"
-            : $"{prefix} [deepskyblue1]{i}[/] {escapedPath}");
+            ? $"{prefix} [{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{i}[/] {formattedPath}"
+            : $"{prefix} [deepskyblue1]{i}[/] {formattedPath}");
     }
 
     return true;
@@ -1871,6 +1958,45 @@ static bool TryParseFuzzyQueryInput(string input, out string query)
 
     query = firstSpace < 0 ? string.Empty : trimmed[(firstSpace + 1)..].Trim();
     return true;
+}
+
+static string FormatInspectorFuzzyCandidateLabel(string path, bool selectedLine)
+{
+    var lastDot = path.LastIndexOf('.');
+    var lastSlash = path.LastIndexOf('/');
+    var separatorIndex = Math.Max(lastDot, lastSlash);
+    if (separatorIndex < 0 || separatorIndex >= path.Length - 1)
+    {
+        var escaped = Markup.Escape(path);
+        return selectedLine
+            ? $"[{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{escaped}[/]"
+            : $"[white]{escaped}[/]";
+    }
+
+    var context = Markup.Escape(path[..(separatorIndex + 1)]);
+    var leaf = Markup.Escape(path[(separatorIndex + 1)..]);
+    return selectedLine
+        ? $"[grey58]{context}[/][bold {CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{leaf}[/]"
+        : $"[grey58]{context}[/][bold white]{leaf}[/]";
+}
+
+static string FormatProjectFuzzyCandidateLabel(string path, bool selectedLine)
+{
+    var normalizedPath = path.Replace('\\', '/');
+    var separatorIndex = normalizedPath.LastIndexOf('/');
+    if (separatorIndex < 0 || separatorIndex >= normalizedPath.Length - 1)
+    {
+        var escaped = Markup.Escape(path);
+        return selectedLine
+            ? $"[bold {CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{escaped}[/]"
+            : $"[bold white]{escaped}[/]";
+    }
+
+    var context = Markup.Escape(normalizedPath[..(separatorIndex + 1)]);
+    var leaf = Markup.Escape(normalizedPath[(separatorIndex + 1)..]);
+    return selectedLine
+        ? $"[grey58]{context}[/][bold {CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{leaf}[/]"
+        : $"[grey58]{context}[/][bold white]{leaf}[/]";
 }
 
 static List<(string Path, string? CommitCommand)> GetProjectFuzzyCandidates(ProjectViewState state, string query)

--- a/src/unifocl/Services/CliVersion.cs
+++ b/src/unifocl/Services/CliVersion.cs
@@ -2,7 +2,7 @@ internal static class CliVersion
 {
     public const int Major = 0;
     public const int Minor = 12;
-    public const int Patch = 0;
+    public const int Patch = 1;
     public const string DevCycle = "";
     public const string Protocol = "v6";
 

--- a/src/unifocl/Services/HierarchyTui.cs
+++ b/src/unifocl/Services/HierarchyTui.cs
@@ -154,7 +154,7 @@ internal sealed class HierarchyTui
                 continue;
             }
 
-            var input = ReadPromptInputWithIntellisenseFromFirstKey(cwdPath, firstKey);
+            var input = ReadPromptInputWithIntellisenseFromFirstKey(cwdPath, firstKey, snapshot, cwdId);
 
             if (string.IsNullOrWhiteSpace(input))
             {
@@ -421,9 +421,11 @@ internal sealed class HierarchyTui
             return true;
         }
 
-        if (tokens.Count >= 2 && tokens[0].Equals("f", StringComparison.OrdinalIgnoreCase))
+        if (tokens.Count >= 1 && tokens[0].Equals("f", StringComparison.OrdinalIgnoreCase))
         {
-            var query = string.Join(' ', tokens.Skip(1));
+            var query = tokens.Count >= 2
+                ? string.Join(' ', tokens.Skip(1))
+                : string.Empty;
             var response = await _daemonClient.SearchAsync(port, new HierarchySearchRequestDto(query, 20, cwdId));
             if (response?.Ok != true)
             {
@@ -1013,7 +1015,11 @@ internal sealed class HierarchyTui
         return null;
     }
 
-    private static string ReadPromptInputWithIntellisenseFromFirstKey(string cwdPath, ConsoleKeyInfo firstKey)
+    private static string ReadPromptInputWithIntellisenseFromFirstKey(
+        string cwdPath,
+        ConsoleKeyInfo firstKey,
+        HierarchySnapshotDto snapshot,
+        int cwdId)
     {
         var input = new StringBuilder();
         if (firstKey.Key == ConsoleKey.Enter)
@@ -1036,12 +1042,11 @@ internal sealed class HierarchyTui
 
         var selectedIndex = 0;
         var dismissed = false;
-        var selectionArmed = false;
-        var renderedLines = RenderPromptIntellisense(cwdPath, input.ToString(), selectedIndex, dismissed);
+        var renderedLines = RenderPromptIntellisense(cwdPath, input.ToString(), selectedIndex, dismissed, snapshot, cwdId);
 
         while (true)
         {
-            var allCandidates = GetHierarchyIntellisenseCandidates(input.ToString());
+            var allCandidates = GetHierarchyIntellisenseCandidates(input.ToString(), snapshot, cwdId);
             var candidates = dismissed ? [] : allCandidates;
             if (candidates.Count == 0)
             {
@@ -1055,16 +1060,23 @@ internal sealed class HierarchyTui
             var key = Console.ReadKey(intercept: true);
             if (key.Key == ConsoleKey.Enter)
             {
-                if (selectionArmed
-                    && candidates.Count > 0
+                if (IsHierarchyCatalogCommandInput(input.ToString()))
+                {
+                    ClearPromptFrame(renderedLines);
+                    Console.WriteLine($"UnityCLI:{cwdPath} > {input}");
+                    return input.ToString().Trim();
+                }
+
+                if (candidates.Count > 0
                     && selectedIndex >= 0
                     && selectedIndex < candidates.Count
                     && !string.IsNullOrWhiteSpace(candidates[selectedIndex].CommitCommand))
                 {
+                    var currentInput = input.ToString();
                     input.Clear();
-                    input.Append(candidates[selectedIndex].CommitCommand);
-                    dismissed = false;
-                    selectionArmed = false;
+                    input.Append(MergeAcceptedSuggestion(currentInput, candidates[selectedIndex].CommitCommand));
+                    // Accepting a suggestion exits IntelliSense so next Enter executes.
+                    dismissed = true;
                 }
                 else
                 {
@@ -1081,7 +1093,6 @@ internal sealed class HierarchyTui
                 }
 
                 dismissed = false;
-                selectionArmed = false;
             }
             else if (key.Key == ConsoleKey.Escape)
             {
@@ -1096,7 +1107,6 @@ internal sealed class HierarchyTui
                 }
 
                 selectedIndex = 0;
-                selectionArmed = false;
             }
             else if (key.Key == ConsoleKey.UpArrow)
             {
@@ -1109,7 +1119,6 @@ internal sealed class HierarchyTui
                 if (candidates.Count > 0)
                 {
                     selectedIndex = selectedIndex <= 0 ? candidates.Count - 1 : selectedIndex - 1;
-                    selectionArmed = true;
                 }
             }
             else if (key.Key == ConsoleKey.DownArrow)
@@ -1123,17 +1132,15 @@ internal sealed class HierarchyTui
                 if (candidates.Count > 0)
                 {
                     selectedIndex = selectedIndex >= candidates.Count - 1 ? 0 : selectedIndex + 1;
-                    selectionArmed = true;
                 }
             }
             else if (TryAppendInputCharacter(key, input))
             {
                 dismissed = false;
-                selectionArmed = false;
             }
 
             ClearPromptFrame(renderedLines);
-            renderedLines = RenderPromptIntellisense(cwdPath, input.ToString(), selectedIndex, dismissed);
+            renderedLines = RenderPromptIntellisense(cwdPath, input.ToString(), selectedIndex, dismissed, snapshot, cwdId);
         }
     }
 
@@ -1152,7 +1159,9 @@ internal sealed class HierarchyTui
         string cwdPath,
         string input,
         int selectedSuggestionIndex,
-        bool suppressIntellisense)
+        bool suppressIntellisense,
+        HierarchySnapshotDto snapshot,
+        int cwdId)
     {
         var lines = new List<string>
         {
@@ -1165,29 +1174,48 @@ internal sealed class HierarchyTui
         }
         else
         {
-            var matches = GetHierarchySuggestionMatches(input);
-            lines.Add("[grey]intellisense[/]: hierarchy commands [dim](up/down + enter to insert)[/]");
-            if (matches.Count == 0)
+            var candidates = GetHierarchyIntellisenseCandidates(input, snapshot, cwdId);
+            var isFuzzyPreview = TryParseFuzzyQuery(input, out _);
+            lines.Add(isFuzzyPreview
+                ? "[grey]fuzzy[/]: hierarchy path suggestions [dim](up/down to browse, Enter to execute current input)[/]"
+                : "[grey]intellisense[/]: hierarchy commands [dim](up/down + enter to insert)[/]");
+            if (candidates.Count == 0)
             {
-                lines.Add(string.IsNullOrWhiteSpace(input)
-                    ? "[dim]no commands available[/]"
-                    : $"[dim]no matches for {Markup.Escape(input)}[/]");
+                lines.Add(isFuzzyPreview
+                    ? "[dim]no fuzzy matches[/]"
+                    : (string.IsNullOrWhiteSpace(input)
+                        ? "[dim]no commands available[/]"
+                        : $"[dim]no matches for {Markup.Escape(input)}[/]"));
             }
             else
             {
-                var selected = Math.Clamp(selectedSuggestionIndex, 0, matches.Count - 1);
-                for (var i = 0; i < matches.Count; i++)
+                var selected = Math.Clamp(selectedSuggestionIndex, 0, candidates.Count - 1);
+                const int maxVisible = 12;
+                var visibleCount = Math.Min(maxVisible, candidates.Count);
+                var windowStart = Math.Clamp(selected - (visibleCount / 2), 0, Math.Max(0, candidates.Count - visibleCount));
+                var windowEnd = windowStart + visibleCount;
+                for (var i = windowStart; i < windowEnd; i++)
                 {
-                    var match = matches[i];
+                    var candidate = candidates[i];
                     var isSelected = i == selected;
                     var prefix = isSelected
                         ? $"[{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]>[/]"
                         : "[grey] [/]";
-                    var signature = Markup.Escape(match.Signature);
-                    var description = Markup.Escape(match.Description);
+                    var label = isFuzzyPreview
+                        ? FormatHierarchyFuzzyCandidateLabel(candidate.Label, isSelected)
+                        : Markup.Escape(candidate.Label);
                     lines.Add(isSelected
-                        ? $"{prefix} [{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{signature}[/] [dim]- {description}[/]"
-                        : $"{prefix} [grey]{signature}[/] [dim]- {description}[/]");
+                        ? (isFuzzyPreview
+                            ? $"{prefix} {label}"
+                            : $"{prefix} [{CliTheme.CursorForeground} on {CliTheme.CursorBackground}]{label}[/]")
+                        : (isFuzzyPreview
+                            ? $"{prefix} {label}"
+                            : $"{prefix} [grey]{label}[/]"));
+                }
+
+                if (candidates.Count > visibleCount)
+                {
+                    lines.Add($"[dim]showing {windowStart + 1}-{windowEnd}/{candidates.Count}[/]");
                 }
             }
         }
@@ -1198,6 +1226,151 @@ internal sealed class HierarchyTui
         }
 
         return lines.Count;
+    }
+
+    private static bool IsHierarchyCatalogCommandInput(string input)
+    {
+        var trimmed = input.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            return false;
+        }
+
+        var head = trimmed.Split(' ', '\t', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(head))
+        {
+            return false;
+        }
+
+        return HierarchyCommands.Any(command => command.Trigger.Equals(head, StringComparison.OrdinalIgnoreCase))
+            || MkTypeCommands.Any(command => command.Trigger.Equals(head, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string MergeAcceptedSuggestion(string currentInput, string acceptedCommand)
+    {
+        if (string.IsNullOrWhiteSpace(acceptedCommand))
+        {
+            return currentInput;
+        }
+
+        var trimmedCurrent = currentInput.TrimStart();
+        if (string.IsNullOrWhiteSpace(trimmedCurrent))
+        {
+            return acceptedCommand;
+        }
+
+        var tokenCount = CountTokens(acceptedCommand);
+        if (tokenCount <= 0)
+        {
+            return acceptedCommand;
+        }
+
+        var remainder = SliceAfterTokenCount(trimmedCurrent, tokenCount);
+        if (string.IsNullOrEmpty(remainder))
+        {
+            return acceptedCommand;
+        }
+
+        if (acceptedCommand.EndsWith(' '))
+        {
+            return acceptedCommand + remainder.TrimStart();
+        }
+
+        if (char.IsWhiteSpace(remainder[0]))
+        {
+            return acceptedCommand + remainder;
+        }
+
+        return $"{acceptedCommand} {remainder}";
+    }
+
+    private static int CountTokens(string input)
+    {
+        var count = 0;
+        var inQuotes = false;
+        var inToken = false;
+        foreach (var ch in input)
+        {
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (!inQuotes && char.IsWhiteSpace(ch))
+            {
+                if (inToken)
+                {
+                    count++;
+                    inToken = false;
+                }
+
+                continue;
+            }
+
+            inToken = true;
+        }
+
+        if (inToken)
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static string SliceAfterTokenCount(string input, int tokenCount)
+    {
+        if (tokenCount <= 0)
+        {
+            return input;
+        }
+
+        var i = 0;
+        var consumed = 0;
+        var inQuotes = false;
+        var inToken = false;
+        while (i < input.Length)
+        {
+            var ch = input[i];
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                if (!inToken)
+                {
+                    inToken = true;
+                }
+
+                i++;
+                continue;
+            }
+
+            if (!inQuotes && char.IsWhiteSpace(ch))
+            {
+                if (inToken)
+                {
+                    consumed++;
+                    inToken = false;
+                    if (consumed == tokenCount)
+                    {
+                        return input[i..];
+                    }
+                }
+
+                i++;
+                continue;
+            }
+
+            inToken = true;
+            i++;
+        }
+
+        if (inToken)
+        {
+            consumed++;
+        }
+
+        return consumed >= tokenCount ? string.Empty : input;
     }
 
     private static void ClearPromptFrame(int renderedLines)
@@ -1225,14 +1398,121 @@ internal sealed class HierarchyTui
                 || normalized.StartsWith(command.Trigger, StringComparison.OrdinalIgnoreCase));
         }
 
-        return source.Take(12).ToList();
+        return source.ToList();
     }
 
-    private static List<(string Label, string CommitCommand)> GetHierarchyIntellisenseCandidates(string query)
+    private static List<(string Label, string CommitCommand)> GetHierarchyIntellisenseCandidates(string query, HierarchySnapshotDto snapshot, int cwdId)
     {
+        if (TryParseFuzzyQuery(query, out var fuzzyQuery))
+        {
+            return GetHierarchyFuzzyPreviewCandidates(snapshot, cwdId, fuzzyQuery);
+        }
+
         return GetHierarchySuggestionMatches(query)
             .Select(match => (match.Signature, string.IsNullOrWhiteSpace(match.Trigger) ? match.Signature : match.Trigger))
             .ToList();
+    }
+
+    private static bool TryParseFuzzyQuery(string input, out string query)
+    {
+        query = string.Empty;
+        var trimmed = input.TrimStart();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            return false;
+        }
+
+        if (trimmed.Equals("f", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("ff", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (trimmed.StartsWith("f ", StringComparison.OrdinalIgnoreCase))
+        {
+            query = trimmed[2..].Trim();
+            return true;
+        }
+
+        if (trimmed.StartsWith("ff ", StringComparison.OrdinalIgnoreCase))
+        {
+            query = trimmed[3..].Trim();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static List<(string Label, string CommitCommand)> GetHierarchyFuzzyPreviewCandidates(
+        HierarchySnapshotDto snapshot,
+        int cwdId,
+        string query)
+    {
+        var cwdNode = FindNode(snapshot.Root, cwdId) ?? snapshot.Root;
+        var seedPath = BuildPath(snapshot.Root, cwdNode.Id);
+        var paths = new List<string>();
+        CollectHierarchyPaths(cwdNode, seedPath, paths);
+
+        IEnumerable<(string Path, double Score)> ranked;
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            ranked = paths.Select(path => (path, 1d));
+        }
+        else
+        {
+            var scored = new List<(string Path, double Score)>();
+            foreach (var path in paths)
+            {
+                if (path.Contains(query, StringComparison.OrdinalIgnoreCase))
+                {
+                    scored.Add((path, 0.9d));
+                    continue;
+                }
+
+                if (FuzzyMatcher.TryScore(query, path, out var score))
+                {
+                    scored.Add((path, score));
+                }
+            }
+
+            ranked = scored;
+        }
+
+        return ranked
+            .OrderByDescending(entry => entry.Score)
+            .ThenBy(entry => entry.Path, StringComparer.OrdinalIgnoreCase)
+            .Take(30)
+            .Select(entry => (entry.Path, $"f {entry.Path}"))
+            .ToList();
+    }
+
+    private static void CollectHierarchyPaths(HierarchyNodeDto node, string currentPath, List<string> output)
+    {
+        foreach (var child in node.Children)
+        {
+            var childPath = $"{currentPath}/{child.Name}";
+            output.Add(childPath);
+            CollectHierarchyPaths(child, childPath, output);
+        }
+    }
+
+    private static string FormatHierarchyFuzzyCandidateLabel(string path, bool selectedLine)
+    {
+        var normalizedPath = path.Replace('\\', '/');
+        var separatorIndex = normalizedPath.LastIndexOf('/');
+        if (separatorIndex < 0 || separatorIndex >= normalizedPath.Length - 1)
+        {
+            var escaped = Markup.Escape(path);
+            return selectedLine
+                ? $"[bold white]{escaped}[/]"
+                : $"[white]{escaped}[/]";
+        }
+
+        var context = Markup.Escape(normalizedPath[..(separatorIndex + 1)]);
+        var leaf = Markup.Escape(normalizedPath[(separatorIndex + 1)..]);
+        return selectedLine
+            ? $"[grey58]{context}[/][bold white]{leaf}[/]"
+            : $"[grey58]{context}[/][bold deepskyblue1]{leaf}[/]";
     }
 
     private static bool TryParseMakeArguments(


### PR DESCRIPTION
## Summary
- What does this PR change?
  - Finalizes release version metadata to `0.12.1` (closed dev-cycle suffix) and updates changelog.
  - Refines IntelliSense/fuzzy behavior in composer and hierarchy flows.
  - Adds leaf-focused fuzzy result styling so nested context is dimmed and the deepest segment stands out (hierarchy/project/inspector).
- Why is this change needed?
  - Aligns release state for merge-time policy.
  - Fixes usability friction where Enter handling and hierarchy fuzzy interactions were inconsistent.
  - Improves scanability of deep paths in fuzzy suggestions.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [x] Chore

## Scope
- Affected areas/components:
  - `src/unifocl/Program.cs`
  - `src/unifocl/Services/HierarchyTui.cs`
  - `src/unifocl/Services/CliVersion.cs`
  - `CHANGELOG.md`
- Out-of-scope / intentionally not addressed:
  - Bridge protocol changes beyond existing `v6` baseline on `main`.
  - New automated tests for these interaction paths.

## How to Test
1. Build CLI: `dotnet build src/unifocl/unifocl.csproj -v minimal`.
2. Run CLI and verify composer behavior:
   - When input already matches a catalog command trigger, press Enter once and confirm command executes.
3. Enter hierarchy mode and verify fuzzy/intellisense behavior:
   - Type `f`/`ff` and confirm live fuzzy suggestions appear.
   - Use Up/Down to browse suggestion window; confirm scrolling updates.
   - Confirm path styling shows dim parent context + emphasized leaf segment.

Expected results:
- Build succeeds.
- Enter behavior is single-press for valid commands.
- Hierarchy fuzzy preview appears and is navigable.
- Fuzzy results across hierarchy/project/inspector emphasize deepest segment.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Changes are limited to local CLI input/rendering behavior and version/changelog metadata.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [ ] I have added/updated tests where applicable.
- [ ] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.
