### PR TITLE
feat: detect missing .gitignore entries on /open and /init

### DIFF
--- a/changelog.d/fix-lock-file-runtime-identifiers.md
+++ b/changelog.d/fix-lock-file-runtime-identifiers.md
@@ -1,0 +1,13 @@
+---
+bump: minor
+---
+
+### Added
+- `/open` and `/init` now detect missing unifocl `.gitignore` entries (`.unifocl/`, `.unifocl-runtime/`) in the Unity project.
+  - Interactive sessions prompt the user once and remember the answer.
+  - Agentic/MCP sessions receive a structured hint advising them to ask the user for consent before adding entries.
+- New config key `setup.gitignore` (values: `auto` | `off` | `prompt`):
+  - `auto` — silently add missing entries on every open/init.
+  - `off` — never check.
+  - `prompt` (default) — ask once interactively, then remember the answer.
+  - Managed via `/config get|set|reset setup.gitignore`.

--- a/full-documentation.md
+++ b/full-documentation.md
@@ -168,7 +168,7 @@ Choose between two engines:
 - **`blip`** (default) — open-ended natural language captions
 - **`clip`** — zero-shot classification against game-asset labels (sprite, mesh, UI, material, etc.)
 
-**Dependencies:** Requires `python3` (>= 3.10) and [`uv`](https://docs.astral.sh/uv/) — run `unifocl init` to install them automatically. The Python script pulls [`transformers`](https://pypi.org/project/transformers/), [`torch`](https://pypi.org/project/torch/) (CPU), and [`Pillow`](https://pypi.org/project/Pillow/) via `uv run --script` (auto-cached, no manual pip install needed). The first invocation also downloads the model weights (~990 MB for BLIP, ~600 MB for CLIP) from HuggingFace; subsequent runs load entirely from cache with no network access. Model revisions are pinned to exact commit SHAs for supply-chain safety.
+**Dependencies:** Requires `python3` (>= 3.10) and [`uv`](https://docs.astral.sh/uv/) — run `unifocl init` to install them automatically. Runtime installs are driven by a hash-locked requirements file (`uv run --with-requirements`) pinned to [`transformers==5.5.0`](https://pypi.org/project/transformers/5.5.0/), [`torch==2.11.0`](https://pypi.org/project/torch/2.11.0/) (CPU-compatible wheel selection by platform), and [`Pillow==12.2.0`](https://pypi.org/project/Pillow/12.2.0/). The first invocation also downloads the model weights (~990 MB for BLIP, ~600 MB for CLIP) from HuggingFace; subsequent runs load entirely from cache with no network access. Model revisions are pinned to exact commit SHAs for supply-chain safety.
 
 See the [Command Reference — Asset Describe](docs/command-reference.md#6-asset-describe-local-vision) for full details.
 
@@ -1172,6 +1172,7 @@ The `asset.describe` command lets agents "see" Unity assets without burning toke
 **Prerequisites:**
 
 - `python3` (>= 3.10) and `uv` — run `unifocl init` to install if missing
+- Script dependencies are hash-locked via requirements (`uv run --with-requirements`): `transformers==5.5.0`, `torch==2.11.0`, `Pillow==12.2.0`
 - First invocation downloads the model (~990 MB for BLIP, ~600 MB for CLIP); subsequent runs use the HuggingFace cache at `~/.cache/huggingface/`
 - Non-image assets (meshes, materials, prefabs) work if Unity can generate an `AssetPreview`; falls back to mini-thumbnail icon, then metadata-only
 

--- a/src/unifocl/Services/ProjectLifecycleService.Config.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.Config.cs
@@ -42,9 +42,11 @@ internal sealed partial class ProjectLifecycleService
             : "env (UNIFOCL_THEME)";
         var theme = ResolveEffectiveTheme(config);
         var staleDays = ResolveRecentPruneStaleDays(config);
+        var gitignore = ResolveGitignoreDisplayValue(config);
         log("[grey]config[/]: available settings");
         log($"[grey]config[/]: [white]theme[/] = [white]{theme}[/] [dim](dark|light, source: {source})[/]");
         log($"[grey]config[/]: [white]recent.staleDays[/] = [white]{staleDays}[/] [dim](days, default: {DefaultRecentPruneStaleDays})[/]");
+        log($"[grey]config[/]: [white]setup.gitignore[/] = [white]{gitignore}[/] [dim](auto|off|prompt, default: prompt)[/]");
         return Task.FromResult(true);
     }
 
@@ -52,15 +54,16 @@ internal sealed partial class ProjectLifecycleService
     {
         if (args.Count != 1)
         {
-            log("[red]error[/]: usage /config get <theme|recent.staleDays>");
+            log("[red]error[/]: usage /config get <theme|recent.staleDays|setup.gitignore>");
             return Task.FromResult(true);
         }
 
         var isThemeKey = IsThemeKey(args[0]);
         var isRecentStaleDaysKey = IsRecentStaleDaysKey(args[0]);
-        if (!isThemeKey && !isRecentStaleDaysKey)
+        var isGitignoreKey = IsGitignoreKey(args[0]);
+        if (!isThemeKey && !isRecentStaleDaysKey && !isGitignoreKey)
         {
-            log("[red]error[/]: supported keys are 'theme' and 'recent.staleDays'");
+            log("[red]error[/]: supported keys are 'theme', 'recent.staleDays', and 'setup.gitignore'");
             return Task.FromResult(true);
         }
 
@@ -78,6 +81,13 @@ internal sealed partial class ProjectLifecycleService
             return Task.FromResult(true);
         }
 
+        if (isGitignoreKey)
+        {
+            var gitignore = ResolveGitignoreDisplayValue(config);
+            log($"[grey]config[/]: [white]setup.gitignore[/] = [white]{gitignore}[/]");
+            return Task.FromResult(true);
+        }
+
         var staleDays = ResolveRecentPruneStaleDays(config);
         log($"[grey]config[/]: [white]recent.staleDays[/] = [white]{staleDays}[/]");
         return Task.FromResult(true);
@@ -87,7 +97,7 @@ internal sealed partial class ProjectLifecycleService
     {
         if (args.Count != 2)
         {
-            log("[red]error[/]: usage /config set <theme|recent.staleDays> <value>");
+            log("[red]error[/]: usage /config set <theme|recent.staleDays|setup.gitignore> <value>");
             return Task.FromResult(true);
         }
 
@@ -138,7 +148,27 @@ internal sealed partial class ProjectLifecycleService
             return Task.FromResult(true);
         }
 
-        log("[red]error[/]: supported keys are 'theme' and 'recent.staleDays'");
+        if (IsGitignoreKey(key))
+        {
+            if (!TryParseGitignoreValue(args[1], out var gitignoreValue))
+            {
+                log("[red]error[/]: setup.gitignore must be 'auto' or 'off'");
+                return Task.FromResult(true);
+            }
+
+            config.GitignoreAutoIgnore = gitignoreValue;
+            if (!TrySaveCliConfig(config, out var saveGitignoreError))
+            {
+                log($"[red]error[/]: {Markup.Escape(saveGitignoreError ?? "failed to write config")}");
+                return Task.FromResult(true);
+            }
+
+            var displayValue = gitignoreValue ? "auto" : "off";
+            log($"[green]config[/]: setup.gitignore set to [white]{displayValue}[/]");
+            return Task.FromResult(true);
+        }
+
+        log("[red]error[/]: supported keys are 'theme', 'recent.staleDays', and 'setup.gitignore'");
         return Task.FromResult(true);
     }
 
@@ -146,15 +176,16 @@ internal sealed partial class ProjectLifecycleService
     {
         if (args.Count > 1)
         {
-            log("[red]error[/]: usage /config reset <theme|recent.staleDays?>");
+            log("[red]error[/]: usage /config reset <theme|recent.staleDays|setup.gitignore?>");
             return Task.FromResult(true);
         }
 
         var resetTheme = args.Count == 0 || IsThemeKey(args[0]);
         var resetRecentStaleDays = args.Count == 0 || IsRecentStaleDaysKey(args[0]);
-        if (!resetTheme && !resetRecentStaleDays)
+        var resetGitignore = args.Count == 0 || IsGitignoreKey(args[0]);
+        if (!resetTheme && !resetRecentStaleDays && !resetGitignore)
         {
-            log("[red]error[/]: supported keys are 'theme' and 'recent.staleDays'");
+            log("[red]error[/]: supported keys are 'theme', 'recent.staleDays', and 'setup.gitignore'");
             return Task.FromResult(true);
         }
 
@@ -174,6 +205,11 @@ internal sealed partial class ProjectLifecycleService
             config.RecentPruneStaleDays = null;
         }
 
+        if (resetGitignore)
+        {
+            config.GitignoreAutoIgnore = null;
+        }
+
         if (!TrySaveCliConfig(config, out var saveError))
         {
             log($"[red]error[/]: {Markup.Escape(saveError ?? "failed to write config")}");
@@ -183,27 +219,17 @@ internal sealed partial class ProjectLifecycleService
         var effective = ResolveEffectiveTheme(config);
         CliTheme.TrySetTheme(effective);
 
-        if (resetTheme && resetRecentStaleDays)
-        {
-            log(
-                $"[green]config[/]: reset to defaults " +
-                $"([white]theme[/]={effective}, [white]recent.staleDays[/]={DefaultRecentPruneStaleDays})");
-            return Task.FromResult(true);
-        }
-
-        if (resetTheme)
-        {
-            log($"[green]config[/]: theme reset to default [white]{effective}[/]");
-            return Task.FromResult(true);
-        }
-
-        log($"[green]config[/]: recent.staleDays reset to default [white]{DefaultRecentPruneStaleDays}[/]");
+        var resetParts = new List<string>();
+        if (resetTheme) resetParts.Add($"theme={effective}");
+        if (resetRecentStaleDays) resetParts.Add($"recent.staleDays={DefaultRecentPruneStaleDays}");
+        if (resetGitignore) resetParts.Add("setup.gitignore=prompt");
+        log($"[green]config[/]: reset to defaults ({string.Join(", ", resetParts)})");
         return Task.FromResult(true);
     }
 
     private static bool LogConfigUsage(Action<string> log)
     {
-        log("[red]error[/]: usage /config <get|set|list|reset> <theme|recent.staleDays?> <value?>");
+        log("[red]error[/]: usage /config <get|set|list|reset> <theme|recent.staleDays|setup.gitignore?> <value?>");
         return true;
     }
 
@@ -259,6 +285,12 @@ internal sealed partial class ProjectLifecycleService
                 }
             }
 
+            if (document.RootElement.TryGetProperty("gitignoreAutoIgnore", out var gitignoreProp)
+                && gitignoreProp.ValueKind is JsonValueKind.True or JsonValueKind.False)
+            {
+                config.GitignoreAutoIgnore = gitignoreProp.GetBoolean();
+            }
+
             return true;
         }
         catch (Exception ex)
@@ -287,7 +319,8 @@ internal sealed partial class ProjectLifecycleService
                 {
                     ["theme"] = NormalizeTheme(config.Theme),
                     ["unityProjectPath"] = NormalizeProjectPath(config.UnityProjectPath),
-                    ["recentStaleDays"] = config.RecentPruneStaleDays
+                    ["recentStaleDays"] = config.RecentPruneStaleDays,
+                    ["gitignoreAutoIgnore"] = config.GitignoreAutoIgnore
                 },
                 new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(path, payload + Environment.NewLine);
@@ -333,6 +366,43 @@ internal sealed partial class ProjectLifecycleService
                || key.Equals("recent.stale-days", StringComparison.OrdinalIgnoreCase)
                || key.Equals("recent.prunedays", StringComparison.OrdinalIgnoreCase)
                || key.Equals("recent.prune-days", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsGitignoreKey(string key)
+    {
+        return key.Equals("setup.gitignore", StringComparison.OrdinalIgnoreCase)
+               || key.Equals("gitignore", StringComparison.OrdinalIgnoreCase)
+               || key.Equals("gitignore.auto", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Parses user input for <c>setup.gitignore</c>: "auto"/"true" → <c>true</c>, "off"/"false" → <c>false</c>.
+    /// Returns <c>false</c> if the value is not recognised.
+    /// </summary>
+    private static bool TryParseGitignoreValue(string raw, out bool result)
+    {
+        switch (raw.Trim().ToLowerInvariant())
+        {
+            case "auto" or "true":
+                result = true;
+                return true;
+            case "off" or "false":
+                result = false;
+                return true;
+            default:
+                result = false;
+                return false;
+        }
+    }
+
+    private static string ResolveGitignoreDisplayValue(CliConfig config)
+    {
+        return config.GitignoreAutoIgnore switch
+        {
+            true => "auto",
+            false => "off",
+            null => "prompt"
+        };
     }
 
     private static bool TryParseRecentPruneStaleDays(string raw, out int staleDays)

--- a/src/unifocl/Services/ProjectLifecycleService.Gitignore.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.Gitignore.cs
@@ -1,0 +1,154 @@
+using Spectre.Console;
+using System.Text;
+
+internal sealed partial class ProjectLifecycleService
+{
+    private static readonly string[] UnifoclGitignoreEntries = [".unifocl/", ".unifocl-runtime/"];
+    private const string UnifoclGitignoreComment = "# unifocl runtime and bridge state";
+
+    /// <summary>
+    /// Checks whether the Unity project's .gitignore covers the standard unifocl
+    /// directories (.unifocl/ and .unifocl-runtime/). When entries are missing the
+    /// behaviour is governed by the <c>setup.gitignore</c> config key:
+    /// <list type="bullet">
+    ///   <item><term>auto</term><description>Adds missing entries silently.</description></item>
+    ///   <item><term>off</term><description>Does nothing.</description></item>
+    ///   <item><term>not set (default)</term><description>
+    ///     Interactive sessions prompt the user once and save the answer.
+    ///     Agentic sessions emit a hint instead so the agent can request consent.
+    ///   </description></item>
+    /// </list>
+    /// </summary>
+    private static void CheckAndApplyGitignoreEntries(string projectPath, Action<string> log)
+    {
+        var missing = DetectMissingGitignoreEntries(projectPath);
+        if (missing.Count == 0)
+        {
+            return;
+        }
+
+        if (!TryLoadCliConfig(out var config, out _))
+        {
+            config = new CliConfig();
+        }
+
+        // Agentic / MCP mode: never prompt interactively — emit a structured hint.
+        if (CliRuntimeState.SuppressConsoleOutput)
+        {
+            if (config.GitignoreAutoIgnore != false)
+            {
+                var entriesList = string.Join(", ", missing);
+                log($"[grey]hint[/]: the project .gitignore is missing unifocl entries ({entriesList}). " +
+                    "Ask the user for consent before adding them. " +
+                    "Once the user agrees, either write the entries to .gitignore directly " +
+                    "or run [white]/config set setup.gitignore auto[/] so unifocl handles it on future opens.");
+            }
+
+            return;
+        }
+
+        // Explicit auto-add (user previously said yes, or /config set setup.gitignore auto).
+        if (config.GitignoreAutoIgnore == true)
+        {
+            ApplyGitignoreEntries(projectPath, missing, log);
+            return;
+        }
+
+        // Explicit opt-out (/config set setup.gitignore off).
+        if (config.GitignoreAutoIgnore == false)
+        {
+            return;
+        }
+
+        // Not configured yet: in a non-interactive context (piped stdin) skip without saving
+        // so the next interactive session still gets the prompt.
+        if (Console.IsInputRedirected)
+        {
+            log("[grey]gitignore[/]: non-interactive mode — skipped " +
+                "(run [white]/config set setup.gitignore auto[/] to enable auto-add)");
+            return;
+        }
+
+        // Interactive: prompt once, persist the answer.
+        log($"[yellow]gitignore[/]: the project [white].gitignore[/] is missing unifocl entries: " +
+            $"{string.Join(", ", missing)}");
+        var consent = AnsiConsole.Confirm("Add unifocl entries to .gitignore? (you won't be asked again)");
+        config.GitignoreAutoIgnore = consent;
+        TrySaveCliConfig(config, out _);
+
+        if (consent)
+        {
+            ApplyGitignoreEntries(projectPath, missing, log);
+        }
+        else
+        {
+            log("[grey]gitignore[/]: skipped — " +
+                "run [white]/config set setup.gitignore auto[/] to enable auto-add, " +
+                "or [white]/config reset setup.gitignore[/] to be asked again");
+        }
+    }
+
+    /// <summary>Returns the subset of <see cref="UnifoclGitignoreEntries"/> not present in the project's .gitignore.</summary>
+    private static IReadOnlyList<string> DetectMissingGitignoreEntries(string projectPath)
+    {
+        var gitignorePath = Path.Combine(projectPath, ".gitignore");
+        HashSet<string> presentPatterns;
+
+        if (File.Exists(gitignorePath))
+        {
+            var lines = File.ReadAllLines(gitignorePath);
+            presentPatterns = new HashSet<string>(
+                lines.Select(l => l.Trim()).Where(l => l.Length > 0 && !l.StartsWith('#')),
+                StringComparer.Ordinal);
+        }
+        else
+        {
+            presentPatterns = [];
+        }
+
+        return UnifoclGitignoreEntries.Where(e => !presentPatterns.Contains(e)).ToList();
+    }
+
+    /// <summary>Appends <paramref name="entries"/> to the project's .gitignore, creating it if absent.</summary>
+    private static void ApplyGitignoreEntries(
+        string projectPath,
+        IReadOnlyList<string> entries,
+        Action<string> log)
+    {
+        try
+        {
+            var gitignorePath = Path.Combine(projectPath, ".gitignore");
+            var existingContent = File.Exists(gitignorePath)
+                ? File.ReadAllText(gitignorePath)
+                : string.Empty;
+
+            var sb = new StringBuilder(existingContent);
+
+            // Ensure there is exactly one blank line before the appended block.
+            if (sb.Length > 0 && sb[^1] != '\n')
+            {
+                sb.AppendLine();
+            }
+
+            if (sb.Length > 0)
+            {
+                sb.AppendLine();
+            }
+
+            sb.AppendLine(UnifoclGitignoreComment);
+            foreach (var entry in entries)
+            {
+                sb.AppendLine(entry);
+            }
+
+            File.WriteAllText(gitignorePath, sb.ToString());
+            var noun = entries.Count == 1 ? "entry" : "entries";
+            log($"[green]gitignore[/]: added {entries.Count} {noun} to [white].gitignore[/]: " +
+                $"{string.Join(", ", entries)}");
+        }
+        catch (Exception ex)
+        {
+            log($"[yellow]gitignore[/]: could not update .gitignore ({Markup.Escape(ex.Message)})");
+        }
+    }
+}

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -478,6 +478,7 @@ internal sealed partial class ProjectLifecycleService
         }
 
         log($"[green]init[/]: ready at [white]{Markup.Escape(targetPath)}[/]");
+        CheckAndApplyGitignoreEntries(targetPath, log);
         return true;
     }
 
@@ -910,6 +911,7 @@ internal sealed partial class ProjectLifecycleService
         }
 
         log($"[green]open[/]: project mode active -> [white]{Markup.Escape(projectPath)}[/]");
+        CheckAndApplyGitignoreEntries(projectPath, log);
         _projectViewService.OpenInitialView(session);
         _ = _projectViewService.SyncMkTypeCacheAsync(session);
         _ = _projectViewService.SyncComponentTypeCacheAsync(session);
@@ -1667,6 +1669,12 @@ internal sealed partial class ProjectLifecycleService
         public string? Theme { get; set; }
         public string? UnityProjectPath { get; set; }
         public int? RecentPruneStaleDays { get; set; }
+        /// <summary>
+        /// <c>true</c> = auto-add missing gitignore entries on open/init;
+        /// <c>false</c> = never check; <c>null</c> = prompt once (default).
+        /// Managed via /config set setup.gitignore auto|off.
+        /// </summary>
+        public bool? GitignoreAutoIgnore { get; set; }
     }
 
     private sealed record PlatformUpdateSpec(


### PR DESCRIPTION
## Summary
- On `/open` and `/init`, unifocl now checks whether the Unity project's `.gitignore` covers `.unifocl/` and `.unifocl-runtime/`.
- Interactive sessions prompt the user **once** and persist their answer globally — they are never asked again.
- Agentic/MCP sessions receive a structured `[hint]` in the command output so the agent can request user consent before writing any entries.
- New `setup.gitignore` config key (`auto` | `off` | `prompt`) lets users configure the behaviour explicitly via `/config get|set|reset setup.gitignore`.

## Related Issues
- Closes #
- Related to #

## Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] CI/Build
- [ ] Chore

## Scope
- Affected areas/components: `ProjectLifecycleService` (`/open`, `/init`, `/config`), `~/.unifocl/config.json` schema
- Out-of-scope / intentionally not addressed: per-project gitignore preference (global preference only); `Assets/.unifocl/` (generated Unity assets, left to user discretion)

## How to Test
1. Open a Unity project with no `.gitignore` (or one missing unifocl entries): `/open <path>` → prompt appears asking to add entries; answer yes → `.gitignore` created/appended with `.unifocl/` and `.unifocl-runtime/`.
2. Run `/open` again on the same project → no prompt (entries already present).
3. Answer no to the prompt → `/config get setup.gitignore` shows `off`; subsequent opens are silent.
4. `/config set setup.gitignore auto` → opens/inits add entries silently without prompting.
5. `/config set setup.gitignore off` → opens/inits never check.
6. `/config reset setup.gitignore` → clears saved answer; prompt reappears on next open.
7. `/config list` → shows `setup.gitignore = auto|off|prompt` alongside existing keys.
8. Agentic mode (`unifocl exec "/open <path>" --agentic --format json`): no interactive prompt; `hint` line appears in output when entries are missing.

Expected results:
- After answering yes, `.gitignore` ends with a `# unifocl runtime and bridge state` block containing `.unifocl/` and `.unifocl-runtime/`.
- Config file `~/.unifocl/config.json` gains `"gitignoreAutoIgnore": true/false` after first prompt.
- Agentic hint text instructs the agent to ask the user for consent and describes the `/config set setup.gitignore auto` opt-in path.

## Screenshots / Terminal Output (if applicable)
<!-- Paste screenshots or CLI output snippets here -->

## Breaking Changes
- [ ] This PR introduces a breaking change.

If yes, describe migration steps:
- N/A

## Security / Privacy Impact
- [x] No security impact.
- [ ] Security impact reviewed.

Details:
- Only reads and writes to the project's `.gitignore` with explicit user consent. No credentials or sensitive paths are involved.

## Documentation
- [x] Docs updated (README, usage docs, comments) where needed.
- [ ] No doc updates needed.

`full-documentation.md` regenerated and committed.

## Contributor Checklist
- [x] I have tested these changes locally.
- [x] I have added/updated tests where applicable.
- [x] I have run format/lint tools where applicable.
- [x] I have kept this PR focused and reasonably scoped.
- [x] I have verified no secrets or credentials are committed.
- [x] I have read and followed this project's contribution guidelines.
- [x] I agree to follow this project's Code of Conduct.