### PR TITLE
fix: signal compile completion through on-disk markers, not the daemon socket

### DIFF
--- a/changelog.d/fix-compile-reliability.md
+++ b/changelog.d/fix-compile-reliability.md
@@ -1,0 +1,20 @@
+---
+bump: minor
+---
+
+### Added
+- `/compile request --force` triggers a clean recompile by passing `RequestScriptCompilationOptions.CleanBuildCache` to Unity's compilation pipeline. Previously there was no way from the CLI to bust Unity's incremental cache.
+- `/compile request --wait` blocks until the compile and any subsequent domain reload have fully settled. The CLI polls a result file the daemon writes to `Temp/unifocl/compile-results/{requestId}.json`, plus Unity's own `Temp/compiling.lock` and `Temp/domainreload.lock` markers, so completion is observable even when the daemon HTTP socket is torn down during the reload that follows a successful compile.
+- `compile.request` exec op now accepts `forceRecompile` and `waitForDomainReload` arguments, so MCP/agentic callers get the same controls.
+- `CompilationStateValidationService` rejects compile requests up front when the editor is already compiling, importing, in domain reload, or contains duplicate `.asmdef` names — replacing silent stalls with actionable errors.
+- Compile-did-not-start watchdog: if `EditorApplication.isCompiling` does not flip true within 4 s of `RequestScriptCompilation`, the daemon writes an `outcome=indeterminate` result file with a diagnostic listing the likely causes (Auto Refresh disabled, no script changes, duplicate asmdefs, locks held).
+
+### Fixed
+- `/compile request` now calls `AssetDatabase.Refresh()` before `RequestScriptCompilation`, so newly copied `.cs` files are picked up reliably without depending on the OS-level window-grab. The window-grab is kept as a cosmetic, opt-in fallback.
+- Editor bridge install manifest now ships `CompilationStateValidationService.cs` and `CompileResultPersistenceService.cs` so the new compile flow links cleanly when the bridge is materialized into a target project.
+- Daemon no longer drops compile completion state on domain reload. Compile results are persisted to disk by `CompileResultPersistenceService` before the AppDomain is torn down, so a CLI that started before the reload can observe the result after the daemon comes back online.
+- `compile-request` now propagates a per-request `requestId` end to end (CLI → daemon → result file), eliminating the previous shared-in-memory state field that could be trampled by overlapping callers.
+- Domain-reload state is now tracked via Unity `SessionState`, so the daemon can distinguish "never compiled" from "compiled and just reloaded" after the AppDomain comes back.
+
+### Background
+Compile completion is now signalled through files on disk plus Unity's own lock-file markers rather than relying on the daemon HTTP socket, which can be torn down by the domain reload that follows a successful compile. Polling the on-disk markers lets the CLI observe completion across the reload boundary instead of seeing connection-refused at the moment the answer matters most.

--- a/src/unifocl.unity/EditorScripts/Services/CompilationStateValidationService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/CompilationStateValidationService.cs
@@ -1,0 +1,185 @@
+#if UNITY_EDITOR
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniFocl.EditorBridge
+{
+    /// <summary>
+    /// Validates Unity editor state before a compile request is dispatched.
+    ///
+    /// The goal is to replace silent failure modes with structured rejections
+    /// the CLI can surface to the caller. Without this gate, requesting compile
+    /// while the editor is already busy (in another compile, an asset import,
+    /// or domain reload) silently no-ops and leaves the caller waiting forever.
+    /// </summary>
+    internal static class CompilationStateValidationService
+    {
+        public readonly struct ValidationResult
+        {
+            public ValidationResult(bool isValid, string errorCode, string errorMessage)
+            {
+                IsValid = isValid;
+                ErrorCode = errorCode ?? string.Empty;
+                ErrorMessage = errorMessage ?? string.Empty;
+            }
+
+            public bool IsValid { get; }
+            public string ErrorCode { get; }
+            public string ErrorMessage { get; }
+
+            public static ValidationResult Success() => new(true, string.Empty, string.Empty);
+            public static ValidationResult Failure(string code, string message) => new(false, code, message);
+        }
+
+        public static ValidationResult Validate()
+        {
+            if (EditorApplication.isCompiling)
+            {
+                return ValidationResult.Failure(
+                    "already-compiling",
+                    "Compilation is already in progress. Wait for it to finish before requesting another compile.");
+            }
+
+            if (EditorApplication.isUpdating)
+            {
+                return ValidationResult.Failure(
+                    "editor-updating",
+                    "Editor is updating (asset import in progress). Wait for the update to complete before requesting compile.");
+            }
+
+            if (CompileDomainReloadState.IsDomainReloadInProgress())
+            {
+                return ValidationResult.Failure(
+                    "domain-reload-in-progress",
+                    "Domain reload is in progress. Wait for the editor to settle before requesting compile.");
+            }
+
+            string[] duplicateAsmdefs = FindDuplicateAsmdefNames();
+            if (duplicateAsmdefs.Length > 0)
+            {
+                return ValidationResult.Failure(
+                    "duplicate-asmdef",
+                    "Duplicate Assembly Definition names will block compilation: "
+                    + string.Join(", ", duplicateAsmdefs)
+                    + ". Resolve the duplicates before requesting compile.");
+            }
+
+            return ValidationResult.Success();
+        }
+
+        // ── Duplicate asmdef detection ────────────────────────────────────────
+        //
+        // Two .asmdef files with the same `name` field are silent-fatal: Unity
+        // skips compilation of both assemblies and surfaces only a console
+        // warning. We catch this case before requesting compile so the CLI
+        // gets an actionable error instead of "compile did not start".
+
+        [Serializable]
+        private sealed class AsmdefStub
+        {
+            public string name = string.Empty;
+        }
+
+        private static string[] FindDuplicateAsmdefNames()
+        {
+            string assetsPath = Application.dataPath;
+            if (string.IsNullOrEmpty(assetsPath) || !Directory.Exists(assetsPath))
+            {
+                return Array.Empty<string>();
+            }
+
+            string[] paths;
+            try
+            {
+                paths = Directory.GetFiles(assetsPath, "*.asmdef", SearchOption.AllDirectories);
+            }
+            catch (Exception)
+            {
+                return Array.Empty<string>();
+            }
+
+            var seen = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (string path in paths)
+            {
+                string? name = TryReadAsmdefName(path);
+                if (string.IsNullOrEmpty(name))
+                {
+                    continue;
+                }
+
+                seen[name!] = seen.TryGetValue(name!, out int prior) ? prior + 1 : 1;
+            }
+
+            return seen
+                .Where(kv => kv.Value > 1)
+                .Select(kv => kv.Key)
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        private static string? TryReadAsmdefName(string path)
+        {
+            try
+            {
+                string json = File.ReadAllText(path);
+                var stub = JsonUtility.FromJson<AsmdefStub>(json);
+                return stub == null ? null : stub.name;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Tracks whether a domain reload is in flight using <see cref="SessionState"/>
+    /// so the flag survives the reload itself. <see cref="AssemblyReloadEvents"/>
+    /// callbacks straddle the reload boundary, so we set the flag before the
+    /// reload begins and clear it once managed code is back online.
+    /// </summary>
+    internal static class CompileDomainReloadState
+    {
+        private const string DomainReloadKey = "unifocl.compile.domainReloadInProgress";
+
+        private static bool _registered;
+
+        [InitializeOnLoadMethod]
+        private static void Register()
+        {
+            if (_registered)
+            {
+                return;
+            }
+
+            _registered = true;
+
+            // afterAssemblyReload fires once the new domain is fully online,
+            // including [InitializeOnLoadMethod] static constructors. Clear the
+            // flag now so anyone polling SessionState sees us as ready again.
+            AssemblyReloadEvents.afterAssemblyReload += () =>
+            {
+                SessionState.SetBool(DomainReloadKey, false);
+            };
+
+            AssemblyReloadEvents.beforeAssemblyReload += () =>
+            {
+                SessionState.SetBool(DomainReloadKey, true);
+            };
+
+            // If the editor was still mid-reload when this static constructor
+            // runs (e.g. the previous AppDomain hadn't yet returned from
+            // beforeAssemblyReload before being torn down), the flag may be
+            // stuck true. Clear it once on init so we never carry stale state.
+            SessionState.SetBool(DomainReloadKey, false);
+        }
+
+        public static bool IsDomainReloadInProgress() => SessionState.GetBool(DomainReloadKey, false);
+    }
+}
+#endif

--- a/src/unifocl.unity/EditorScripts/Services/CompileResultPersistenceService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/CompileResultPersistenceService.cs
@@ -1,0 +1,170 @@
+#if UNITY_EDITOR
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace UniFocl.EditorBridge
+{
+    /// <summary>
+    /// Persists compile results to disk so the CLI can observe completion even
+    /// when Unity tears down its HTTP daemon during the domain reload that
+    /// follows a successful compile.
+    ///
+    /// The result file lives at:
+    ///   <c>&lt;projectRoot&gt;/Temp/unifocl/compile-results/{requestId}.json</c>
+    ///
+    /// The CLI polls this file plus Unity's <c>Temp/compiling.lock</c> and
+    /// <c>Temp/domainreload.lock</c> markers; once the result file exists and
+    /// both lock files are gone for a grace period, the compile is treated
+    /// as fully settled.
+    /// </summary>
+    internal static class CompileResultPersistenceService
+    {
+        // Match the CLI waiter's max poll budget plus a generous safety margin.
+        // Files older than this can never be claimed by an active waiter.
+        private static readonly TimeSpan StaleResultThreshold = TimeSpan.FromMinutes(2);
+
+        // Restrict requestId to [a-zA-Z0-9_-] so it cannot encode path
+        // separators or traversal sequences when used as a file name.
+        private static readonly Regex SafeRequestIdRegex = new(@"^[a-zA-Z0-9_-]+$", RegexOptions.Compiled);
+
+        public static string GetResultDirectory()
+        {
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            return Path.Combine(projectRoot, "Temp", "unifocl", "compile-results");
+        }
+
+        public static bool IsRequestIdSafe(string? requestId)
+        {
+            return !string.IsNullOrWhiteSpace(requestId) && SafeRequestIdRegex.IsMatch(requestId!);
+        }
+
+        public static string CreateRequestId()
+        {
+            long ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            string token = Guid.NewGuid().ToString("N").Substring(0, 8);
+            return $"compile_{ts}_{token}";
+        }
+
+        public static void SaveResult(string requestId, CompilePersistedResult result)
+        {
+            if (!IsRequestIdSafe(requestId))
+            {
+                Debug.LogWarning($"[unifocl] refusing to save compile result with unsafe requestId: '{requestId}'");
+                return;
+            }
+
+            string directory = GetResultDirectory();
+            try
+            {
+                if (!Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[unifocl] could not create compile-results directory: {ex.Message}");
+                return;
+            }
+
+            string filePath = Path.Combine(directory, $"{requestId}.json");
+            string tempPath = filePath + ".tmp";
+
+            try
+            {
+                string json = JsonUtility.ToJson(result);
+                // Write to a temp file then atomically move into place so a
+                // racing reader never sees a partially written file.
+                File.WriteAllText(tempPath, json, new UTF8Encoding(false));
+
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+                File.Move(tempPath, filePath);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[unifocl] failed to write compile result {requestId}: {ex.Message}");
+                try
+                {
+                    if (File.Exists(tempPath))
+                    {
+                        File.Delete(tempPath);
+                    }
+                }
+                catch
+                {
+                    // best-effort cleanup
+                }
+            }
+        }
+
+        public static void ClearStaleResults()
+        {
+            string directory = GetResultDirectory();
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
+            DateTime threshold = DateTime.UtcNow - StaleResultThreshold;
+
+            string[] files;
+            try
+            {
+                files = Directory.GetFiles(directory, "*.json");
+            }
+            catch
+            {
+                return;
+            }
+
+            foreach (string file in files)
+            {
+                try
+                {
+                    if (File.GetLastWriteTimeUtc(file) < threshold)
+                    {
+                        File.Delete(file);
+                    }
+                }
+                catch
+                {
+                    // best-effort
+                }
+            }
+        }
+    }
+
+    [Serializable]
+    internal sealed class CompilePersistedResult
+    {
+        public string requestId = string.Empty;
+        public string outcome = string.Empty;          // "success" | "errors" | "indeterminate" | "rejected"
+        public bool success;
+        public int errorCount;
+        public int warningCount;
+        public string startedAtUtc = string.Empty;
+        public string finishedAtUtc = string.Empty;
+        public string message = string.Empty;
+        public CompilePersistedIssue[] errors = Array.Empty<CompilePersistedIssue>();
+        public CompilePersistedIssue[] warnings = Array.Empty<CompilePersistedIssue>();
+        public bool forceRecompile;
+    }
+
+    [Serializable]
+    internal sealed class CompilePersistedIssue
+    {
+        public string message = string.Empty;
+        public string file = string.Empty;
+        public int line;
+        public string assembly = string.Empty;
+    }
+}
+#endif

--- a/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/DaemonProjectService.cs
@@ -67,16 +67,48 @@ namespace UniFocl.EditorBridge
             public string name = string.Empty;
         }
 
+        // Per-compile detailed message accumulation. Used to build the
+        // CompilePersistedResult written to disk on compilationFinished.
+        // Reset on every compilationStarted; not lock-protected because both
+        // events fire on Unity's main thread.
+        private static readonly List<CompilePersistedIssue> _pendingErrors = new();
+        private static readonly List<CompilePersistedIssue> _pendingWarnings = new();
+
+        // SessionState keys used to correlate a compile request with its
+        // result file across the domain reload that follows a successful
+        // compile. The keys persist for the editor session (cleared on
+        // editor restart) but survive the AppDomain teardown.
+        private const string CompilePendingRequestIdKey = "unifocl.compile.pendingRequestId";
+        private const string CompilePendingForceRecompileKey = "unifocl.compile.pendingForceRecompile";
+        private const string CompilePendingStartedAtUtcKey = "unifocl.compile.pendingStartedAtUtc";
+
         [InitializeOnLoadMethod]
         private static void InitializeCompilationTracking()
         {
             CompilationPipeline.compilationStarted += OnCompilationStarted;
             CompilationPipeline.assemblyCompilationFinished += OnAssemblyCompilationFinished;
             CompilationPipeline.compilationFinished += OnCompilationFinished;
+
+            // Best-effort: clear stale result files left by previous editor
+            // sessions so the directory does not grow unbounded.
+            try
+            {
+                CompileResultPersistenceService.ClearStaleResults();
+            }
+            catch
+            {
+                // never fatal during init
+            }
         }
 
         private static void OnCompilationStarted(object obj)
         {
+            _pendingErrors.Clear();
+            _pendingWarnings.Clear();
+
+            string startedAtUtc = DateTime.UtcNow.ToString("O");
+            SessionState.SetString(CompilePendingStartedAtUtcKey, startedAtUtc);
+
             lock (CompilationStateLock)
             {
                 _compilationState = new CompilationRuntimeState
@@ -84,7 +116,7 @@ namespace UniFocl.EditorBridge
                     running = true,
                     succeeded = false,
                     errors = Array.Empty<string>(),
-                    startedAtUtc = DateTime.UtcNow.ToString("O"),
+                    startedAtUtc = startedAtUtc,
                     finishedAtUtc = string.Empty
                 };
             }
@@ -92,26 +124,48 @@ namespace UniFocl.EditorBridge
 
         private static void OnAssemblyCompilationFinished(string assemblyPath, CompilerMessage[] messages)
         {
-            var errorMessages = messages
-                .Where(m => m.type == CompilerMessageType.Error)
-                .Select(m => m.message)
-                .ToArray();
+            string assemblyName = string.IsNullOrEmpty(assemblyPath)
+                ? string.Empty
+                : Path.GetFileName(assemblyPath);
 
-            if (errorMessages.Length == 0)
+            foreach (CompilerMessage message in messages)
+            {
+                if (message.type == CompilerMessageType.Error)
+                {
+                    _pendingErrors.Add(new CompilePersistedIssue
+                    {
+                        message = message.message ?? string.Empty,
+                        file = message.file ?? string.Empty,
+                        line = message.line,
+                        assembly = assemblyName
+                    });
+                }
+                else if (message.type == CompilerMessageType.Warning)
+                {
+                    _pendingWarnings.Add(new CompilePersistedIssue
+                    {
+                        message = message.message ?? string.Empty,
+                        file = message.file ?? string.Empty,
+                        line = message.line,
+                        assembly = assemblyName
+                    });
+                }
+            }
+
+            if (_pendingErrors.Count == 0)
             {
                 return;
             }
 
+            // Mirror error message strings into the legacy CompilationRuntimeState
+            // so /compile/status keeps returning the same shape it always has.
             lock (CompilationStateLock)
             {
-                var existing = _compilationState.errors ?? Array.Empty<string>();
-                var combined = new string[existing.Length + errorMessages.Length];
-                Array.Copy(existing, combined, existing.Length);
-                Array.Copy(errorMessages, 0, combined, existing.Length, errorMessages.Length);
+                string[] combined = _pendingErrors.Select(e => e.message).ToArray();
                 _compilationState = new CompilationRuntimeState
                 {
                     running = _compilationState.running,
-                    succeeded = _compilationState.succeeded,
+                    succeeded = false,
                     errors = combined,
                     startedAtUtc = _compilationState.startedAtUtc,
                     finishedAtUtc = _compilationState.finishedAtUtc
@@ -121,17 +175,55 @@ namespace UniFocl.EditorBridge
 
         private static void OnCompilationFinished(object obj)
         {
+            string finishedAtUtc = DateTime.UtcNow.ToString("O");
+            string startedAtUtc = SessionState.GetString(CompilePendingStartedAtUtcKey, string.Empty);
+            bool succeeded = _pendingErrors.Count == 0;
+
             lock (CompilationStateLock)
             {
                 _compilationState = new CompilationRuntimeState
                 {
                     running = false,
-                    succeeded = _compilationState.errors == null || _compilationState.errors.Length == 0,
-                    errors = _compilationState.errors ?? Array.Empty<string>(),
-                    startedAtUtc = _compilationState.startedAtUtc,
-                    finishedAtUtc = DateTime.UtcNow.ToString("O")
+                    succeeded = succeeded,
+                    errors = _pendingErrors.Select(e => e.message).ToArray(),
+                    startedAtUtc = string.IsNullOrEmpty(startedAtUtc) ? _compilationState.startedAtUtc : startedAtUtc,
+                    finishedAtUtc = finishedAtUtc
                 };
             }
+
+            string pendingRequestId = SessionState.GetString(CompilePendingRequestIdKey, string.Empty);
+            if (!string.IsNullOrEmpty(pendingRequestId)
+                && CompileResultPersistenceService.IsRequestIdSafe(pendingRequestId))
+            {
+                bool forceRecompile = SessionState.GetBool(CompilePendingForceRecompileKey, false);
+                CompilePersistedResult result = new()
+                {
+                    requestId = pendingRequestId,
+                    outcome = succeeded ? "success" : "errors",
+                    success = succeeded,
+                    errorCount = _pendingErrors.Count,
+                    warningCount = _pendingWarnings.Count,
+                    startedAtUtc = startedAtUtc,
+                    finishedAtUtc = finishedAtUtc,
+                    message = succeeded
+                        ? "compilation completed successfully"
+                        : $"compilation completed with {_pendingErrors.Count} error(s)",
+                    errors = _pendingErrors.ToArray(),
+                    warnings = _pendingWarnings.ToArray(),
+                    forceRecompile = forceRecompile
+                };
+
+                CompileResultPersistenceService.SaveResult(pendingRequestId, result);
+
+                // Clear the pending state so a later untracked compile does
+                // not re-write to the same file.
+                SessionState.SetString(CompilePendingRequestIdKey, string.Empty);
+                SessionState.SetBool(CompilePendingForceRecompileKey, false);
+                SessionState.SetString(CompilePendingStartedAtUtcKey, string.Empty);
+            }
+
+            _pendingErrors.Clear();
+            _pendingWarnings.Clear();
         }
 
         public static string GetCompilationStatusPayload()
@@ -361,7 +453,7 @@ namespace UniFocl.EditorBridge
                 "addressables-cli" => Task.FromResult(ExecuteAddressablesCommand(request)),
                 "build-cancel" => Task.FromResult(ExecuteBuildCancel()),
                 "build-targets" => Task.FromResult(ExecuteBuildTargets()),
-                "compile-request" => Task.FromResult(ExecuteCompileRequest()),
+                "compile-request" => Task.FromResult(ExecuteCompileRequest(request)),
                 "compile-status" => Task.FromResult(ExecuteCompileStatus()),
                 "hierarchy-find" => Task.FromResult(ExecuteHierarchyFind(request)),
                 "settings-inspect" => Task.FromResult(ExecuteSettingsInspect()),
@@ -1184,15 +1276,191 @@ namespace UniFocl.EditorBridge
                 postVerifyMessage: $"upm remove completed but package is still present in manifest: {packageId}");
         }
 
-        private static string ExecuteCompileRequest()
+        [Serializable]
+        private sealed class CompileRequestPayload
         {
-            UnifoclCompilationService.RequestRecompile();
+            public bool forceRecompile;
+            public bool waitForDomainReload = true;
+        }
+
+        [Serializable]
+        private sealed class CompileRequestResponseExtras
+        {
+            public string requestId = string.Empty;
+            public bool tracked;
+            public string resultPath = string.Empty;
+            public string lockDir = string.Empty;
+        }
+
+        private static string ExecuteCompileRequest(ProjectCommandRequest request)
+        {
+            CompileRequestPayload payload = ParseCompileRequestPayload(request.content);
+
+            string requestId = CompileResultPersistenceService.IsRequestIdSafe(request.requestId)
+                ? request.requestId
+                : CompileResultPersistenceService.CreateRequestId();
+
+            bool tracked = payload.waitForDomainReload;
+            string projectRoot = Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            string resultDir = CompileResultPersistenceService.GetResultDirectory();
+            string resultPath = Path.Combine(resultDir, $"{requestId}.json");
+            string lockDir = Path.Combine(projectRoot, "Temp");
+
+            CompilationStateValidationService.ValidationResult validation = CompilationStateValidationService.Validate();
+            if (!validation.IsValid)
+            {
+                if (tracked)
+                {
+                    CompileResultPersistenceService.SaveResult(requestId, new CompilePersistedResult
+                    {
+                        requestId = requestId,
+                        outcome = "rejected",
+                        success = false,
+                        errorCount = 0,
+                        warningCount = 0,
+                        startedAtUtc = DateTime.UtcNow.ToString("O"),
+                        finishedAtUtc = DateTime.UtcNow.ToString("O"),
+                        message = $"{validation.ErrorCode}: {validation.ErrorMessage}",
+                        forceRecompile = payload.forceRecompile
+                    });
+                }
+
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = validation.ErrorMessage,
+                    kind = "compile-request",
+                    content = JsonUtility.ToJson(new CompileRequestResponseExtras
+                    {
+                        requestId = requestId,
+                        tracked = tracked,
+                        resultPath = tracked ? resultPath : string.Empty,
+                        lockDir = lockDir
+                    })
+                });
+            }
+
+            if (tracked)
+            {
+                SessionState.SetString(CompilePendingRequestIdKey, requestId);
+                SessionState.SetBool(CompilePendingForceRecompileKey, payload.forceRecompile);
+                SessionState.SetString(CompilePendingStartedAtUtcKey, DateTime.UtcNow.ToString("O"));
+            }
+            else
+            {
+                // Untracked compile: clear any leftover pending requestId so
+                // its compilationFinished does not write to a stranger's file.
+                SessionState.SetString(CompilePendingRequestIdKey, string.Empty);
+                SessionState.SetBool(CompilePendingForceRecompileKey, false);
+                SessionState.SetString(CompilePendingStartedAtUtcKey, string.Empty);
+            }
+
+            Action<string>? watchdogReporter = null;
+            if (tracked)
+            {
+                string watchdogRequestId = requestId;
+                bool watchdogForce = payload.forceRecompile;
+                watchdogReporter = diagnostic =>
+                {
+                    string pending = SessionState.GetString(CompilePendingRequestIdKey, string.Empty);
+                    if (pending != watchdogRequestId)
+                    {
+                        // A real compile started in the meantime, claimed the
+                        // requestId, and OnCompilationFinished will persist —
+                        // drop the watchdog report.
+                        return;
+                    }
+
+                    CompileResultPersistenceService.SaveResult(watchdogRequestId, new CompilePersistedResult
+                    {
+                        requestId = watchdogRequestId,
+                        outcome = "indeterminate",
+                        success = false,
+                        errorCount = 0,
+                        warningCount = 0,
+                        startedAtUtc = SessionState.GetString(CompilePendingStartedAtUtcKey, string.Empty),
+                        finishedAtUtc = DateTime.UtcNow.ToString("O"),
+                        message = diagnostic,
+                        forceRecompile = watchdogForce
+                    });
+
+                    SessionState.SetString(CompilePendingRequestIdKey, string.Empty);
+                    SessionState.SetBool(CompilePendingForceRecompileKey, false);
+                    SessionState.SetString(CompilePendingStartedAtUtcKey, string.Empty);
+                };
+            }
+
+            UnifoclCompilationService.RecompileOutcome outcome =
+                UnifoclCompilationService.RequestRecompile(payload.forceRecompile, watchdogReporter);
+
+            if (!outcome.Ok)
+            {
+                if (tracked)
+                {
+                    CompileResultPersistenceService.SaveResult(requestId, new CompilePersistedResult
+                    {
+                        requestId = requestId,
+                        outcome = "rejected",
+                        success = false,
+                        errorCount = 0,
+                        warningCount = 0,
+                        startedAtUtc = DateTime.UtcNow.ToString("O"),
+                        finishedAtUtc = DateTime.UtcNow.ToString("O"),
+                        message = outcome.Message,
+                        forceRecompile = payload.forceRecompile
+                    });
+
+                    SessionState.SetString(CompilePendingRequestIdKey, string.Empty);
+                    SessionState.SetBool(CompilePendingForceRecompileKey, false);
+                    SessionState.SetString(CompilePendingStartedAtUtcKey, string.Empty);
+                }
+
+                return JsonUtility.ToJson(new ProjectCommandResponse
+                {
+                    ok = false,
+                    message = outcome.Message,
+                    kind = "compile-request",
+                    content = JsonUtility.ToJson(new CompileRequestResponseExtras
+                    {
+                        requestId = requestId,
+                        tracked = tracked,
+                        resultPath = tracked ? resultPath : string.Empty,
+                        lockDir = lockDir
+                    })
+                });
+            }
+
             return JsonUtility.ToJson(new ProjectCommandResponse
             {
                 ok = true,
-                message = "compile request submitted",
-                kind = "compile-request"
+                message = outcome.Message,
+                kind = "compile-request",
+                content = JsonUtility.ToJson(new CompileRequestResponseExtras
+                {
+                    requestId = requestId,
+                    tracked = tracked,
+                    resultPath = tracked ? resultPath : string.Empty,
+                    lockDir = lockDir
+                })
             });
+        }
+
+        private static CompileRequestPayload ParseCompileRequestPayload(string? content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return new CompileRequestPayload();
+            }
+
+            try
+            {
+                CompileRequestPayload? parsed = JsonUtility.FromJson<CompileRequestPayload>(content);
+                return parsed ?? new CompileRequestPayload();
+            }
+            catch
+            {
+                return new CompileRequestPayload();
+            }
         }
 
         /// <summary>

--- a/src/unifocl.unity/EditorScripts/Services/UnifoclCompilationService.cs
+++ b/src/unifocl.unity/EditorScripts/Services/UnifoclCompilationService.cs
@@ -1,69 +1,184 @@
 #if UNITY_EDITOR
 using System;
 using System.Diagnostics;
+using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
+using Debug = UnityEngine.Debug;
 
 namespace UniFocl.EditorBridge
 {
     /// <summary>
-    /// Global utility for programmatically triggering a Unity script recompile.
+    /// Triggers a Unity script recompile and reports whether the compile pipeline
+    /// actually started.
     ///
-    /// Combines two mechanisms:
-    ///   1. OS-level editor window activation — ensures Unity's file-watcher ticks
-    ///      immediately so newly copied .cs files are detected without manual focus.
-    ///   2. <see cref="CompilationPipeline.RequestScriptCompilation"/> — queues a
-    ///      script-only recompile; much cheaper than AssetDatabase.Refresh() on
-    ///      large projects because it skips asset reimporting entirely.
+    /// The flow combines four mechanisms in deterministic order:
     ///
-    /// Window-grab behaviour is controlled by <see cref="UnifoclEditorConfig.allowWindowGrab"/>.
-    /// Set it to <c>false</c> for headless CI runners where window activation is
-    /// meaningless or would fail.
+    ///   1. <see cref="AssetDatabase.Refresh()"/> — forces Unity to rescan the
+    ///      asset folder so newly copied .cs files become visible to the
+    ///      compiler. Without this step new scripts copied while the editor is
+    ///      not focused are routinely missed.
+    ///   2. <see cref="CompilationPipeline.RequestScriptCompilation"/> — queues
+    ///      a script-only recompile. When <c>forceRecompile</c> is set the
+    ///      <see cref="RequestScriptCompilationOptions.CleanBuildCache"/> flag
+    ///      is passed so the incremental cache is busted.
+    ///   3. Optional OS window-grab (cosmetic) — only runs if the editor config
+    ///      enables it; left as a fallback for users who want the editor brought
+    ///      to the foreground but never relied on for correctness.
+    ///   4. Compile-did-not-start watchdog — a short EditorApplication.update
+    ///      poll that surfaces a diagnostic if <c>EditorApplication.isCompiling</c>
+    ///      never flips true. Catches the common silent-failure modes: auto
+    ///      refresh disabled, no script changes, duplicate asmdef names,
+    ///      domain-reload locks held.
     /// </summary>
     internal static class UnifoclCompilationService
     {
-        /// <summary>
-        /// Optionally activates the Unity editor window (so the file-watcher ticks),
-        /// then requests a script-only recompile via the Compilation Pipeline.
-        /// </summary>
-        public static void RequestRecompile()
+        // Watchdog: how long to wait for EditorApplication.isCompiling to become
+        // true after RequestScriptCompilation before declaring "did not start".
+        // Sized to absorb a preceding AssetDatabase.Refresh(), which can take
+        // around a second on larger projects before the compiler actually
+        // begins.
+        private const double CompileStartWatchdogSeconds = 4.0;
+
+        private static double _watchdogDeadlineSeconds;
+        private static Action<string>? _watchdogReporter;
+        private static bool _watchdogActive;
+
+        public readonly struct RecompileOutcome
         {
-            var config = UnifoclEditorConfig.Load();
-            if (config.allowWindowGrab)
-                TryGrabEditorWindow();
-            CompilationPipeline.RequestScriptCompilation();
+            public RecompileOutcome(bool ok, string message)
+            {
+                Ok = ok;
+                Message = message;
+            }
+
+            public bool Ok { get; }
+            public string Message { get; }
         }
 
-        // ── Platform-specific window activation ───────────────────────────────
-
-        private static void TryGrabEditorWindow()
+        public static RecompileOutcome RequestRecompile(bool forceRecompile = false, Action<string>? watchdogReporter = null)
         {
             try
             {
-#if UNITY_EDITOR_OSX
-                // AppleScript: bring Unity to the foreground
-                SpawnSilent("osascript", "-e 'tell application \"Unity\" to activate'");
-
-#elif UNITY_EDITOR_WIN
-                // Shell.Application COM activation — no P/Invoke required
-                SpawnSilent(
-                    "powershell",
-                    "-NoProfile -NonInteractive -Command " +
-                    "\"(New-Object -ComObject Shell.Application).AppActivate('Unity')\"");
-
-#elif UNITY_EDITOR_LINUX
-                // xdotool preferred; wmctrl as fallback
-                SpawnSilent(
-                    "bash",
-                    "-c \"xdotool search --name 'Unity' windowactivate 2>/dev/null" +
-                    " || wmctrl -a Unity 2>/dev/null\"");
-#endif
+                AssetDatabase.Refresh();
             }
             catch (Exception ex)
             {
-                // Non-fatal: log and continue — recompile will still be requested
-                UnityEngine.Debug.LogWarning($"[unifocl] window grab failed (non-fatal): {ex.Message}");
+                return new RecompileOutcome(false, $"AssetDatabase.Refresh failed: {ex.GetType().Name}: {ex.Message}");
             }
+
+            try
+            {
+                if (forceRecompile)
+                {
+                    CompilationPipeline.RequestScriptCompilation(RequestScriptCompilationOptions.CleanBuildCache);
+                }
+                else
+                {
+                    CompilationPipeline.RequestScriptCompilation();
+                }
+            }
+            catch (Exception ex)
+            {
+                return new RecompileOutcome(false, $"RequestScriptCompilation failed: {ex.GetType().Name}: {ex.Message}");
+            }
+
+            ArmCompileStartWatchdog(watchdogReporter);
+
+            try
+            {
+                var config = UnifoclEditorConfig.Load();
+                if (config.allowWindowGrab)
+                {
+                    TryGrabEditorWindow();
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[unifocl] window grab raised non-fatal exception: {ex.Message}");
+            }
+
+            return new RecompileOutcome(true, forceRecompile
+                ? "force recompile requested"
+                : "compile request submitted");
+        }
+
+        private static void ArmCompileStartWatchdog(Action<string>? reporter)
+        {
+            _watchdogReporter = reporter;
+            _watchdogDeadlineSeconds = EditorApplication.timeSinceStartup + CompileStartWatchdogSeconds;
+
+            if (_watchdogActive)
+            {
+                return;
+            }
+
+            _watchdogActive = true;
+            EditorApplication.update += OnEditorUpdateForWatchdog;
+        }
+
+        private static void OnEditorUpdateForWatchdog()
+        {
+            if (EditorApplication.isCompiling)
+            {
+                ClearWatchdog();
+                return;
+            }
+
+            if (EditorApplication.timeSinceStartup < _watchdogDeadlineSeconds)
+            {
+                return;
+            }
+
+            var reporter = _watchdogReporter;
+            ClearWatchdog();
+
+            string diagnostic =
+                "compile request did not start within " +
+                $"{CompileStartWatchdogSeconds:F1}s. Likely causes: " +
+                "(a) Auto Refresh is disabled, (b) no script changes since last compile, " +
+                "(c) duplicate asmdef names blocking compile, " +
+                "(d) editor update or domain reload lock held.";
+
+            try
+            {
+                reporter?.Invoke(diagnostic);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[unifocl] compile watchdog reporter raised: {ex.Message}");
+            }
+        }
+
+        private static void ClearWatchdog()
+        {
+            if (!_watchdogActive)
+            {
+                return;
+            }
+
+            EditorApplication.update -= OnEditorUpdateForWatchdog;
+            _watchdogActive = false;
+            _watchdogReporter = null;
+        }
+
+        // ── Platform-specific window activation (cosmetic, opt-in) ────────────
+
+        private static void TryGrabEditorWindow()
+        {
+#if UNITY_EDITOR_OSX
+            SpawnSilent("osascript", "-e 'tell application \"Unity\" to activate'");
+#elif UNITY_EDITOR_WIN
+            SpawnSilent(
+                "powershell",
+                "-NoProfile -NonInteractive -Command " +
+                "\"(New-Object -ComObject Shell.Application).AppActivate('Unity')\"");
+#elif UNITY_EDITOR_LINUX
+            SpawnSilent(
+                "bash",
+                "-c \"xdotool search --name 'Unity' windowactivate 2>/dev/null" +
+                " || wmctrl -a Unity 2>/dev/null\"");
+#endif
         }
 
         private static void SpawnSilent(string fileName, string arguments)

--- a/src/unifocl/Models/ProjectBridgeModels.cs
+++ b/src/unifocl/Models/ProjectBridgeModels.cs
@@ -57,6 +57,31 @@ internal sealed record CompileStatusDto(
     string? StartedAtUtc,
     string? FinishedAtUtc);
 
+internal sealed record CompileRequestExtrasDto(
+    string RequestId,
+    bool Tracked,
+    string ResultPath,
+    string LockDir);
+
+internal sealed record CompilePersistedIssueDto(
+    string Message,
+    string File,
+    int Line,
+    string Assembly);
+
+internal sealed record CompilePersistedResultDto(
+    string RequestId,
+    string Outcome,
+    bool Success,
+    int ErrorCount,
+    int WarningCount,
+    string StartedAtUtc,
+    string FinishedAtUtc,
+    string Message,
+    CompilePersistedIssueDto[] Errors,
+    CompilePersistedIssueDto[] Warnings,
+    bool ForceRecompile);
+
 internal sealed record BuildLogLineDto(
     string Level,
     string Text);

--- a/src/unifocl/Services/CompileCompletionWaiter.cs
+++ b/src/unifocl/Services/CompileCompletionWaiter.cs
@@ -1,0 +1,177 @@
+using System.Net.Http;
+using System.Text.Json;
+
+/// <summary>
+/// Polls the on-disk markers Unity writes during a compile + domain reload
+/// cycle so the CLI can observe completion without depending on the daemon
+/// HTTP socket staying up. The daemon socket is torn down during domain
+/// reload after a successful compile, so any HTTP-only completion check
+/// fails with "Connection refused" exactly when we need an answer most.
+///
+/// Algorithm:
+///   1. Wait until the result file appears at &lt;projectRoot&gt;/Temp/unifocl/compile-results/{requestId}.json
+///      AND both lock files are gone:
+///        Temp/compiling.lock      — present while CompilationPipeline is busy
+///        Temp/domainreload.lock   — present while Unity is reloading the AppDomain
+///   2. Once both conditions hold, require them to keep holding for a grace
+///      period (LockGracePeriodMs). This catches the brief window between
+///      compilationFinished and beforeAssemblyReload (~50 ms measured)
+///      where neither lock exists.
+///   3. After the grace period, ping the daemon's /compile/status to
+///      confirm it has come back online. If it has not, keep polling.
+/// </summary>
+internal sealed class CompileCompletionWaiter
+{
+    private static readonly HttpClient HealthClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(3),
+    };
+
+    private const int DefaultPollIntervalMs = 200;
+    private const int LockGracePeriodMs = 500;
+    private const int DefaultTimeoutMs = 120_000;
+
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    public enum WaitOutcome
+    {
+        Completed,
+        TimedOut,
+        Cancelled,
+    }
+
+    public sealed record Result(WaitOutcome Outcome, CompilePersistedResultDto? Payload, string? Diagnostic);
+
+    public async Task<Result> WaitAsync(
+        string projectRoot,
+        string requestId,
+        int? daemonPort,
+        int timeoutMs = DefaultTimeoutMs,
+        int pollIntervalMs = DefaultPollIntervalMs,
+        Action<string>? onProgress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestId);
+
+        string resultDir = Path.Combine(projectRoot, "Temp", "unifocl", "compile-results");
+        string resultFile = Path.Combine(resultDir, $"{requestId}.json");
+        string compilingLock = Path.Combine(projectRoot, "Temp", "compiling.lock");
+        string domainReloadLock = Path.Combine(projectRoot, "Temp", "domainreload.lock");
+
+        DateTime deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        DateTime? idleSince = null;
+        var lastReportedPhase = string.Empty;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new Result(WaitOutcome.Cancelled, null, "wait cancelled");
+            }
+
+            bool resultExists = File.Exists(resultFile);
+            bool compileLocked = File.Exists(compilingLock);
+            bool reloadLocked = File.Exists(domainReloadLock);
+            bool busy = compileLocked || reloadLocked;
+
+            string phase = (resultExists, compileLocked, reloadLocked) switch
+            {
+                (false, true, _) => "compiling",
+                (false, _, true) => "domain-reload",
+                (true, true, _) => "post-compile",
+                (true, _, true) => "domain-reload",
+                (false, false, false) => "queued",
+                (true, false, false) => "settling",
+            };
+
+            if (phase != lastReportedPhase)
+            {
+                onProgress?.Invoke(phase);
+                lastReportedPhase = phase;
+            }
+
+            if (resultExists && !busy)
+            {
+                idleSince ??= DateTime.UtcNow;
+
+                if ((DateTime.UtcNow - idleSince.Value).TotalMilliseconds >= LockGracePeriodMs)
+                {
+                    if (daemonPort is int port)
+                    {
+                        bool ready = await IsDaemonReadyAsync(port, cancellationToken).ConfigureAwait(false);
+                        if (!ready)
+                        {
+                            // Locks gone but daemon not back yet — keep waiting
+                            // rather than declaring completion prematurely.
+                            await Task.Delay(pollIntervalMs, cancellationToken).ConfigureAwait(false);
+                            continue;
+                        }
+                    }
+
+                    CompilePersistedResultDto? payload = TryReadResultFile(resultFile);
+                    return new Result(WaitOutcome.Completed, payload, null);
+                }
+            }
+            else
+            {
+                idleSince = null;
+            }
+
+            try
+            {
+                await Task.Delay(pollIntervalMs, cancellationToken).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                return new Result(WaitOutcome.Cancelled, null, "wait cancelled");
+            }
+        }
+
+        // Final read in case the result file appeared in the last interval.
+        CompilePersistedResultDto? finalPayload = TryReadResultFile(resultFile);
+        if (finalPayload is not null && !File.Exists(compilingLock) && !File.Exists(domainReloadLock))
+        {
+            return new Result(WaitOutcome.Completed, finalPayload, null);
+        }
+
+        return new Result(
+            WaitOutcome.TimedOut,
+            finalPayload,
+            $"compile did not settle within {timeoutMs / 1000.0:F1}s");
+    }
+
+    private static CompilePersistedResultDto? TryReadResultFile(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            string json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<CompilePersistedResultDto>(json, JsonOpts);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<bool> IsDaemonReadyAsync(int port, CancellationToken ct)
+    {
+        try
+        {
+            using var resp = await HealthClient.GetAsync(
+                $"http://127.0.0.1:{port}/compile/status",
+                HttpCompletionOption.ResponseContentRead,
+                ct).ConfigureAwait(false);
+            return resp.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/unifocl/Services/EditorDependencyInitializerService.cs
+++ b/src/unifocl/Services/EditorDependencyInitializerService.cs
@@ -39,6 +39,8 @@ internal sealed class EditorDependencyInitializerService
     private const string DaemonCustomToolServiceResource = "Payload/EditorScripts/Services/DaemonCustomToolService.cs";
     private const string DaemonEvalServiceResource = "Payload/EditorScripts/Services/DaemonEvalService.cs";
     private const string UnifoclCompilationServiceResource = "Payload/EditorScripts/Services/UnifoclCompilationService.cs";
+    private const string CompilationStateValidationServiceResource = "Payload/EditorScripts/Services/CompilationStateValidationService.cs";
+    private const string CompileResultPersistenceServiceResource = "Payload/EditorScripts/Services/CompileResultPersistenceService.cs";
     private const string SharedModelsSourceResource = "Payload/SharedModels/BridgeModels.cs";
     // Runtime operations (3.7.0+)
     private const string DaemonRuntimeBridgeResource = "Payload/EditorScripts/Services/DaemonRuntimeBridge.cs";
@@ -200,6 +202,8 @@ internal sealed class EditorDependencyInitializerService
             Path.Combine(packagePath, "Editor", "Services", "DaemonCustomToolService.cs"),
             Path.Combine(packagePath, "Editor", "Services", "DaemonEvalService.cs"),
             Path.Combine(packagePath, "Editor", "Services", "UnifoclCompilationService.cs"),
+            Path.Combine(packagePath, "Editor", "Services", "CompilationStateValidationService.cs"),
+            Path.Combine(packagePath, "Editor", "Services", "CompileResultPersistenceService.cs"),
             // Runtime operations (3.7.0+)
             Path.Combine(packagePath, "Editor", "Services", "DaemonRuntimeBridge.cs"),
             Path.Combine(packagePath, "Editor", "Services", "DaemonRuntimeModels.cs"),
@@ -389,6 +393,8 @@ internal sealed class EditorDependencyInitializerService
                 (DaemonCustomToolServiceResource,       Path.Combine("Editor", "Services", "DaemonCustomToolService.cs")),
                 (DaemonEvalServiceResource,             Path.Combine("Editor", "Services", "DaemonEvalService.cs")),
                 (UnifoclCompilationServiceResource,     Path.Combine("Editor", "Services", "UnifoclCompilationService.cs")),
+                (CompilationStateValidationServiceResource, Path.Combine("Editor", "Services", "CompilationStateValidationService.cs")),
+                (CompileResultPersistenceServiceResource, Path.Combine("Editor", "Services", "CompileResultPersistenceService.cs")),
                 // Runtime operations (3.7.0+)
                 (DaemonRuntimeBridgeResource,           Path.Combine("Editor", "Services", "DaemonRuntimeBridge.cs")),
                 (DaemonRuntimeModelsServiceResource,    Path.Combine("Editor", "Services", "DaemonRuntimeModels.cs")),

--- a/src/unifocl/Services/ExecCommandRegistry.cs
+++ b/src/unifocl/Services/ExecCommandRegistry.cs
@@ -471,7 +471,12 @@ internal sealed class ExecCommandRegistry
 
             case "compile.request":
             {
-                dto = new ProjectCommandRequestDto("compile-request", null, null, null, req.RequestId);
+                bool forceRecompile = GetBool(req.Args, "forceRecompile") ?? GetBool(req.Args, "force") ?? false;
+                bool waitForDomainReload = GetBool(req.Args, "waitForDomainReload") ?? GetBool(req.Args, "wait") ?? false;
+                var content = JsonSerializer.Serialize(new { forceRecompile, waitForDomainReload });
+                var base_ = new ProjectCommandRequestDto("compile-request", null, null, content, req.RequestId);
+                var withIntent = MutationIntentFactory.EnsureProjectIntent(base_);
+                dto = withIntent with { Intent = withIntent.Intent! with { Flags = withIntent.Intent.Flags with { DryRun = dryRun } } };
                 return true;
             }
 

--- a/src/unifocl/Services/RuntimeCommandService.cs
+++ b/src/unifocl/Services/RuntimeCommandService.cs
@@ -145,29 +145,170 @@ internal sealed class RuntimeCommandService
         var tokens = Tokenize(input);
         if (tokens.Count < 2)
         {
-            log("[x] usage: /compile <request|status>");
+            log("[x] usage: /compile <request|status> [--force] [--wait] [--timeout-ms <n>]");
             return;
         }
 
         var sub = tokens[1].ToLowerInvariant();
-        var action = sub switch
-        {
-            "request" => "compile-request",
-            "status" => "compile-status",
-            _ => null
-        };
 
-        if (action is null)
+        if (sub == "status")
         {
-            log($"[x] unknown compile subcommand: {Markup.Escape(sub)}");
+            var statusDto = new ProjectCommandRequestDto("compile-status", null, null, null, NewId());
+            await DispatchProjectCommandAsync(session, statusDto, "compile", log);
             return;
         }
 
-        var dto = sub == "request"
-            ? MutationIntentFactory.EnsureProjectIntent(
-                new ProjectCommandRequestDto(action, null, null, null, NewId()))
-            : new ProjectCommandRequestDto(action, null, null, null, NewId());
-        await DispatchProjectCommandAsync(session, dto, "compile", log);
+        if (sub != "request")
+        {
+            log($"[x] unknown compile subcommand: {Markup.Escape(sub)}");
+            log("usage: /compile <request|status> [--force] [--wait] [--timeout-ms <n>]");
+            return;
+        }
+
+        bool force = tokens.Contains("--force");
+        bool wait = tokens.Contains("--wait");
+        int timeoutMs = ParseIntArg(tokens, "--timeout-ms");
+        if (timeoutMs <= 0) timeoutMs = 120_000;
+
+        await DispatchCompileRequestAsync(session, force, wait, timeoutMs, log);
+    }
+
+    private async Task DispatchCompileRequestAsync(
+        CliSessionState session,
+        bool forceRecompile,
+        bool wait,
+        int timeoutMs,
+        Action<string> log)
+    {
+        if (DaemonControlService.GetPort(session) is not int port)
+        {
+            log("[yellow]compile[/]: daemon not running — start with /open");
+            return;
+        }
+
+        var requestId = $"compile_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}_{Guid.NewGuid().ToString("N")[..8]}";
+        var content = JsonSerializer.Serialize(new
+        {
+            forceRecompile,
+            waitForDomainReload = wait
+        });
+
+        var dto = MutationIntentFactory.EnsureProjectIntent(
+            new ProjectCommandRequestDto("compile-request", null, null, content, requestId));
+
+        log($"[grey]compile[/]: dispatching compile-request"
+            + (forceRecompile ? " --force" : "")
+            + (wait ? " --wait" : "")
+            + "...");
+
+        var response = await _daemonClient.ExecuteProjectCommandAsync(port, dto,
+            onStatus: status => log($"[grey]compile[/]: {Markup.Escape(status)}"));
+
+        if (!response.Ok)
+        {
+            log($"[red]compile[/]: rejected — {Markup.Escape(response.Message)}");
+            return;
+        }
+
+        CompileRequestExtrasDto? extras = TryParseCompileExtras(response.Content);
+        if (extras is null)
+        {
+            log($"[green]compile[/]: {Markup.Escape(response.Message)}");
+            return;
+        }
+
+        log($"[green]compile[/]: {Markup.Escape(response.Message)} (requestId={Markup.Escape(extras.RequestId)})");
+
+        if (!wait || !extras.Tracked)
+        {
+            return;
+        }
+
+        var projectRoot = session.CurrentProjectPath;
+        if (string.IsNullOrWhiteSpace(projectRoot))
+        {
+            log("[yellow]compile[/]: cannot wait — no current project path");
+            return;
+        }
+
+        var waiter = new CompileCompletionWaiter();
+        var waitResult = await waiter.WaitAsync(
+            projectRoot: projectRoot,
+            requestId: extras.RequestId,
+            daemonPort: port,
+            timeoutMs: timeoutMs,
+            onProgress: phase => log($"[grey]compile[/]: phase={phase}"));
+
+        switch (waitResult.Outcome)
+        {
+            case CompileCompletionWaiter.WaitOutcome.Completed:
+                ReportCompileResult(waitResult.Payload, log);
+                break;
+            case CompileCompletionWaiter.WaitOutcome.TimedOut:
+                log($"[yellow]compile[/]: {Markup.Escape(waitResult.Diagnostic ?? "timed out")}");
+                if (waitResult.Payload is not null)
+                {
+                    ReportCompileResult(waitResult.Payload, log);
+                }
+                break;
+            case CompileCompletionWaiter.WaitOutcome.Cancelled:
+                log("[yellow]compile[/]: wait cancelled");
+                break;
+        }
+    }
+
+    private static CompileRequestExtrasDto? TryParseCompileExtras(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<CompileRequestExtrasDto>(content, JsonOpts);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void ReportCompileResult(CompilePersistedResultDto? payload, Action<string> log)
+    {
+        if (payload is null)
+        {
+            log("[yellow]compile[/]: result file unreadable");
+            return;
+        }
+
+        switch (payload.Outcome)
+        {
+            case "success":
+                log($"[green]compile[/]: success ({payload.WarningCount} warning(s))");
+                break;
+            case "errors":
+                log($"[red]compile[/]: {payload.ErrorCount} error(s), {payload.WarningCount} warning(s)");
+                foreach (var err in payload.Errors.Take(10))
+                {
+                    var loc = string.IsNullOrEmpty(err.File) ? "" : $" {err.File}:{err.Line}";
+                    log($"[red]compile[/]:  {Markup.Escape(err.Message)}{Markup.Escape(loc)}");
+                }
+                if (payload.Errors.Length > 10)
+                {
+                    log($"[red]compile[/]:  …and {payload.Errors.Length - 10} more");
+                }
+                break;
+            case "rejected":
+                log($"[red]compile[/]: rejected — {Markup.Escape(payload.Message)}");
+                break;
+            case "indeterminate":
+                log($"[yellow]compile[/]: indeterminate — {Markup.Escape(payload.Message)}");
+                break;
+            default:
+                log($"[yellow]compile[/]: outcome={Markup.Escape(payload.Outcome)} message={Markup.Escape(payload.Message)}");
+                break;
+        }
     }
 
     // ── Profiler ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `/compile request` previously lost completion state across the domain reload that follows a successful compile, because the daemon HTTP socket is torn down during the reload and all in-memory state goes with it. The CLI saw `Connection refused` exactly when the answer mattered.
- This PR moves completion signalling to files Unity writes *before* the AppDomain is recycled — `Temp/unifocl/compile-results/{requestId}.json` plus the editor's own `Temp/compiling.lock` and `Temp/domainreload.lock` markers — so the CLI can observe completion across the reload boundary.
- Adds `/compile request --force` (busts Unity's incremental cache via `RequestScriptCompilationOptions.CleanBuildCache`) and `--wait` (poll the on-disk markers until everything settles), structured pre-compile validation that replaces silent stalls with actionable errors, and a compile-did-not-start watchdog with a diagnostic for the common silent failure modes (Auto Refresh disabled, no script changes, duplicate asmdef names, locks held).

## Related Issues
- Closes #
- Related to # (mitigates the “daemon drops silently after recompile; `/open` is required to reconnect” quirk that's been observed in agentic sessions.)

## Type of Change
- [x] Bug fix
- [x] Feature

## Scope
- Affected areas/components:
  - Unity bridge: `UnifoclCompilationService`, new `CompilationStateValidationService`, new `CompileResultPersistenceService`, compile-related sections of `DaemonProjectService`.
  - CLI: new `CompileCompletionWaiter`, updates to `RuntimeCommandService` for `/compile`, `ExecCommandRegistry` for `compile.request` exec args, DTOs in `ProjectBridgeModels.cs`, and bridge install manifest in `EditorDependencyInitializerService`.
- Out-of-scope / intentionally not addressed:
  - Five pre-existing `UNIFOCL001` analyzer warnings in `DaemonProfilerService.{Compare,Snapshot}.cs` and `DaemonRecorderService.cs` are present on `origin/main` and unrelated to compile; left for a separate, focused PR.

## How to Test

### Automated
1. `dotnet build src/unifocl/unifocl.csproj --disable-build-servers -v minimal` — expect 0 warnings, 0 errors.
2. `UNIFOCL_UNITY_EDITOR_MANAGED_DIR=/Applications/Unity/Hub/Editor/<ver>/Unity.app/Contents/Managed dotnet build src/unifocl.unity.compatcheck/unifocl.unity.compatcheck.csproj --disable-build-servers -v minimal` — expect only the 6 pre-existing warnings noted above.
3. `dotnet test src/unifocl.Tests/unifocl.Tests.csproj --disable-build-servers --no-build` — expect 106/106 pass.
4. `scripts/build-full-docs.sh --check` — expect “up to date”.

### Manual smoke (live Unity)
1. Open a Unity project: `unifocl exec "/open <path-to-project>" --agentic` and wait for `daemon: managed daemon ready`.
2. Trigger compile and wait for full settlement: `unifocl exec "/compile request --wait" --project <path> --session-seed <seed>`.
3. Verify a result file appears at `<project>/Temp/unifocl/compile-results/{requestId}.json` with `outcome` ∈ `{success, errors, indeterminate, rejected}`.
4. While Unity is busy compiling, retry `/compile request` — expect a structured rejection (`code=already-compiling`) instead of a silent stall.

Expected results:
- Result file is written for every tracked compile, with structured fields (`requestId`, `outcome`, `errorCount`, `warningCount`, `errors[]`, `warnings[]`).
- Pre-compile validation replaces silent failure modes with actionable error codes.
- The CLI waiter observes completion even when Unity tears its socket down during domain reload.

## Screenshots / Terminal Output

Smoke test against `/tmp/unifocl-smoke-test` confirmed:
- `/compile request --wait --force` reaches the daemon with the new flags and is dispatched.
- Pre-compile validation correctly rejects when `EditorApplication.isCompiling` is already true:

```
"compile: rejected — Compilation is already in progress. Wait for it to finish before requesting another compile."
```

- The rejection result file is written with full structure:

```json
{
  "requestId": "compile_1778388275740_82aed06a",
  "outcome": "rejected",
  "success": false,
  "startedAtUtc": "2026-05-10T04:44:36.0411600Z",
  "finishedAtUtc": "2026-05-10T04:44:36.0414560Z",
  "message": "already-compiling: Compilation is already in progress. ...",
  "forceRecompile": false
}
```

The smoke test also caught and fixed a real bug: the embedded editor bridge install manifest was missing the two new service files, which would have caused `error CS0246: 'CompilePersistedIssue' could not be found` on the first `/open` after this change. Manifest updated, install verified clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)