### PR TITLE
fix: quirks feedback — routing, REPL handlers, catalog, error hints, backgrounded /close+/open

### DIFF
--- a/changelog.d/fix-quirks-feedback.md
+++ b/changelog.d/fix-quirks-feedback.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+### Fixed
+- `/asset` slash commands (`/asset rename`, `/asset remove`, `/asset describe`) now route correctly instead of returning "unsupported route" — the routing condition was too narrow (only covered get/set/refresh).
+- `asset rename <path> <new-name>` and `asset remove <path>` are now implemented as REPL commands; previously they appeared in the catalog but fell through with an unhelpful usage error.
+- Removed `asset create` and `asset create-script` from both the slash and project command catalogs — they routed to nothing. Use `make --type <type>` instead.
+- Stale session lock error now prints the exact `rm` command to clear the dead lock file, so agents don't need to hunt for the path manually.
+- "Connection refused" daemon errors now include a hint to call `/open <project-path>` to reconnect after a Unity recompile.
+- Documented double-quote path support in `asset get`, `asset set`, `asset rename`, `asset remove`, and `make --parent` usage strings — paths containing spaces must be wrapped in double quotes (e.g. `asset get "Assets/Asset Bundle/Foo.asset"`).

--- a/changelog.d/fix-quirks-feedback.md
+++ b/changelog.d/fix-quirks-feedback.md
@@ -7,5 +7,4 @@ bump: patch
 - `asset rename <path> <new-name>` and `asset remove <path>` are now implemented as REPL commands; previously they appeared in the catalog but fell through with an unhelpful usage error.
 - Removed `asset create` and `asset create-script` from both the slash and project command catalogs — they routed to nothing. Use `make --type <type>` instead.
 - Stale session lock error now prints the exact `rm` command to clear the dead lock file, so agents don't need to hunt for the path manually.
-- "Connection refused" daemon errors now include a hint to call `/open <project-path>` to reconnect after a Unity recompile.
 - Documented double-quote path support in `asset get`, `asset set`, `asset rename`, `asset remove`, and `make --parent` usage strings — paths containing spaces must be wrapped in double quotes (e.g. `asset get "Assets/Asset Bundle/Foo.asset"`).

--- a/changelog.d/fix-quirks-feedback.md
+++ b/changelog.d/fix-quirks-feedback.md
@@ -8,3 +8,4 @@ bump: patch
 - Removed `asset create` and `asset create-script` from both the slash and project command catalogs — they routed to nothing. Use `make --type <type>` instead.
 - Stale session lock error now prints the exact `rm` command to clear the dead lock file, so agents don't need to hunt for the path manually.
 - Documented double-quote path support in `asset get`, `asset set`, `asset rename`, `asset remove`, and `make --parent` usage strings — paths containing spaces must be wrapped in double quotes (e.g. `asset get "Assets/Asset Bundle/Foo.asset"`).
+- Fixed `/close` + `/open` hang when Unity is backgrounded: the bridge listener restart after `/close` (detach) now uses `EditorApplication.update` instead of `EditorApplication.delayCall`, so it fires on the editor loop even without a Unity paint/focus tick.

--- a/src/unifocl.unity/EditorScripts/CLIDaemon.cs
+++ b/src/unifocl.unity/EditorScripts/CLIDaemon.cs
@@ -547,7 +547,8 @@ namespace UniFocl.EditorBridge
                         if (!_isBatchMode)
                         {
                             // Bridge mode lives inside Unity GUI; restart listener so future /open can reattach without restarting the editor.
-                            EditorApplication.delayCall += RestartBridgeModeListenerAfterDetach;
+                            // Use EditorApplication.update (not delayCall) so the callback fires even when Unity is backgrounded.
+                            EditorApplication.update += RestartBridgeModeListenerOnNextUpdate;
                         }
                     }
                     return;
@@ -1725,6 +1726,13 @@ namespace UniFocl.EditorBridge
 
             Debug.Log("[unifocl] domain reload detected; shutting down daemon listener before reload.");
             StopInternal(quitEditor: false);
+        }
+
+        private static void RestartBridgeModeListenerOnNextUpdate()
+        {
+            // One-shot: unsubscribe immediately so this fires exactly once.
+            EditorApplication.update -= RestartBridgeModeListenerOnNextUpdate;
+            RestartBridgeModeListenerAfterDetach();
         }
 
         private static void RestartBridgeModeListenerAfterDetach()

--- a/src/unifocl/CliCommandCatalog.cs
+++ b/src/unifocl/CliCommandCatalog.cs
@@ -156,11 +156,9 @@ internal static class CliCommandCatalog
             // ── asset ─────────────────────────────────────────────────────
             new("/asset rename <path> <new-name>", "Rename an asset at the given path (DestructiveWrite, requires approval)", "/asset rename", "asset"),
             new("/asset remove <path>", "Delete an asset at the given path (DestructiveWrite, requires approval)", "/asset remove", "asset"),
-            new("/asset create <type> <path>", "Create a new asset of the given type at path", "/asset create", "asset"),
-            new("/asset create-script <name> <path>", "Create a new C# script at path", "/asset create-script", "asset"),
             new("/asset describe <path> [--engine blip|clip]", "Describe asset visually using local BLIP/CLIP model (SafeRead)", "/asset describe", "asset"),
-            new("/asset get <path> [<field>]", "Read serialized fields from a ScriptableObject or asset importer (SafeRead)", "/asset get", "asset"),
-            new("/asset set <path> <field> <value>", "Write a serialized field on a ScriptableObject or asset importer (SafeWrite)", "/asset set", "asset"),
+            new("/asset get <path> [<field>]", "Read serialized fields from a ScriptableObject or asset importer; quote paths with spaces (SafeRead)", "/asset get", "asset"),
+            new("/asset set <path> <field> <value>", "Write a serialized field on a ScriptableObject or asset importer; quote paths with spaces (SafeWrite)", "/asset set", "asset"),
             new("/asset refresh [<path>]", "Trigger AssetDatabase.Refresh or targeted reimport of a single asset (SafeWrite)", "/asset refresh", "asset"),
 
             // ── animator ──────────────────────────────────────────────────
@@ -380,13 +378,10 @@ internal static class CliCommandCatalog
             new("layer rm <name|index>", "Alias for layer remove", "layer rm", "layer"),
 
             // ── asset ─────────────────────────────────────────────────────
-            new("asset rename <path> <new-name>", "Rename an asset at the given path", "asset rename", "asset"),
-            new("asset remove <path>", "Delete an asset at the given path", "asset remove", "asset"),
-            new("asset create <type> <path>", "Create a new asset of the given type at path", "asset create", "asset"),
-            new("asset create-script <name> <path>", "Create a new C# script at path", "asset create-script", "asset"),
-            new("asset describe <path> [--engine blip|clip]", "Describe asset visually using local BLIP/CLIP model", "asset describe", "asset"),
-            new("asset get <path> [<field>]", "Read serialized fields from a ScriptableObject or asset importer", "asset get", "asset"),
-            new("asset set <path> <field> <value>", "Write a serialized field on a ScriptableObject or asset importer", "asset set", "asset"),
+            new("asset rename <path> <new-name>", "Rename an asset at the given path (quote paths with spaces)", "asset rename", "asset"),
+            new("asset remove <path>", "Delete an asset at the given path (quote paths with spaces)", "asset remove", "asset"),
+            new("asset get <path> [<field>]", "Read serialized fields from a ScriptableObject or asset importer; quote paths with spaces", "asset get", "asset"),
+            new("asset set <path> <field> <value>", "Write a serialized field on a ScriptableObject or asset importer; quote paths with spaces", "asset set", "asset"),
             new("asset refresh [<path>]", "Trigger AssetDatabase.Refresh or targeted reimport of a single asset", "asset refresh", "asset"),
 
             // ── time ─────────────────────────────────────────────────────

--- a/src/unifocl/Services/AgenticStatePersistenceService.cs
+++ b/src/unifocl/Services/AgenticStatePersistenceService.cs
@@ -303,7 +303,7 @@ internal static class AgenticStatePersistenceService
         return Path.Combine(home, ".unifocl-runtime", "agentic");
     }
 
-    private static string ResolveSessionPath(string sessionSeed)
+    public static string ResolveSessionPath(string sessionSeed)
     {
         return Path.Combine(ResolveRuntimeRoot(), "sessions", $"{sessionSeed}.json");
     }

--- a/src/unifocl/Services/CliOneShotExecutionService.cs
+++ b/src/unifocl/Services/CliOneShotExecutionService.cs
@@ -813,9 +813,7 @@ internal static class CliOneShotExecutionService
             return;
         }
 
-        if (matched.Trigger.StartsWith("/asset get", StringComparison.Ordinal)
-            || matched.Trigger.StartsWith("/asset set", StringComparison.Ordinal)
-            || matched.Trigger.StartsWith("/asset refresh", StringComparison.Ordinal))
+        if (matched.Trigger.StartsWith("/asset", StringComparison.Ordinal))
         {
             if (session.Mode != CliMode.Project || string.IsNullOrWhiteSpace(session.CurrentProjectPath))
             {

--- a/src/unifocl/Services/HierarchyDaemonClient.cs
+++ b/src/unifocl/Services/HierarchyDaemonClient.cs
@@ -541,8 +541,23 @@ internal sealed class HierarchyDaemonClient
         }
         catch (Exception ex)
         {
-            return new ProjectCommandTransportResult(null, $"daemon project command request failed: {ex.Message}", false);
+            var hint = IsConnectionRefusedException(ex)
+                ? " — Unity may have recompiled; call /open <project-path> to reconnect"
+                : string.Empty;
+            return new ProjectCommandTransportResult(null, $"daemon project command request failed: {ex.Message}{hint}", false);
         }
+    }
+
+    private static bool IsConnectionRefusedException(Exception ex)
+    {
+        if (ex.Message.Contains("Connection refused", StringComparison.OrdinalIgnoreCase)
+            || ex.Message.Contains("actively refused", StringComparison.OrdinalIgnoreCase)
+            || ex.Message.Contains("ECONNREFUSED", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return ex.InnerException is not null && IsConnectionRefusedException(ex.InnerException);
     }
 
     private static async Task<string> ProbeDaemonHealthAsync(string requestUri)

--- a/src/unifocl/Services/HierarchyDaemonClient.cs
+++ b/src/unifocl/Services/HierarchyDaemonClient.cs
@@ -541,23 +541,8 @@ internal sealed class HierarchyDaemonClient
         }
         catch (Exception ex)
         {
-            var hint = IsConnectionRefusedException(ex)
-                ? " — Unity may have recompiled; call /open <project-path> to reconnect"
-                : string.Empty;
-            return new ProjectCommandTransportResult(null, $"daemon project command request failed: {ex.Message}{hint}", false);
+            return new ProjectCommandTransportResult(null, $"daemon project command request failed: {ex.Message}", false);
         }
-    }
-
-    private static bool IsConnectionRefusedException(Exception ex)
-    {
-        if (ex.Message.Contains("Connection refused", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("actively refused", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("ECONNREFUSED", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return ex.InnerException is not null && IsConnectionRefusedException(ex.InnerException);
     }
 
     private static async Task<string> ProbeDaemonHealthAsync(string requestUri)

--- a/src/unifocl/Services/ProjectLifecycleService.cs
+++ b/src/unifocl/Services/ProjectLifecycleService.cs
@@ -711,6 +711,7 @@ internal sealed partial class ProjectLifecycleService
                     && !string.Equals(ownerSeed, session.SessionSeed, StringComparison.Ordinal))
                 {
                     log($"[red]error[/]: project is already open in another agent session ({Markup.Escape(ownerSeed)})");
+                    log($"[yellow]hint[/]: if that session is no longer active, remove the stale lock: [white]rm {Markup.Escape(AgenticStatePersistenceService.ResolveSessionPath(ownerSeed))}[/]");
                     log($"[yellow]hint[/]: concurrent agents must clone the project to an isolated path before opening");
                     log($"[yellow]hint[/]: use the [white]project.clone[/] ExecV2 operation to create an isolated copy with a seeded Library cache, then open the cloned path");
                     log($"[yellow]example[/]: {{\"operation\":\"project.clone\",\"args\":{{\"sourcePath\":\"{Markup.Escape(projectPath)}\",\"destPath\":\"<new-path>\"}}}}");

--- a/src/unifocl/Services/ProjectViewMkCommandUtils.cs
+++ b/src/unifocl/Services/ProjectViewMkCommandUtils.cs
@@ -69,7 +69,7 @@ internal static class ProjectViewMkCommandUtils
         count = 1;
         name = null;
         parent = null;
-        error = "usage: make --type <type> [--count <count>] [--name <name>|-n <name>] [--parent <idx|name>] | mk <type> [count] [--name <name>|-n <name>] [--parent <idx|name>]";
+        error = "usage: make --type <type> [--count <count>] [--name <name>|-n <name>] [--parent <idx|name>] | mk <type> [count] [--name <name>|-n <name>] [--parent <idx|name>]  (quote --parent paths with spaces: --parent \"Assets/My Folder\")";
         if (tokens.Count == 0)
         {
             return false;

--- a/src/unifocl/Services/ProjectViewService.AssetFields.cs
+++ b/src/unifocl/Services/ProjectViewService.AssetFields.cs
@@ -15,7 +15,7 @@ internal sealed partial class ProjectViewService
         // tokens: asset get <path> [<field>]
         if (tokens.Count < 3)
         {
-            outputs.Add("[x] usage: asset get <asset-path> [<field>]");
+            outputs.Add("[x] usage: asset get <asset-path> [<field>]  (quote paths with spaces: asset get \"Assets/My Folder/Foo.asset\")");
             return true;
         }
 
@@ -76,7 +76,7 @@ internal sealed partial class ProjectViewService
         // tokens: asset set <path> <field> <value>
         if (tokens.Count < 5)
         {
-            outputs.Add("[x] usage: asset set <asset-path> <field> <value>");
+            outputs.Add("[x] usage: asset set <asset-path> <field> <value>  (quote paths with spaces: asset set \"Assets/My Folder/Foo.asset\" fieldName value)");
             return true;
         }
 
@@ -101,6 +101,131 @@ internal sealed partial class ProjectViewService
 
         outputs.Add($"[+] {response.Message}");
         return true;
+    }
+
+    // ── asset rename ──────────────────────────────────────────────────────
+
+    private async Task<bool> HandleAssetRenameByPathAsync(
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        List<string> outputs)
+    {
+        // tokens: asset rename <source-path> <new-name>
+        if (tokens.Count < 4)
+        {
+            outputs.Add("[x] usage: asset rename <asset-path> <new-name>  (quote paths with spaces: asset rename \"Assets/My Folder/Foo.asset\" Bar)");
+            return true;
+        }
+
+        var sourceRelativePath = tokens[2];
+        var newName = tokens[3];
+
+        var isDirectory = !Path.HasExtension(sourceRelativePath)
+                          && !string.IsNullOrWhiteSpace(session.CurrentProjectPath)
+                          && Directory.Exists(Path.Combine(session.CurrentProjectPath, sourceRelativePath));
+        var destinationRelative = ProjectViewServiceUtils.ComputeRenameDestinationPath(sourceRelativePath, isDirectory, newName);
+
+        var state = session.ProjectView;
+        state.DbState = ProjectDbState.LockedImporting;
+        try
+        {
+            var response = await RunTrackableProgressAsync(
+                session,
+                $"renaming '{Path.GetFileName(sourceRelativePath)}' → '{newName}'",
+                TimeSpan.FromSeconds(10),
+                () => ExecuteProjectCommandAsync(
+                    session,
+                    BuildVcsAwareProjectRequest(
+                        session,
+                        new ProjectCommandRequestDto("rename-asset", sourceRelativePath, destinationRelative, null),
+                        sourceRelativePath,
+                        sourceRelativePath + ".meta",
+                        destinationRelative,
+                        destinationRelative + ".meta")));
+
+            if (!response.Ok)
+            {
+                outputs.Add(ProjectViewServiceUtils.FormatProjectCommandFailure("asset rename", response.Message));
+                return true;
+            }
+
+            if (response.Kind?.Equals("dry-run", StringComparison.OrdinalIgnoreCase) == true
+                && TryAppendDryRunDiff(outputs, response.Content))
+            {
+                return true;
+            }
+
+            outputs.Add("[=] rename complete. .meta file updated successfully.");
+            if (!string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+            {
+                ProjectViewTreeUtils.RefreshTree(session.CurrentProjectPath, state);
+            }
+
+            await SyncAssetIndexAsync(session);
+            return true;
+        }
+        finally
+        {
+            state.DbState = ProjectDbState.IdleSafe;
+        }
+    }
+
+    // ── asset remove ──────────────────────────────────────────────────────
+
+    private async Task<bool> HandleAssetRemoveByPathAsync(
+        IReadOnlyList<string> tokens,
+        CliSessionState session,
+        List<string> outputs)
+    {
+        // tokens: asset remove <path>
+        if (tokens.Count < 3)
+        {
+            outputs.Add("[x] usage: asset remove <asset-path>  (quote paths with spaces: asset remove \"Assets/My Folder/Foo.asset\")");
+            return true;
+        }
+
+        var sourcePath = tokens[2];
+        var state = session.ProjectView;
+        state.DbState = ProjectDbState.LockedImporting;
+        try
+        {
+            var response = await RunTrackableProgressAsync(
+                session,
+                $"removing '{Path.GetFileName(sourcePath)}'",
+                TimeSpan.FromSeconds(6),
+                () => ExecuteProjectCommandAsync(
+                    session,
+                    BuildVcsAwareProjectRequest(
+                        session,
+                        new ProjectCommandRequestDto("remove-asset", sourcePath, null, null),
+                        sourcePath,
+                        sourcePath + ".meta")));
+
+            if (!response.Ok)
+            {
+                outputs.Add(ProjectViewServiceUtils.FormatProjectCommandFailure("asset remove", response.Message));
+                return true;
+            }
+
+            if (response.Kind?.Equals("dry-run", StringComparison.OrdinalIgnoreCase) == true
+                && TryAppendDryRunDiff(outputs, response.Content))
+            {
+                return true;
+            }
+
+            outputs.Add($"[=] removed: {sourcePath}");
+            if (!string.IsNullOrWhiteSpace(session.CurrentProjectPath))
+            {
+                ProjectViewTreeUtils.RefreshTree(session.CurrentProjectPath, state);
+            }
+
+            await SyncAssetIndexAsync(session);
+            return true;
+        }
+        finally
+        {
+            state.DbState = ProjectDbState.IdleSafe;
+        }
     }
 
     // ── asset refresh ───────────────────────────────────────────────────────

--- a/src/unifocl/Services/ProjectViewService.cs
+++ b/src/unifocl/Services/ProjectViewService.cs
@@ -133,7 +133,7 @@ internal sealed partial class ProjectViewService
         {
             if (tokens.Count < 2)
             {
-                outputs.Add("[x] usage: asset <find|duplicate|get|set|refresh> <...>");
+                outputs.Add("[x] usage: asset <find|duplicate|get|set|refresh|rename|remove> <...>");
                 handled = true;
             }
             else if (tokens[1].Equals("find", StringComparison.OrdinalIgnoreCase))
@@ -171,9 +171,35 @@ internal sealed partial class ProjectViewService
                 await EnsureModeContextAsync(session, daemonControlService, daemonRuntime);
                 handled = await HandleAssetRefreshAsync(tokens, session, outputs);
             }
+            else if (tokens[1].Equals("rename", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!EnsureVcsSetupForMutation(session, outputs))
+                {
+                    handled = true;
+                    ProjectViewTranscriptUtils.Append(session.ProjectView, outputs);
+                    RenderFrame(session.ProjectView);
+                    return true;
+                }
+
+                await EnsureModeContextAsync(session, daemonControlService, daemonRuntime);
+                handled = await HandleAssetRenameByPathAsync(tokens, session, outputs);
+            }
+            else if (tokens[1].Equals("remove", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!EnsureVcsSetupForMutation(session, outputs))
+                {
+                    handled = true;
+                    ProjectViewTranscriptUtils.Append(session.ProjectView, outputs);
+                    RenderFrame(session.ProjectView);
+                    return true;
+                }
+
+                await EnsureModeContextAsync(session, daemonControlService, daemonRuntime);
+                handled = await HandleAssetRemoveByPathAsync(tokens, session, outputs);
+            }
             else
             {
-                outputs.Add("[x] usage: asset <find|duplicate|get|set|refresh> <...>");
+                outputs.Add("[x] usage: asset <find|duplicate|get|set|refresh|rename|remove> <...>");
                 handled = true;
             }
         }


### PR DESCRIPTION
## Summary

- `/asset` slash command routing now covers all subcommands (was too narrow: only `get/set/refresh`)
- `asset rename <path> <new-name>` and `asset remove <path>` implemented as REPL + slash commands
- Removed dead catalog entries: `/asset create`, `/asset create-script` (routed to nothing; use `make --type`)
- Stale session lock error now prints the exact `rm` path so agents can self-recover
- Double-quote path support documented in usage strings for `asset get`, `asset set`, `asset rename`, `asset remove`, `make --parent`
- Fixed `/close` + `/open` hang when Unity is backgrounded: replaced `EditorApplication.delayCall` with a one-shot `EditorApplication.update` subscription in `CLIDaemon.cs` — `delayCall` requires a Unity paint/focus tick, `update` fires on the editor loop even without window focus

## Test plan

- [ ] `/asset rename Assets/Foo.png Bar` routes correctly and renames the asset
- [ ] `/asset remove Assets/Foo.png` routes correctly and removes the asset
- [ ] `/asset create` returns a helpful error pointing to `make --type`
- [ ] Stale session lock message includes the exact `rm` command for the lock file path
- [ ] `asset get "Assets/My Folder/Foo.asset"` (quoted path) works
- [ ] After `/close` with Unity backgrounded, a subsequent `/open` completes without requiring Unity focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)